### PR TITLE
[BREAKING] Invert the sign of the current sensor

### DIFF
--- a/components/jk_bms/jk_bms.h
+++ b/components/jk_bms/jk_bms.h
@@ -303,9 +303,9 @@ class JkBms : public PollingComponent, public jk_modbus::JkModbusDevice {
     float current = 0.0f;
     if (protocol_version == 0x01) {
       if ((value & 0x8000) == 0x8000) {
-        current = (float) (value & 0x7FFF) * -1;
-      } else {
         current = (float) (value & 0x7FFF);
+      } else {
+        current = (float) (value & 0x7FFF) * -1;
       }
     }
 


### PR DESCRIPTION
This is a breaking change! Please check your current sensor and add
or remove a filter if the new behavior doesn't fit to your needs.

```
sensor:
  - platform: jk_bms
    current:
      name: "${name} current"
      filters:
        - multiply: -1
```