### PR TITLE
[BREAKING] Distinguish between the current state and switch position

### DIFF
--- a/components/jk_bms/binary_sensor.py
+++ b/components/jk_bms/binary_sensor.py
@@ -10,23 +10,29 @@ DEPENDENCIES = ["jk_bms"]
 CODEOWNERS = ["@syssi"]
 
 CONF_CHARGING = "charging"
+CONF_CHARGING_SWITCH = "charging_switch"
 CONF_DISCHARGING = "discharging"
+CONF_DISCHARGING_SWITCH = "discharging_switch"
 CONF_BALANCING = "balancing"
-CONF_BALANCING_ENABLED = "balancing_enabled"
-CONF_DEDICATED_CHARGER = "dedicated_charger"
+CONF_BALANCING_SWITCH = "balancing_switch"
+CONF_DEDICATED_CHARGER_SWITCH = "dedicated_charger_switch"
 
 ICON_CHARGING = "mdi:battery-charging"
+ICON_CHARGING_SWITCH = "mdi:battery-charging"
 ICON_DISCHARGING = "mdi:power-plug"
+ICON_DISCHARGING_SWITCH = "mdi:power-plug"
 ICON_BALANCING = "mdi:battery-heart-variant"
-ICON_BALANCING_ENABLED = "mdi:battery-heart-variant"
-ICON_DEDICATED_CHARGER = "mdi:battery-charging"
+ICON_BALANCING_SWITCH = "mdi:battery-heart-variant"
+ICON_DEDICATED_CHARGER_SWITCH = "mdi:battery-charging"
 
 BINARY_SENSORS = [
     CONF_CHARGING,
+    CONF_CHARGING_SWITCH,
     CONF_DISCHARGING,
+    CONF_DISCHARGING_SWITCH,
     CONF_BALANCING,
-    CONF_BALANCING_ENABLED,
-    CONF_DEDICATED_CHARGER,
+    CONF_BALANCING_SWITCH,
+    CONF_DEDICATED_CHARGER_SWITCH,
 ]
 
 CONFIG_SCHEMA = cv.Schema(
@@ -38,10 +44,22 @@ CONFIG_SCHEMA = cv.Schema(
                 cv.Optional(CONF_ICON, default=ICON_CHARGING): cv.icon,
             }
         ),
+        cv.Optional(CONF_CHARGING_SWITCH): binary_sensor.BINARY_SENSOR_SCHEMA.extend(
+            {
+                cv.GenerateID(): cv.declare_id(binary_sensor.BinarySensor),
+                cv.Optional(CONF_ICON, default=ICON_CHARGING_SWITCH): cv.icon,
+            }
+        ),
         cv.Optional(CONF_DISCHARGING): binary_sensor.BINARY_SENSOR_SCHEMA.extend(
             {
                 cv.GenerateID(): cv.declare_id(binary_sensor.BinarySensor),
                 cv.Optional(CONF_ICON, default=ICON_DISCHARGING): cv.icon,
+            }
+        ),
+        cv.Optional(CONF_DISCHARGING_SWITCH): binary_sensor.BINARY_SENSOR_SCHEMA.extend(
+            {
+                cv.GenerateID(): cv.declare_id(binary_sensor.BinarySensor),
+                cv.Optional(CONF_ICON, default=ICON_DISCHARGING_SWITCH): cv.icon,
             }
         ),
         cv.Optional(CONF_BALANCING): binary_sensor.BINARY_SENSOR_SCHEMA.extend(
@@ -50,16 +68,18 @@ CONFIG_SCHEMA = cv.Schema(
                 cv.Optional(CONF_ICON, default=ICON_BALANCING): cv.icon,
             }
         ),
-        cv.Optional(CONF_BALANCING_ENABLED): binary_sensor.BINARY_SENSOR_SCHEMA.extend(
+        cv.Optional(CONF_BALANCING_SWITCH): binary_sensor.BINARY_SENSOR_SCHEMA.extend(
             {
                 cv.GenerateID(): cv.declare_id(binary_sensor.BinarySensor),
-                cv.Optional(CONF_ICON, default=ICON_BALANCING_ENABLED): cv.icon,
+                cv.Optional(CONF_ICON, default=ICON_BALANCING_SWITCH): cv.icon,
             }
         ),
-        cv.Optional(CONF_DEDICATED_CHARGER): binary_sensor.BINARY_SENSOR_SCHEMA.extend(
+        cv.Optional(
+            CONF_DEDICATED_CHARGER_SWITCH
+        ): binary_sensor.BINARY_SENSOR_SCHEMA.extend(
             {
                 cv.GenerateID(): cv.declare_id(binary_sensor.BinarySensor),
-                cv.Optional(CONF_ICON, default=ICON_DEDICATED_CHARGER): cv.icon,
+                cv.Optional(CONF_ICON, default=ICON_DEDICATED_CHARGER_SWITCH): cv.icon,
             }
         ),
     }

--- a/components/jk_bms/jk_bms.cpp
+++ b/components/jk_bms/jk_bms.cpp
@@ -186,6 +186,8 @@ void JkBms::on_status_data_(const std::vector<uint8_t> &data) {
   this->publish_state_(this->operation_mode_bitmask_sensor_, (float) raw_modes_bitmask);
   this->publish_state_(this->operation_mode_text_sensor_, this->mode_bits_to_string_(raw_modes_bitmask));
   this->publish_state_(this->balancing_binary_sensor_, (4 & raw_modes_bitmask) == 4);
+  this->publish_state_(this->charging_binary_sensor_, (0 & raw_modes_bitmask) == 0);
+  this->publish_state_(this->discharging_binary_sensor_, (1 & raw_modes_bitmask) == 1);
 
   // 0x8E 0x16 0x26: Total voltage overvoltage protection        5670 * 0.01 = 56.70V     0.01 V
   this->publish_state_(this->total_voltage_overvoltage_protection_sensor_,
@@ -241,7 +243,7 @@ void JkBms::on_status_data_(const std::vector<uint8_t> &data) {
                        (float) jk_get_16bit(offset + 6 + 3 * 24) * 0.001f);
 
   // 0x9D 0x01: Active balance switch                              1 (on)                     Bool     0 (off), 1 (on)
-  this->publish_state_(this->balancing_enabled_binary_sensor_, (bool) data[offset + 6 + 3 * 25]);
+  this->publish_state_(this->balancing_switch_binary_sensor_, (bool) data[offset + 6 + 3 * 25]);
 
   // 0x9E 0x00 0x5A: Power tube temperature protection value                90°C            1.0 °C     0-100°C
   this->publish_state_(this->power_tube_temperature_protection_sensor_, (float) jk_get_16bit(offset + 8 + 3 * 25));
@@ -293,10 +295,10 @@ void JkBms::on_status_data_(const std::vector<uint8_t> &data) {
                        (float) (raw_total_battery_capacity_setting * (raw_battery_remaining_capacity * 0.01f)));
 
   // 0xAB 0x01: Charging MOS tube switch                                     1 (on)         Bool       0 (off), 1 (on)
-  this->publish_state_(this->charging_binary_sensor_, (bool) data[offset + 15 + 3 * 36]);
+  this->publish_state_(this->charging_switch_binary_sensor_, (bool) data[offset + 15 + 3 * 36]);
 
   // 0xAC 0x01: Discharge MOS tube switch                                    1 (on)         Bool       0 (off), 1 (on)
-  this->publish_state_(this->discharging_binary_sensor_, (bool) data[offset + 17 + 3 * 36]);
+  this->publish_state_(this->discharging_switch_binary_sensor_, (bool) data[offset + 17 + 3 * 36]);
 
   // 0xAD 0x04 0x11: Current calibration                       1041mA * 0.001 = 1.041A     0.001 A     0.1-2.0A
   this->publish_state_(this->current_calibration_sensor_, (float) jk_get_16bit(offset + 19 + 3 * 36) * 0.001f);
@@ -324,7 +326,7 @@ void JkBms::on_status_data_(const std::vector<uint8_t> &data) {
                        std::string(data.begin() + offset + 25 + 3 * 38, data.begin() + offset + 35 + 3 * 38));
 
   // 0xB3 0x00: Dedicated charger switch                                     1 (on)         Bool       0 (off), 1 (on)
-  this->publish_state_(this->dedicated_charger_binary_sensor_, (bool) data[offset + 36 + 3 * 38]);
+  this->publish_state_(this->dedicated_charger_switch_binary_sensor_, (bool) data[offset + 36 + 3 * 38]);
 
   // 0xB4 0x49 0x6E 0x70 0x75 0x74 0x20 0x55 0x73: Device ID code
   this->publish_state_(this->device_type_text_sensor_,
@@ -558,10 +560,12 @@ void JkBms::dump_config() {  // NOLINT(google-readability-function-size,readabil
   LOG_TEXT_SENSOR("", "Manufacturer", this->manufacturer_text_sensor_);
   LOG_SENSOR("", "Protocol Version", this->protocol_version_sensor_);
   LOG_BINARY_SENSOR("", "Balancing", this->balancing_binary_sensor_);
-  LOG_BINARY_SENSOR("", "Balancing Enabled", this->balancing_enabled_binary_sensor_);
+  LOG_BINARY_SENSOR("", "Balancing Switch", this->balancing_switch_binary_sensor_);
   LOG_BINARY_SENSOR("", "Charging", this->charging_binary_sensor_);
+  LOG_BINARY_SENSOR("", "Charging Switch", this->charging_switch_binary_sensor_);
   LOG_BINARY_SENSOR("", "Discharging", this->discharging_binary_sensor_);
-  LOG_BINARY_SENSOR("", "Dedicated Charger", this->dedicated_charger_binary_sensor_);
+  LOG_BINARY_SENSOR("", "Discharging Switch", this->discharging_switch_binary_sensor_);
+  LOG_BINARY_SENSOR("", "Dedicated Charger Switch", this->dedicated_charger_switch_binary_sensor_);
   LOG_TEXT_SENSOR("", "Total Runtime Formatted", this->total_runtime_formatted_text_sensor_);
 }
 

--- a/components/jk_bms/jk_bms.h
+++ b/components/jk_bms/jk_bms.h
@@ -14,8 +14,8 @@ class JkBms : public PollingComponent, public jk_modbus::JkModbusDevice {
   void set_balancing_binary_sensor(binary_sensor::BinarySensor *balancing_binary_sensor) {
     balancing_binary_sensor_ = balancing_binary_sensor;
   }
-  void set_balancing_enabled_binary_sensor(binary_sensor::BinarySensor *balancing_enabled_binary_sensor) {
-    balancing_enabled_binary_sensor_ = balancing_enabled_binary_sensor;
+  void set_balancing_switch_binary_sensor(binary_sensor::BinarySensor *balancing_switch_binary_sensor) {
+    balancing_switch_binary_sensor_ = balancing_switch_binary_sensor;
   }
   void set_charging_binary_sensor(binary_sensor::BinarySensor *charging_binary_sensor) {
     charging_binary_sensor_ = charging_binary_sensor;

--- a/components/jk_bms/jk_bms.h
+++ b/components/jk_bms/jk_bms.h
@@ -20,11 +20,17 @@ class JkBms : public PollingComponent, public jk_modbus::JkModbusDevice {
   void set_charging_binary_sensor(binary_sensor::BinarySensor *charging_binary_sensor) {
     charging_binary_sensor_ = charging_binary_sensor;
   }
+  void set_charging_switch_binary_sensor(binary_sensor::BinarySensor *charging_switch_binary_sensor) {
+    charging_switch_binary_sensor_ = charging_switch_binary_sensor;
+  }
   void set_discharging_binary_sensor(binary_sensor::BinarySensor *discharging_binary_sensor) {
     discharging_binary_sensor_ = discharging_binary_sensor;
   }
-  void set_dedicated_charger_binary_sensor(binary_sensor::BinarySensor *dedicated_charger_binary_sensor) {
-    dedicated_charger_binary_sensor_ = dedicated_charger_binary_sensor;
+  void set_discharging_switch_binary_sensor(binary_sensor::BinarySensor *discharging_switch_binary_sensor) {
+    discharging_switch_binary_sensor_ = discharging_switch_binary_sensor;
+  }
+  void set_dedicated_charger_switch_binary_sensor(binary_sensor::BinarySensor *dedicated_charger_switch_binary_sensor) {
+    dedicated_charger_switch_binary_sensor_ = dedicated_charger_switch_binary_sensor;
   }
 
   void set_min_cell_voltage_sensor(sensor::Sensor *min_cell_voltage_sensor) {
@@ -284,10 +290,12 @@ class JkBms : public PollingComponent, public jk_modbus::JkModbusDevice {
   sensor::Sensor *protocol_version_sensor_;
 
   binary_sensor::BinarySensor *balancing_binary_sensor_;
-  binary_sensor::BinarySensor *balancing_enabled_binary_sensor_;
+  binary_sensor::BinarySensor *balancing_switch_binary_sensor_;
   binary_sensor::BinarySensor *charging_binary_sensor_;
+  binary_sensor::BinarySensor *charging_switch_binary_sensor_;
   binary_sensor::BinarySensor *discharging_binary_sensor_;
-  binary_sensor::BinarySensor *dedicated_charger_binary_sensor_;
+  binary_sensor::BinarySensor *discharging_switch_binary_sensor_;
+  binary_sensor::BinarySensor *dedicated_charger_switch_binary_sensor_;
 
   text_sensor::TextSensor *errors_text_sensor_;
   text_sensor::TextSensor *operation_mode_text_sensor_;

--- a/esp32-example.yaml
+++ b/esp32-example.yaml
@@ -43,16 +43,20 @@ jk_bms:
 
 binary_sensor:
   - platform: jk_bms
-    charging:
-      name: "${name} charging"
-    discharging:
-      name: "${name} discharging"
     balancing:
       name: "${name} balancing"
-    balancing_enabled:
-      name: "${name} balancing enabled"
-    dedicated_charger:
-      name: "${name} dedicated charger"
+    balancing_switch:
+      name: "${name} balancing switch"
+    charging:
+      name: "${name} charging"
+    charging_switch:
+      name: "${name} charging switch"
+    discharging:
+      name: "${name} discharging"
+    discharging_switch:
+      name: "${name} discharging switch"
+    dedicated_charger_switch:
+      name: "${name} dedicated charger switch"
 
 sensor:
   - platform: jk_bms

--- a/esp8266-example.yaml
+++ b/esp8266-example.yaml
@@ -45,16 +45,20 @@ jk_bms:
 
 binary_sensor:
   - platform: jk_bms
-    charging:
-      name: "${name} charging"
-    discharging:
-      name: "${name} discharging"
     balancing:
       name: "${name} balancing"
-    balancing_enabled:
-      name: "${name} balancing enabled"
-    dedicated_charger:
-      name: "${name} dedicated charger"
+    balancing_switch:
+      name: "${name} balancing switch"
+    charging:
+      name: "${name} charging"
+    charging_switch:
+      name: "${name} charging switch"
+    discharging:
+      name: "${name} discharging"
+    discharging_switch:
+      name: "${name} discharging switch"
+    dedicated_charger_switch:
+      name: "${name} dedicated charger switch"
 
 sensor:
   - platform: jk_bms


### PR DESCRIPTION
Please update your configuration:

Rename `binary_sensor.charging` to `binary_sensor.charging_switch`
Rename `binary_sensor.discharging` to `binary_sensor.discharging_switch`
Rename `binary_sensor.balacing_enabled` to `binary_sensor.balancing_switch`

Add the new sensors reporting the current state if you like:

- `binary_sensor.charging`
- `binary_sensor.discharging`
- `binary_sensor.balacing`

Fixes: #65