### PR TITLE
Add switch entities to control the BMS via BLE

### DIFF
--- a/components/jk_bms_ble/__init__.py
+++ b/components/jk_bms_ble/__init__.py
@@ -3,7 +3,7 @@ from esphome.components import ble_client
 import esphome.config_validation as cv
 from esphome.const import CONF_ID, CONF_THROTTLE
 
-AUTO_LOAD = ["binary_sensor", "sensor", "text_sensor"]
+AUTO_LOAD = ["binary_sensor", "sensor", "switch", "text_sensor"]
 CODEOWNERS = ["@syssi"]
 MULTI_CONF = True
 

--- a/components/jk_bms_ble/jk_bms_ble.cpp
+++ b/components/jk_bms_ble/jk_bms_ble.cpp
@@ -862,6 +862,35 @@ void JkBmsBle::decode_device_info_(const std::vector<uint8_t> &data) {
   ESP_LOGI(TAG, "  Setup passcode: %s", std::string(data.begin() + 118, data.begin() + 118 + 16).c_str());
 }
 
+void JkBmsBle::write_register(uint8_t address, uint32_t value) {
+  uint8_t frame[20];
+  frame[0] = 0xAA;     // start sequence
+  frame[1] = 0x55;     // start sequence
+  frame[2] = 0x90;     // start sequence
+  frame[3] = 0xEB;     // start sequence
+  frame[4] = address;  // holding register
+  frame[5] = 0x04;     // size of the value in byte
+  frame[6] = value;
+  frame[7] = value;
+  frame[8] = value;
+  frame[9] = value;
+  frame[10] = 0x00;
+  frame[11] = 0x00;
+  frame[12] = 0x00;
+  frame[13] = 0x00;
+  frame[14] = 0x00;
+  frame[15] = 0x00;
+  frame[16] = 0x00;
+  frame[17] = 0x00;
+  frame[18] = 0x00;
+  frame[19] = crc(frame, 19);
+
+  auto status = esp_ble_gattc_write_char(this->parent_->gattc_if, this->parent_->conn_id, this->char_handle_,
+                                         sizeof(frame), frame, ESP_GATT_WRITE_TYPE_NO_RSP, ESP_GATT_AUTH_REQ_NONE);
+  if (status)
+    ESP_LOGW(TAG, "[%s] esp_ble_gattc_write_char failed, status=%d", this->parent_->address_str().c_str(), status);
+}
+
 void JkBmsBle::publish_state_(binary_sensor::BinarySensor *binary_sensor, const bool &state) {
   if (binary_sensor == nullptr)
     return;

--- a/components/jk_bms_ble/jk_bms_ble.cpp
+++ b/components/jk_bms_ble/jk_bms_ble.cpp
@@ -764,12 +764,19 @@ void JkBmsBle::decode_settings_(const std::vector<uint8_t> &data) {
   ESP_LOGI(TAG, "  MOS OTP recovery: %f °C", (float) jk_get_32bit(110) * 0.1f);
   // 114   4   0x0D 0x00 0x00 0x00    Cell count
   ESP_LOGI(TAG, "  Cell count: %f", (float) jk_get_32bit(114));
+
   // 118   4   0x01 0x00 0x00 0x00    Charge switch
   ESP_LOGI(TAG, "  Charge switch: %s", ((bool) data[118]) ? "on" : "off");
+  this->publish_state_(this->charging_switch_, (bool) data[118]);
+
   // 122   4   0x01 0x00 0x00 0x00    Discharge switch
   ESP_LOGI(TAG, "  Discharge switch: %s", ((bool) data[122]) ? "on" : "off");
+  this->publish_state_(this->discharging_switch_, (bool) data[122]);
+
   // 126   4   0x01 0x00 0x00 0x00    Balancer switch
   ESP_LOGI(TAG, "  Balancer switch: %s", ((bool) data[126]) ? "on" : "off");
+  this->publish_state_(this->balancer_switch_, (bool) (data[126]));
+
   // 130   4   0x88 0x13 0x00 0x00    Nominal battery capacity
   ESP_LOGI(TAG, "  Nominal battery capacity: %f Ah", (float) jk_get_32bit(130) * 0.001f);
   // 134   4   0xDC 0x05 0x00 0x00    Unknown6
@@ -862,7 +869,7 @@ void JkBmsBle::decode_device_info_(const std::vector<uint8_t> &data) {
   ESP_LOGI(TAG, "  Setup passcode: %s", std::string(data.begin() + 118, data.begin() + 118 + 16).c_str());
 }
 
-void JkBmsBle::write_register(uint8_t address, uint32_t value) {
+bool JkBmsBle::write_register(uint8_t address, uint32_t value) {
   uint8_t frame[20];
   frame[0] = 0xAA;     // start sequence
   frame[1] = 0x55;     // start sequence
@@ -870,10 +877,10 @@ void JkBmsBle::write_register(uint8_t address, uint32_t value) {
   frame[3] = 0xEB;     // start sequence
   frame[4] = address;  // holding register
   frame[5] = 0x04;     // size of the value in byte
-  frame[6] = value;
-  frame[7] = value;
-  frame[8] = value;
-  frame[9] = value;
+  frame[6] = value >> 24;
+  frame[7] = value >> 16;
+  frame[8] = value >> 8;
+  frame[9] = value >> 0;
   frame[10] = 0x00;
   frame[11] = 0x00;
   frame[12] = 0x00;
@@ -883,12 +890,16 @@ void JkBmsBle::write_register(uint8_t address, uint32_t value) {
   frame[16] = 0x00;
   frame[17] = 0x00;
   frame[18] = 0x00;
-  frame[19] = crc(frame, 19);
+  frame[19] = crc(frame, sizeof(frame) - 1);
 
+  ESP_LOGD(TAG, "Write register: %s", format_hex_pretty(frame, sizeof(frame)).c_str());
   auto status = esp_ble_gattc_write_char(this->parent_->gattc_if, this->parent_->conn_id, this->char_handle_,
                                          sizeof(frame), frame, ESP_GATT_WRITE_TYPE_NO_RSP, ESP_GATT_AUTH_REQ_NONE);
+
   if (status)
     ESP_LOGW(TAG, "[%s] esp_ble_gattc_write_char failed, status=%d", this->parent_->address_str().c_str(), status);
+
+  return (status == 0);
 }
 
 void JkBmsBle::publish_state_(binary_sensor::BinarySensor *binary_sensor, const bool &state) {
@@ -903,6 +914,13 @@ void JkBmsBle::publish_state_(sensor::Sensor *sensor, float value) {
     return;
 
   sensor->publish_state(value);
+}
+
+void JkBmsBle::publish_state_(switch_::Switch *obj, const bool &state) {
+  if (obj == nullptr)
+    return;
+
+  obj->publish_state(state);
 }
 
 void JkBmsBle::publish_state_(text_sensor::TextSensor *text_sensor, const std::string &state) {

--- a/components/jk_bms_ble/jk_bms_ble.h
+++ b/components/jk_bms_ble/jk_bms_ble.h
@@ -114,7 +114,7 @@ class JkBmsBle : public esphome::ble_client::BLEClientNode, public PollingCompon
 
   void set_enable_fake_traffic(bool enable_fake_traffic) { enable_fake_traffic_ = enable_fake_traffic; }
   void set_protocol_version(ProtocolVersion protocol_version) { this->protocol_version_ = protocol_version; }
-  void write_register(uint8_t address, uint32_t value);
+  bool write_register(uint8_t address, uint32_t value);
 
   struct Cell {
     sensor::Sensor *cell_voltage_sensor_{nullptr};

--- a/components/jk_bms_ble/jk_bms_ble.h
+++ b/components/jk_bms_ble/jk_bms_ble.h
@@ -6,6 +6,7 @@
 #include "esphome/components/esp32_ble_tracker/esp32_ble_tracker.h"
 #include "esphome/components/binary_sensor/binary_sensor.h"
 #include "esphome/components/sensor/sensor.h"
+#include "esphome/components/switch/switch.h"
 #include "esphome/components/text_sensor/text_sensor.h"
 
 #ifdef USE_ESP32
@@ -107,8 +108,13 @@ class JkBmsBle : public esphome::ble_client::BLEClientNode, public PollingCompon
     total_runtime_formatted_text_sensor_ = total_runtime_formatted_text_sensor;
   }
 
+  void set_charging_switch(switch_::Switch *charging_switch) { charging_switch_ = charging_switch; }
+  void set_discharging_switch(switch_::Switch *discharging_switch) { discharging_switch_ = discharging_switch; }
+  void set_balancer_switch(switch_::Switch *balancer_switch) { balancer_switch_ = balancer_switch; }
+
   void set_enable_fake_traffic(bool enable_fake_traffic) { enable_fake_traffic_ = enable_fake_traffic; }
   void set_protocol_version(ProtocolVersion protocol_version) { this->protocol_version_ = protocol_version; }
+  void write_register(uint8_t address, uint32_t value);
 
   struct Cell {
     sensor::Sensor *cell_voltage_sensor_{nullptr};
@@ -144,6 +150,10 @@ class JkBmsBle : public esphome::ble_client::BLEClientNode, public PollingCompon
   sensor::Sensor *total_runtime_sensor_;
   sensor::Sensor *balancing_current_sensor_;
 
+  switch_::Switch *charging_switch_;
+  switch_::Switch *discharging_switch_;
+  switch_::Switch *balancer_switch_;
+
   text_sensor::TextSensor *total_runtime_formatted_text_sensor_;
 
   std::vector<uint8_t> frame_buffer_;
@@ -161,6 +171,7 @@ class JkBmsBle : public esphome::ble_client::BLEClientNode, public PollingCompon
   void decode_settings_(const std::vector<uint8_t> &data);
   void publish_state_(binary_sensor::BinarySensor *binary_sensor, const bool &state);
   void publish_state_(sensor::Sensor *sensor, float value);
+  void publish_state_(switch_::Switch *obj, const bool &state);
   void publish_state_(text_sensor::TextSensor *text_sensor, const std::string &state);
 
   std::string format_total_runtime_(const uint32_t value) {

--- a/components/jk_bms_ble/switch/__init__.py
+++ b/components/jk_bms_ble/switch/__init__.py
@@ -1,0 +1,63 @@
+import esphome.codegen as cg
+from esphome.components import switch
+import esphome.config_validation as cv
+from esphome.const import CONF_ICON, CONF_ID
+
+from .. import CONF_JK_BMS_BLE_ID, JkBmsBle, jk_bms_ble_ns
+
+DEPENDENCIES = ["jk_bms_ble"]
+
+CODEOWNERS = ["@syssi"]
+
+CONF_CHARGING = "charging"
+CONF_DISCHARGING = "discharging"
+CONF_BALANCER = "balancer"
+
+ICON_CHARGING = "mdi:battery-charging-50"
+ICON_DISCHARGING = "mdi:battery-charging-50"
+ICON_BALANCER = "mdi:seesaw"
+
+SWITCHES = {
+    CONF_CHARGING: 0x1D,
+    CONF_DISCHARGING: 0x1E,
+    CONF_BALANCER: 0x1F,
+}
+
+JkSwitch = jk_bms_ble_ns.class_("JkSwitch", switch.Switch, cg.Component)
+
+CONFIG_SCHEMA = cv.Schema(
+    {
+        cv.GenerateID(CONF_JK_BMS_BLE_ID): cv.use_id(JkBmsBle),
+        cv.Optional(CONF_CHARGING): switch.SWITCH_SCHEMA.extend(
+            {
+                cv.GenerateID(): cv.declare_id(JkSwitch),
+                cv.Optional(CONF_ICON, default=ICON_CHARGING): switch.icon,
+            }
+        ).extend(cv.COMPONENT_SCHEMA),
+        cv.Optional(CONF_DISCHARGING): switch.SWITCH_SCHEMA.extend(
+            {
+                cv.GenerateID(): cv.declare_id(JkSwitch),
+                cv.Optional(CONF_ICON, default=ICON_DISCHARGING): switch.icon,
+            }
+        ).extend(cv.COMPONENT_SCHEMA),
+        cv.Optional(CONF_BALANCER): switch.SWITCH_SCHEMA.extend(
+            {
+                cv.GenerateID(): cv.declare_id(JkSwitch),
+                cv.Optional(CONF_ICON, default=ICON_BALANCER): switch.icon,
+            }
+        ).extend(cv.COMPONENT_SCHEMA),
+    }
+)
+
+
+def to_code(config):
+    hub = yield cg.get_variable(config[CONF_JK_BMS_BLE_ID])
+    for key, address in SWITCHES.items():
+        if key in config:
+            conf = config[key]
+            var = cg.new_Pvariable(conf[CONF_ID])
+            yield cg.register_component(var, conf)
+            yield switch.register_switch(var, conf)
+            cg.add(getattr(hub, f"set_{key}_switch")(var))
+            cg.add(var.set_parent(hub))
+            cg.add(var.set_holding_register(address))

--- a/components/jk_bms_ble/switch/jk_switch.cpp
+++ b/components/jk_bms_ble/switch/jk_switch.cpp
@@ -9,7 +9,9 @@ static const char *const TAG = "jk_bms_ble.switch";
 
 void JkSwitch::dump_config() { LOG_SWITCH("", "JkBmsBle Switch", this); }
 void JkSwitch::write_state(bool state) {
-  this->parent_->write_register(this->holding_register_, (state) ? 0x01000000 : 0x00000000);
+  if (this->parent_->write_register(this->holding_register_, (state) ? 0x01000000 : 0x00000000)) {
+    this->publish_state(state);
+  }
 }
 
 }  // namespace jk_bms_ble

--- a/components/jk_bms_ble/switch/jk_switch.cpp
+++ b/components/jk_bms_ble/switch/jk_switch.cpp
@@ -9,7 +9,7 @@ static const char *const TAG = "jk_bms_ble.switch";
 
 void JkSwitch::dump_config() { LOG_SWITCH("", "JkBmsBle Switch", this); }
 void JkSwitch::write_state(bool state) {
-  this->parent_->write_register(this->holding_register_, (state) ? 0x01000000, 0x00000000);
+  this->parent_->write_register(this->holding_register_, (state) ? 0x01000000 : 0x00000000);
 }
 
 }  // namespace jk_bms_ble

--- a/components/jk_bms_ble/switch/jk_switch.cpp
+++ b/components/jk_bms_ble/switch/jk_switch.cpp
@@ -1,0 +1,16 @@
+#include "jk_switch.h"
+#include "esphome/core/log.h"
+#include "esphome/core/application.h"
+
+namespace esphome {
+namespace jk_bms_ble {
+
+static const char *const TAG = "jk_bms_ble.switch";
+
+void JkSwitch::dump_config() { LOG_SWITCH("", "JkBmsBle Switch", this); }
+void JkSwitch::write_state(bool state) {
+  this->parent_->write_register(this->holding_register_, (state) ? 0x01000000, 0x00000000);
+}
+
+}  // namespace jk_bms_ble
+}  // namespace esphome

--- a/components/jk_bms_ble/switch/jk_switch.h
+++ b/components/jk_bms_ble/switch/jk_switch.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "../jk_bms_ble.h"
+#include "esphome/core/component.h"
+#include "esphome/components/switch/switch.h"
+
+namespace esphome {
+namespace jk_bms_ble {
+
+class JkBmsBle;
+class JkSwitch : public switch_::Switch, public Component {
+ public:
+  void set_parent(JkBms *parent) { this->parent_ = parent; };
+  void set_holding_register(uint8_t holding_register) { this->holding_register_ = holding_register; };
+  void dump_config() override;
+  void loop() override {}
+  float get_setup_priority() const override { return setup_priority::DATA; }
+
+ protected:
+  void write_state(bool state) override;
+  JkBmsBle *parent_;
+  uint8_t holding_register_;
+};
+
+}  // namespace jk_bms_ble
+}  // namespace esphome

--- a/components/jk_bms_ble/switch/jk_switch.h
+++ b/components/jk_bms_ble/switch/jk_switch.h
@@ -10,7 +10,7 @@ namespace jk_bms_ble {
 class JkBmsBle;
 class JkSwitch : public switch_::Switch, public Component {
  public:
-  void set_parent(JkBms *parent) { this->parent_ = parent; };
+  void set_parent(JkBmsBle *parent) { this->parent_ = parent; };
   void set_holding_register(uint8_t holding_register) { this->holding_register_ = holding_register; };
   void dump_config() override;
   void loop() override {}

--- a/esp32-ble-example.yaml
+++ b/esp32-ble-example.yaml
@@ -202,6 +202,15 @@ sensor:
     balancing_current:
       name: "${name} balancing current"
 
+switch:
+  - platform: jk_bms_ble
+    charging:
+      name: "${name} charging"
+    discharging:
+      name: "${name} discharging"
+    balancer:
+      name: "${name} balancer"
+
 text_sensor:
   - platform: jk_bms_ble
     total_runtime_formatted:


### PR DESCRIPTION
Please add

```
switch:
  - platform: jk_bms_ble
    charging:
      name: "${name} charging"
    discharging:
      name: "${name} discharging"
    balancer:
      name: "${name} balancer"
```

to your yaml configuration to use this new feature!

Closes: #73