### PR TITLE
Expose error bitmask as sensor and text_sensor (Closes: #74)

### DIFF
--- a/components/jk_bms_ble/jk_bms_ble.cpp
+++ b/components/jk_bms_ble/jk_bms_ble.cpp
@@ -19,7 +19,7 @@ static const char *const ERRORS[ERRORS_SIZE] = {
     "Charge Overtemperature",               // 0000 0000 0000 0001
     "Charge Undertemperature",              // 0000 0000 0000 0010
     "Error 0x00 0x04",                      // 0000 0000 0000 0100
-    "Cell Undervoltage"                     // 0000 0000 0000 1000
+    "Cell Undervoltage",                    // 0000 0000 0000 1000
     "Error 0x00 0x10",                      // 0000 0000 0001 0000
     "Error 0x00 0x20",                      // 0000 0000 0010 0000
     "Error 0x00 0x40",                      // 0000 0000 0100 0000
@@ -440,7 +440,6 @@ void JkBmsBle::decode_jk02_cell_info_(const std::vector<uint8_t> &data) {
   //                                    Cell count is not equal to settings
   //           0x04 0x08                Cell Undervoltage +                  0000 0100 0000 1000
   //                                    Cell count is not equal to settings
-  ESP_LOGI(TAG, "System alarms: %02X %02X", data[136], data[137]);
   uint16_t raw_errors_bitmask = jk_get_16bit(data[136]);
   this->publish_state_(this->errors_bitmask_sensor_, (float) raw_errors_bitmask);
   this->publish_state_(this->errors_text_sensor_, this->error_bits_to_string_(raw_errors_bitmask));

--- a/components/jk_bms_ble/jk_bms_ble.cpp
+++ b/components/jk_bms_ble/jk_bms_ble.cpp
@@ -14,6 +14,26 @@ static const uint16_t JK_BMS_CHARACTERISTIC_UUID = 0xFFE1;
 static const uint16_t MIN_RESPONSE_SIZE = 300;
 static const uint16_t MAX_RESPONSE_SIZE = 320;
 
+static const uint8_t ERRORS_SIZE = 16;
+static const char *const ERRORS[ERRORS_SIZE] = {
+    "Charge Overtemperature",               // 0000 0000 0000 0001
+    "Charge Undertemperature",              // 0000 0000 0000 0010
+    "Error 0x00 0x04",                      // 0000 0000 0000 0100
+    "Cell Undervoltage"                     // 0000 0000 0000 1000
+    "Error 0x00 0x10",                      // 0000 0000 0001 0000
+    "Error 0x00 0x20",                      // 0000 0000 0010 0000
+    "Error 0x00 0x40",                      // 0000 0000 0100 0000
+    "Error 0x00 0x80",                      // 0000 0000 1000 0000
+    "Error 0x01 0x00",                      // 0000 0001 0000 0000
+    "Error 0x02 0x00",                      // 0000 0010 0000 0000
+    "Cell count is not equal to settings",  // 0000 0100 0000 0000
+    "Error 0x08 0x00",                      // 0000 1000 0000 0000
+    "Cell Overvoltage",                     // 0001 0000 0000 0000
+    "Error 0x20 0x00",                      // 0010 0000 0000 0000
+    "Error 0x40 0x00",                      // 0100 0000 0000 0000
+    "Error 0x80 0x00",                      // 1000 0000 0000 0000
+};
+
 uint8_t crc(const uint8_t data[], const uint16_t len) {
   uint8_t crc = 0;
   for (uint16_t i = 0; i < len; i++) {
@@ -421,6 +441,9 @@ void JkBmsBle::decode_jk02_cell_info_(const std::vector<uint8_t> &data) {
   //           0x04 0x08                Cell Undervoltage +                  0000 0100 0000 1000
   //                                    Cell count is not equal to settings
   ESP_LOGI(TAG, "System alarms: %02X %02X", data[136], data[137]);
+  uint16_t raw_errors_bitmask = jk_get_16bit(data[136]);
+  this->publish_state_(this->errors_bitmask_sensor_, (float) raw_errors_bitmask);
+  this->publish_state_(this->errors_text_sensor_, this->error_bits_to_string_(raw_errors_bitmask));
 
   // 138   2   0x00 0x00              Balance current      0.001         A
   this->publish_state_(this->balancing_current_sensor_, (float) ((int16_t) jk_get_16bit(138)) * 0.001f);
@@ -928,6 +951,26 @@ void JkBmsBle::publish_state_(text_sensor::TextSensor *text_sensor, const std::s
     return;
 
   text_sensor->publish_state(state);
+}
+
+std::string JkBmsBle::error_bits_to_string_(const uint16_t mask) {
+  bool first = true;
+  std::string errors_list = "";
+
+  if (mask) {
+    for (int i = 0; i < ERRORS_SIZE; i++) {
+      if (mask & (1 << i)) {
+        if (first) {
+          first = false;
+        } else {
+          errors_list.append(";");
+        }
+        errors_list.append(ERRORS[i]);
+      }
+    }
+  }
+
+  return errors_list;
 }
 
 }  // namespace jk_bms_ble

--- a/components/jk_bms_ble/jk_bms_ble.h
+++ b/components/jk_bms_ble/jk_bms_ble.h
@@ -103,7 +103,11 @@ class JkBmsBle : public esphome::ble_client::BLEClientNode, public PollingCompon
   void set_balancing_current_sensor(sensor::Sensor *balancing_current_sensor) {
     balancing_current_sensor_ = balancing_current_sensor;
   }
+  void set_errors_bitmask_sensor(sensor::Sensor *errors_bitmask_sensor) {
+    errors_bitmask_sensor_ = errors_bitmask_sensor;
+  }
 
+  void set_errors_text_sensor(text_sensor::TextSensor *errors_text_sensor) { errors_text_sensor_ = errors_text_sensor; }
   void set_total_runtime_formatted_text_sensor(text_sensor::TextSensor *total_runtime_formatted_text_sensor) {
     total_runtime_formatted_text_sensor_ = total_runtime_formatted_text_sensor;
   }
@@ -149,11 +153,13 @@ class JkBmsBle : public esphome::ble_client::BLEClientNode, public PollingCompon
   sensor::Sensor *total_charging_cycle_capacity_sensor_;
   sensor::Sensor *total_runtime_sensor_;
   sensor::Sensor *balancing_current_sensor_;
+  sensor::Sensor *errors_bitmask_sensor_;
 
   switch_::Switch *charging_switch_;
   switch_::Switch *discharging_switch_;
   switch_::Switch *balancer_switch_;
 
+  text_sensor::TextSensor *errors_text_sensor_;
   text_sensor::TextSensor *total_runtime_formatted_text_sensor_;
 
   std::vector<uint8_t> frame_buffer_;

--- a/components/jk_bms_ble/jk_bms_ble.h
+++ b/components/jk_bms_ble/jk_bms_ble.h
@@ -179,6 +179,7 @@ class JkBmsBle : public esphome::ble_client::BLEClientNode, public PollingCompon
   void publish_state_(sensor::Sensor *sensor, float value);
   void publish_state_(switch_::Switch *obj, const bool &state);
   void publish_state_(text_sensor::TextSensor *text_sensor, const std::string &state);
+  std::string error_bits_to_string_(uint16_t bitmask);
 
   std::string format_total_runtime_(const uint32_t value) {
     int seconds = (int) value;

--- a/components/jk_bms_ble/sensor.py
+++ b/components/jk_bms_ble/sensor.py
@@ -95,6 +95,7 @@ CONF_CHARGING_CYCLES = "charging_cycles"
 CONF_TOTAL_CHARGING_CYCLE_CAPACITY = "total_charging_cycle_capacity"
 CONF_TOTAL_RUNTIME = "total_runtime"
 CONF_BALANCING_CURRENT = "balancing_current"
+CONF_ERRORS_BITMASK = "errors_bitmask"
 
 UNIT_AMPERE_HOURS = "Ah"
 UNIT_OHM = "Ω"
@@ -106,6 +107,7 @@ ICON_MAX_VOLTAGE_CELL = "mdi:battery-plus-outline"
 ICON_STATE_OF_CHARGE = "mdi:battery-50"
 ICON_CAPACITY_REMAINING = "mdi:battery-50"
 ICON_CHARGING_CYCLES = "mdi:battery-sync"
+ICON_ERRORS_BITMASK = "mdi:alert-circle-outline"
 
 CELL_VOLTAGES = [
     CONF_CELL_VOLTAGE_1,
@@ -183,6 +185,7 @@ SENSORS = [
     CONF_TOTAL_CHARGING_CYCLE_CAPACITY,
     CONF_TOTAL_RUNTIME,
     CONF_BALANCING_CURRENT,
+    CONF_ERRORS_BITMASK,
 ]
 
 # pylint: disable=too-many-function-args
@@ -670,6 +673,13 @@ CONFIG_SCHEMA = cv.Schema(
             icon=ICON_EMPTY,
             accuracy_decimals=2,
             device_class=DEVICE_CLASS_CURRENT,
+            state_class=STATE_CLASS_MEASUREMENT,
+        ),
+        cv.Optional(CONF_ERRORS_BITMASK): sensor.sensor_schema(
+            unit_of_measurement=UNIT_EMPTY,
+            icon=ICON_ERRORS_BITMASK,
+            accuracy_decimals=0,
+            device_class=DEVICE_CLASS_EMPTY,
             state_class=STATE_CLASS_MEASUREMENT,
         ),
     }

--- a/components/jk_bms_ble/text_sensor.py
+++ b/components/jk_bms_ble/text_sensor.py
@@ -9,15 +9,25 @@ DEPENDENCIES = ["jk_bms_ble"]
 
 CODEOWNERS = ["@syssi"]
 
+CONF_ERRORS = "errors"
 CONF_TOTAL_RUNTIME_FORMATTED = "total_runtime_formatted"
 
+ICON_ERRORS = "mdi:alert-circle-outline"
+
 TEXT_SENSORS = [
+    CONF_ERRORS,
     CONF_TOTAL_RUNTIME_FORMATTED,
 ]
 
 CONFIG_SCHEMA = cv.Schema(
     {
         cv.GenerateID(CONF_JK_BMS_BLE_ID): cv.use_id(JkBmsBle),
+        cv.Optional(CONF_ERRORS): text_sensor.TEXT_SENSOR_SCHEMA.extend(
+            {
+                cv.GenerateID(): cv.declare_id(text_sensor.TextSensor),
+                cv.Optional(CONF_ICON, default=ICON_ERRORS): cv.icon,
+            }
+        ),
         cv.Optional(
             CONF_TOTAL_RUNTIME_FORMATTED
         ): text_sensor.TEXT_SENSOR_SCHEMA.extend(

--- a/esp32-ble-example.yaml
+++ b/esp32-ble-example.yaml
@@ -201,6 +201,8 @@ sensor:
       name: "${name} total runtime"
     balancing_current:
       name: "${name} balancing current"
+    errors_bitmask:
+      name: "${name} errors bitmask"
 
 switch:
   - platform: jk_bms_ble
@@ -213,5 +215,7 @@ switch:
 
 text_sensor:
   - platform: jk_bms_ble
+    errors:
+      name: "${name} errors"
     total_runtime_formatted:
       name: "${name} total runtime formatted"


### PR DESCRIPTION
Please extend your configuration yaml by:

```
sensor:
    errors_bitmask:
      name: "${name} errors bitmask"

text_sensor:
  - platform: jk_bms_ble
    errors:
      name: "${name} errors"
```