### PR TITLE
Control the most important settings of the BMS (JK02 protocol)

### DIFF
--- a/components/jk_bms_ble/__init__.py
+++ b/components/jk_bms_ble/__init__.py
@@ -3,7 +3,7 @@ from esphome.components import ble_client
 import esphome.config_validation as cv
 from esphome.const import CONF_ID, CONF_THROTTLE
 
-AUTO_LOAD = ["binary_sensor", "button", "sensor", "switch", "text_sensor"]
+AUTO_LOAD = ["binary_sensor", "button", "number", "sensor", "switch", "text_sensor"]
 CODEOWNERS = ["@syssi"]
 MULTI_CONF = True
 
@@ -21,6 +21,12 @@ PROTOCOL_VERSION_OPTIONS = {
     "JK02": ProtocolVersion.PROTOCOL_VERSION_JK02,
     "JK04": ProtocolVersion.PROTOCOL_VERSION_JK04,
 }
+
+JK_BMS_BLE_COMPONENT_SCHEMA = cv.Schema(
+    {
+        cv.GenerateID(CONF_JK_BMS_BLE_ID): cv.use_id(JkBmsBle),
+    }
+)
 
 CONFIG_SCHEMA = (
     cv.Schema(

--- a/components/jk_bms_ble/button/__init__.py
+++ b/components/jk_bms_ble/button/__init__.py
@@ -3,7 +3,7 @@ from esphome.components import button
 import esphome.config_validation as cv
 from esphome.const import CONF_ICON, CONF_ID
 
-from .. import CONF_JK_BMS_BLE_ID, JkBmsBle, jk_bms_ble_ns
+from .. import CONF_JK_BMS_BLE_ID, JK_BMS_BLE_COMPONENT_SCHEMA, jk_bms_ble_ns
 
 DEPENDENCIES = ["jk_bms_ble"]
 
@@ -23,9 +23,8 @@ BUTTONS = {
 
 JkButton = jk_bms_ble_ns.class_("JkButton", button.Button, cg.Component)
 
-CONFIG_SCHEMA = cv.Schema(
+CONFIG_SCHEMA = JK_BMS_BLE_COMPONENT_SCHEMA.extend(
     {
-        cv.GenerateID(CONF_JK_BMS_BLE_ID): cv.use_id(JkBmsBle),
         cv.Optional(CONF_RETRIEVE_SETTINGS): button.BUTTON_SCHEMA.extend(
             {
                 cv.GenerateID(): cv.declare_id(JkButton),

--- a/components/jk_bms_ble/jk_bms_ble.cpp
+++ b/components/jk_bms_ble/jk_bms_ble.cpp
@@ -1096,7 +1096,6 @@ bool JkBmsBle::write_register(uint8_t address, uint32_t value, uint8_t length) {
   frame[19] = crc(frame, sizeof(frame) - 1);
 
   ESP_LOGD(TAG, "Write register: %s", format_hex_pretty(frame, sizeof(frame)).c_str());
-
   auto status = esp_ble_gattc_write_char(this->parent_->gattc_if, this->parent_->conn_id, this->char_handle_,
                                          sizeof(frame), frame, ESP_GATT_WRITE_TYPE_NO_RSP, ESP_GATT_AUTH_REQ_NONE);
 

--- a/components/jk_bms_ble/jk_bms_ble.cpp
+++ b/components/jk_bms_ble/jk_bms_ble.cpp
@@ -772,28 +772,44 @@ void JkBmsBle::decode_jk02_settings_(const std::vector<uint8_t> &data) {
   ESP_LOGD(TAG, "  Unknown6: %f", (float) jk_get_32bit(6) * 0.001f);
   // 10    4   0x54 0x0B 0x00 0x00    Cell UVP
   ESP_LOGI(TAG, "  Cell UVP: %f V", (float) jk_get_32bit(10) * 0.001f);
+  this->publish_state_(this->cell_voltage_undervoltage_protection_number_, (float) jk_get_32bit(10) * 0.001f);
+
   // 14    4   0x80 0x0C 0x00 0x00    Cell OVP Recovery
   ESP_LOGI(TAG, "  Cell UVPR: %f V", (float) jk_get_32bit(14) * 0.001f);
+  this->publish_state_(this->cell_voltage_undervoltage_recovery_number_, (float) jk_get_32bit(14) * 0.001f);
+
   // 18    4   0xCC 0x10 0x00 0x00    Cell OVP
   ESP_LOGI(TAG, "  Cell OVP: %f V", (float) jk_get_32bit(18) * 0.001f);
+  this->publish_state_(this->cell_voltage_overvoltage_protection_number_, (float) jk_get_32bit(18) * 0.001f);
+
   // 22    4   0x68 0x10 0x00 0x00    Cell OVP Recovery
   ESP_LOGI(TAG, "  Cell OVPR: %f V", (float) jk_get_32bit(22) * 0.001f);
+  this->publish_state_(this->cell_voltage_overvoltage_recovery_number_, (float) jk_get_32bit(22) * 0.001f);
+
   // 26    4   0x0A 0x00 0x00 0x00    Balance trigger voltage
   ESP_LOGI(TAG, "  Balance trigger voltage: %f V", (float) jk_get_32bit(26) * 0.001f);
+  this->publish_state_(this->balance_trigger_voltage_number_, (float) jk_get_32bit(26) * 0.001f);
+
   // 30    4   0x00 0x00 0x00 0x00    Unknown30
   // 34    4   0x00 0x00 0x00 0x00    Unknown34
   // 38    4   0x00 0x00 0x00 0x00    Unknown38
   // 42    4   0x00 0x00 0x00 0x00    Unknown42
-  // 46    4   0xF0 0x0A 0x00 0x00    Power off value
+  // 46    4   0xF0 0x0A 0x00 0x00    Power off voltage
   ESP_LOGI(TAG, "  Power off voltage: %f V", (float) jk_get_32bit(46) * 0.001f);
+  this->publish_state_(this->power_off_voltage_number_, (float) jk_get_32bit(46) * 0.001f);
+
   // 50    4   0xA8 0x61 0x00 0x00    Max. charge current
   ESP_LOGI(TAG, "  Max. charge current: %f A", (float) jk_get_32bit(50) * 0.001f);
+  this->publish_state_(this->max_charge_current_number_, (float) jk_get_32bit(50) * 0.001f);
+
   // 54    4   0x1E 0x00 0x00 0x00    Charge OCP delay
   ESP_LOGI(TAG, "  Charge OCP delay: %f s", (float) jk_get_32bit(54));
   // 58    4   0x3C 0x00 0x00 0x00    Charge OCP recovery delay
   ESP_LOGI(TAG, "  Charge OCP recovery delay: %f s", (float) jk_get_32bit(58));
   // 62    4   0xF0 0x49 0x02 0x00    Max. discharge current
   ESP_LOGI(TAG, "  Max. discharge current: %f A", (float) jk_get_32bit(62) * 0.001f);
+  this->publish_state_(this->max_discharge_current_number_, (float) jk_get_32bit(62) * 0.001f);
+
   // 66    4   0x2C 0x01 0x00 0x00    Discharge OCP delay
   ESP_LOGI(TAG, "  Discharge OCP recovery delay: %f s", (float) jk_get_32bit(66));
   // 70    4   0x3C 0x00 0x00 0x00    Discharge OCP recovery delay
@@ -802,6 +818,8 @@ void JkBmsBle::decode_jk02_settings_(const std::vector<uint8_t> &data) {
   ESP_LOGI(TAG, "  SCP recovery time: %f s", (float) jk_get_32bit(74));
   // 78    4   0xD0 0x07 0x00 0x00    Max balance current
   ESP_LOGI(TAG, "  Max. balance current: %f A", (float) jk_get_32bit(78) * 0.001f);
+  this->publish_state_(this->max_balance_current_number_, (float) jk_get_32bit(78) * 0.001f);
+
   // 82    4   0xBC 0x02 0x00 0x00    Charge OTP
   ESP_LOGI(TAG, "  Charge OTP: %f °C", (float) jk_get_32bit(82) * 0.1f);
   // 86    4   0x58 0x02 0x00 0x00    Charge OTP Recovery
@@ -820,6 +838,7 @@ void JkBmsBle::decode_jk02_settings_(const std::vector<uint8_t> &data) {
   ESP_LOGI(TAG, "  MOS OTP recovery: %f °C", (float) ((int32_t) jk_get_32bit(110)) * 0.1f);
   // 114   4   0x0D 0x00 0x00 0x00    Cell count
   ESP_LOGI(TAG, "  Cell count: %f", (float) jk_get_32bit(114));
+  this->publish_state_(this->cell_count_number_, (float) data[114]);
 
   // 118   4   0x01 0x00 0x00 0x00    Charge switch
   ESP_LOGI(TAG, "  Charge switch: %s", ((bool) data[118]) ? "on" : "off");
@@ -835,10 +854,14 @@ void JkBmsBle::decode_jk02_settings_(const std::vector<uint8_t> &data) {
 
   // 130   4   0x88 0x13 0x00 0x00    Nominal battery capacity
   ESP_LOGI(TAG, "  Nominal battery capacity: %f Ah", (float) jk_get_32bit(130) * 0.001f);
+  this->publish_state_(this->total_battery_capacity_number_, (float) jk_get_32bit(130) * 0.001f);
+
   // 134   4   0xDC 0x05 0x00 0x00    Unknown134
   ESP_LOGD(TAG, "  Unknown134: %f", (float) jk_get_32bit(134) * 0.001f);
   // 138   4   0xE4 0x0C 0x00 0x00    Start balance voltage
   ESP_LOGI(TAG, "  Start balance voltage: %f V", (float) jk_get_32bit(138) * 0.001f);
+  this->publish_state_(this->balance_starting_voltage_number_, (float) jk_get_32bit(138) * 0.001f);
+
   // 142   4   0x00 0x00 0x00 0x00
   // 146   4   0x00 0x00 0x00 0x00
   // 150   4   0x00 0x00 0x00 0x00
@@ -1057,10 +1080,10 @@ bool JkBmsBle::write_register(uint8_t address, uint32_t value, uint8_t length) {
   frame[3] = 0xEB;     // start sequence
   frame[4] = address;  // holding register
   frame[5] = length;   // size of the value in byte
-  frame[6] = value >> 24;
-  frame[7] = value >> 16;
-  frame[8] = value >> 8;
-  frame[9] = value >> 0;
+  frame[6] = value >> 0;
+  frame[7] = value >> 8;
+  frame[8] = value >> 16;
+  frame[9] = value >> 24;
   frame[10] = 0x00;
   frame[11] = 0x00;
   frame[12] = 0x00;
@@ -1073,6 +1096,7 @@ bool JkBmsBle::write_register(uint8_t address, uint32_t value, uint8_t length) {
   frame[19] = crc(frame, sizeof(frame) - 1);
 
   ESP_LOGD(TAG, "Write register: %s", format_hex_pretty(frame, sizeof(frame)).c_str());
+
   auto status = esp_ble_gattc_write_char(this->parent_->gattc_if, this->parent_->conn_id, this->char_handle_,
                                          sizeof(frame), frame, ESP_GATT_WRITE_TYPE_NO_RSP, ESP_GATT_AUTH_REQ_NONE);
 
@@ -1080,6 +1104,8 @@ bool JkBmsBle::write_register(uint8_t address, uint32_t value, uint8_t length) {
     ESP_LOGW(TAG, "[%s] esp_ble_gattc_write_char failed, status=%d", this->parent_->address_str().c_str(), status);
 
   return (status == 0);
+
+  return true;
 }
 
 void JkBmsBle::publish_state_(binary_sensor::BinarySensor *binary_sensor, const bool &state) {
@@ -1087,6 +1113,13 @@ void JkBmsBle::publish_state_(binary_sensor::BinarySensor *binary_sensor, const 
     return;
 
   binary_sensor->publish_state(state);
+}
+
+void JkBmsBle::publish_state_(number::Number *number, float value) {
+  if (number == nullptr)
+    return;
+
+  number->publish_state(value);
 }
 
 void JkBmsBle::publish_state_(sensor::Sensor *sensor, float value) {

--- a/components/jk_bms_ble/jk_bms_ble.h
+++ b/components/jk_bms_ble/jk_bms_ble.h
@@ -5,6 +5,7 @@
 #include "esphome/components/ble_client/ble_client.h"
 #include "esphome/components/esp32_ble_tracker/esp32_ble_tracker.h"
 #include "esphome/components/binary_sensor/binary_sensor.h"
+#include "esphome/components/number/number.h"
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/switch/switch.h"
 #include "esphome/components/text_sensor/text_sensor.h"
@@ -30,6 +31,47 @@ class JkBmsBle : public esphome::ble_client::BLEClientNode, public PollingCompon
   void dump_config() override;
   void update() override;
   float get_setup_priority() const override { return setup_priority::DATA; }
+
+  void set_balance_trigger_voltage_number(number::Number *balance_trigger_voltage_number) {
+    balance_trigger_voltage_number_ = balance_trigger_voltage_number;
+  }
+  void set_cell_count_number(number::Number *cell_count_number) { cell_count_number_ = cell_count_number; }
+  void set_total_battery_capacity_number(number::Number *total_battery_capacity_number) {
+    total_battery_capacity_number_ = total_battery_capacity_number;
+  }
+  void set_cell_voltage_overvoltage_protection_number(number::Number *cell_voltage_overvoltage_protection_number) {
+    cell_voltage_overvoltage_protection_number_ = cell_voltage_overvoltage_protection_number;
+  }
+  void set_cell_voltage_overvoltage_recovery_number(number::Number *cell_voltage_overvoltage_recovery_number) {
+    cell_voltage_overvoltage_recovery_number_ = cell_voltage_overvoltage_recovery_number;
+  }
+  void set_cell_voltage_undervoltage_protection_number(number::Number *cell_voltage_undervoltage_protection_number) {
+    cell_voltage_undervoltage_protection_number_ = cell_voltage_undervoltage_protection_number;
+  }
+  void set_cell_voltage_undervoltage_recovery_number(number::Number *cell_voltage_undervoltage_recovery_number) {
+    cell_voltage_undervoltage_recovery_number_ = cell_voltage_undervoltage_recovery_number;
+  }
+  void set_balance_starting_voltage_number(number::Number *balance_starting_voltage_number) {
+    balance_starting_voltage_number_ = balance_starting_voltage_number;
+  }
+  void set_voltage_calibration_number(number::Number *voltage_calibration_number) {
+    voltage_calibration_number_ = voltage_calibration_number;
+  }
+  void set_current_calibration_number(number::Number *current_calibration_number) {
+    current_calibration_number_ = current_calibration_number;
+  }
+  void set_power_off_voltage_number(number::Number *power_off_voltage_number) {
+    power_off_voltage_number_ = power_off_voltage_number;
+  }
+  void set_max_balance_current_number(number::Number *max_balance_current_number) {
+    max_balance_current_number_ = max_balance_current_number;
+  }
+  void set_max_charge_current_number(number::Number *max_charge_current_number) {
+    max_charge_current_number_ = max_charge_current_number;
+  }
+  void set_max_discharge_current_number(number::Number *max_discharge_current_number) {
+    max_discharge_current_number_ = max_discharge_current_number;
+  }
 
   void set_balancing_binary_sensor(binary_sensor::BinarySensor *balancing_binary_sensor) {
     balancing_binary_sensor_ = balancing_binary_sensor;
@@ -136,6 +178,21 @@ class JkBmsBle : public esphome::ble_client::BLEClientNode, public PollingCompon
   binary_sensor::BinarySensor *charging_binary_sensor_;
   binary_sensor::BinarySensor *discharging_binary_sensor_;
 
+  number::Number *balance_trigger_voltage_number_;
+  number::Number *cell_count_number_;
+  number::Number *total_battery_capacity_number_;
+  number::Number *cell_voltage_overvoltage_protection_number_;
+  number::Number *cell_voltage_overvoltage_recovery_number_;
+  number::Number *cell_voltage_undervoltage_protection_number_;
+  number::Number *cell_voltage_undervoltage_recovery_number_;
+  number::Number *balance_starting_voltage_number_;
+  number::Number *voltage_calibration_number_;  // @FIXME: Identify value at the settings frame
+  number::Number *current_calibration_number_;  // @FIXME: Identify value at the settings frame
+  number::Number *power_off_voltage_number_;
+  number::Number *max_balance_current_number_;
+  number::Number *max_charge_current_number_;
+  number::Number *max_discharge_current_number_;
+
   sensor::Sensor *min_cell_voltage_sensor_;
   sensor::Sensor *max_cell_voltage_sensor_;
   sensor::Sensor *min_voltage_cell_sensor_;
@@ -182,6 +239,7 @@ class JkBmsBle : public esphome::ble_client::BLEClientNode, public PollingCompon
   void decode_jk02_settings_(const std::vector<uint8_t> &data);
   void decode_jk04_settings_(const std::vector<uint8_t> &data);
   void publish_state_(binary_sensor::BinarySensor *binary_sensor, const bool &state);
+  void publish_state_(number::Number *number, float value);
   void publish_state_(sensor::Sensor *sensor, float value);
   void publish_state_(switch_::Switch *obj, const bool &state);
   void publish_state_(text_sensor::TextSensor *text_sensor, const std::string &state);

--- a/components/jk_bms_ble/number/__init__.py
+++ b/components/jk_bms_ble/number/__init__.py
@@ -1,0 +1,257 @@
+import esphome.codegen as cg
+from esphome.components import number
+import esphome.config_validation as cv
+from esphome.const import (
+    CONF_ENTITY_CATEGORY,
+    CONF_ICON,
+    CONF_ID,
+    CONF_MAX_VALUE,
+    CONF_MIN_VALUE,
+    CONF_MODE,
+    CONF_STEP,
+    CONF_UNIT_OF_MEASUREMENT,
+    ENTITY_CATEGORY_CONFIG,
+    ICON_EMPTY,
+    UNIT_AMPERE,
+    UNIT_EMPTY,
+    UNIT_VOLT,
+)
+
+from .. import CONF_JK_BMS_BLE_ID, JK_BMS_BLE_COMPONENT_SCHEMA, jk_bms_ble_ns
+
+DEPENDENCIES = ["jk_bms_ble"]
+
+CODEOWNERS = ["@syssi"]
+
+DEFAULT_STEP = 1
+
+# 06 04 03000000  Set balance trig voltage to 0.003
+# 1c 04 10000000  Set cell count to 16
+# 20 04 f0ba0400  Set battery cap to 310
+# 04 04 420e0000  Set Cell OVP to 3.65
+# 05 04 b0040000  Set Cell OVPR to 1.2
+# 02 04 b0040000  Set Cell UVP to 1.2
+# 03 04 b0040000  Set Cell UVPR to 1.2
+# 26 04 b0040000  Set Start Balance voltage to 1.2
+# 21 04 42d10000  Set cal voltage to 53.57
+# 24 04 64000000  Set cal current to 0.100
+# 0b 04 b0040000  Set Power Off value to 1.2
+# 13 04 2c010000  Set max Balance current to 0.3
+# 0c 04 e8030000  Set Max charge Current to 1.0
+# 0f 04 e8030000  Set Max discharge Current to 1.0
+
+CONF_BALANCE_TRIGGER_VOLTAGE = "balance_trigger_voltage"
+CONF_CELL_COUNT = "cell_count"
+CONF_TOTAL_BATTERY_CAPACITY = "total_battery_capacity"
+CONF_CELL_VOLTAGE_OVERVOLTAGE_PROTECTION = "cell_voltage_overvoltage_protection"
+CONF_CELL_VOLTAGE_OVERVOLTAGE_RECOVERY = "cell_voltage_overvoltage_recovery"
+CONF_CELL_VOLTAGE_UNDERVOLTAGE_PROTECTION = "cell_voltage_undervoltage_protection"
+CONF_CELL_VOLTAGE_UNDERVOLTAGE_RECOVERY = "cell_voltage_undervoltage_recovery"
+CONF_BALANCE_STARTING_VOLTAGE = "balance_starting_voltage"
+CONF_VOLTAGE_CALIBRATION = "voltage_calibration"
+CONF_CURRENT_CALIBRATION = "current_calibration"
+CONF_POWER_OFF_VOLTAGE = "power_off_voltage"
+CONF_MAX_BALANCE_CURRENT = "max_balance_current"
+CONF_MAX_CHARGE_CURRENT = "max_charge_current"
+CONF_MAX_DISCHARGE_CURRENT = "max_discharge_current"
+
+# 0d 04 02000000  Set Charge OCP delay to 2
+# 0e 04 02000000  Set Charge OCPR Time to 2
+# 10 04 02000000  Set Discharge OCP delay to 2
+# 11 04 02000000  Set Discharge OCPR Time to 2
+# 25 04 0a000000  Set to SCP Delay to 10.000
+# 12 04 02000000  Set SCPR Time to 2
+# 14 04 2c010000  Set Charge OTP to 30
+# 15 04 2c010000  Set Charge OTPR to 30
+# 16 04 2c010000  Set Discharge OTP to 30
+# 17 04 2c010000  Set Discharge OTPR to 30
+# 18 04 00000000  Set Charge UTP to 0
+# 19 04 00000000  Set Charge UTPR to 0
+
+# 9f 04 54657374  Set User Private Data (4 bytes) to TEST
+# 9f 0d 30313233343536373839303132 c6  Set User Private Data (4 bytes) to 0123456789012
+# 27 04 00000000  Set Con. Wire Res.01 to 0.00
+# ...
+# 3e 04 00000000  Set Con. Wire Res.24 to 0.00
+#
+# https://github.com/jblance/mpp-solar/issues/170#issuecomment-1050503970
+
+UNIT_AMPERE_HOUR = "Ah"
+
+NUMBERS = {
+    # JK02 register, JK04 register, factor
+    CONF_BALANCE_TRIGGER_VOLTAGE: [0x06, 0x00, 1000.0],
+    CONF_CELL_COUNT: [0x1C, 0x00, 1.0],
+    CONF_TOTAL_BATTERY_CAPACITY: [0x20, 0x00, 1000.0],
+    CONF_CELL_VOLTAGE_OVERVOLTAGE_PROTECTION: [0x04, 0x00, 1000.0],
+    CONF_CELL_VOLTAGE_OVERVOLTAGE_RECOVERY: [0x05, 0x00, 1000.0],
+    CONF_CELL_VOLTAGE_UNDERVOLTAGE_PROTECTION: [0x02, 0x00, 1000.0],
+    CONF_CELL_VOLTAGE_UNDERVOLTAGE_RECOVERY: [0x03, 0x00, 1000.0],
+    CONF_BALANCE_STARTING_VOLTAGE: [0x26, 0x00, 1000.0],
+    CONF_VOLTAGE_CALIBRATION: [0x21, 0x00, 1000.0],
+    CONF_CURRENT_CALIBRATION: [0x24, 0x00, 1000.0],
+    CONF_POWER_OFF_VOLTAGE: [0x0B, 0x00, 1000.0],
+    CONF_MAX_BALANCE_CURRENT: [0x13, 0x00, 1000.0],
+    CONF_MAX_CHARGE_CURRENT: [0x0C, 0x00, 1000.0],
+    CONF_MAX_DISCHARGE_CURRENT: [0x0F, 0x00, 1000.0],
+}
+
+JkNumber = jk_bms_ble_ns.class_("JkNumber", number.Number, cg.Component)
+
+JK_NUMBER_SCHEMA = number.NUMBER_SCHEMA.extend(
+    {
+        cv.GenerateID(): cv.declare_id(JkNumber),
+        cv.Optional(CONF_ICON, default=ICON_EMPTY): number.icon,
+        cv.Optional(CONF_STEP, default=0.01): cv.float_,
+        cv.Optional(CONF_UNIT_OF_MEASUREMENT, default=UNIT_VOLT): cv.string_strict,
+        cv.Optional(CONF_MODE, default="BOX"): cv.enum(number.NUMBER_MODES, upper=True),
+        cv.Optional(
+            CONF_ENTITY_CATEGORY, default=ENTITY_CATEGORY_CONFIG
+        ): cv.entity_category,
+    }
+).extend(cv.COMPONENT_SCHEMA)
+
+CONFIG_SCHEMA = JK_BMS_BLE_COMPONENT_SCHEMA.extend(
+    {
+        cv.Optional(CONF_BALANCE_TRIGGER_VOLTAGE): JK_NUMBER_SCHEMA.extend(
+            {
+                cv.Optional(CONF_MIN_VALUE, default=0.003): cv.float_,
+                cv.Optional(CONF_MAX_VALUE, default=1.0): cv.float_,
+                cv.Optional(CONF_STEP, default=0.001): cv.float_,
+            }
+        ),
+        cv.Optional(CONF_CELL_COUNT): JK_NUMBER_SCHEMA.extend(
+            {
+                cv.Optional(CONF_MIN_VALUE, default=8): cv.float_,
+                cv.Optional(CONF_MAX_VALUE, default=24): cv.float_,
+                cv.Optional(CONF_STEP, default=1.0): cv.float_,
+                cv.Optional(
+                    CONF_UNIT_OF_MEASUREMENT, default=UNIT_EMPTY
+                ): cv.string_strict,
+            }
+        ),
+        cv.Optional(CONF_TOTAL_BATTERY_CAPACITY): JK_NUMBER_SCHEMA.extend(
+            {
+                cv.Optional(CONF_MIN_VALUE, default=5): cv.float_,
+                cv.Optional(CONF_MAX_VALUE, default=2000): cv.float_,
+                cv.Optional(CONF_STEP, default=1.0): cv.float_,
+                cv.Optional(
+                    CONF_UNIT_OF_MEASUREMENT, default=UNIT_AMPERE_HOUR
+                ): cv.string_strict,
+            }
+        ),
+        cv.Optional(CONF_CELL_VOLTAGE_OVERVOLTAGE_PROTECTION): JK_NUMBER_SCHEMA.extend(
+            {
+                cv.Optional(CONF_MIN_VALUE, default=1.2): cv.float_,
+                cv.Optional(CONF_MAX_VALUE, default=4.350): cv.float_,
+                cv.Optional(CONF_STEP, default=0.001): cv.float_,
+            }
+        ),
+        cv.Optional(CONF_CELL_VOLTAGE_OVERVOLTAGE_RECOVERY): JK_NUMBER_SCHEMA.extend(
+            {
+                cv.Optional(CONF_MIN_VALUE, default=1.2): cv.float_,
+                cv.Optional(CONF_MAX_VALUE, default=4.350): cv.float_,
+                cv.Optional(CONF_STEP, default=0.001): cv.float_,
+            }
+        ),
+        cv.Optional(CONF_CELL_VOLTAGE_UNDERVOLTAGE_PROTECTION): JK_NUMBER_SCHEMA.extend(
+            {
+                cv.Optional(CONF_MIN_VALUE, default=1.2): cv.float_,
+                cv.Optional(CONF_MAX_VALUE, default=4.350): cv.float_,
+                cv.Optional(CONF_STEP, default=0.001): cv.float_,
+            }
+        ),
+        cv.Optional(CONF_CELL_VOLTAGE_UNDERVOLTAGE_RECOVERY): JK_NUMBER_SCHEMA.extend(
+            {
+                cv.Optional(CONF_MIN_VALUE, default=1.2): cv.float_,
+                cv.Optional(CONF_MAX_VALUE, default=4.350): cv.float_,
+                cv.Optional(CONF_STEP, default=0.001): cv.float_,
+            }
+        ),
+        cv.Optional(CONF_BALANCE_STARTING_VOLTAGE): JK_NUMBER_SCHEMA.extend(
+            {
+                cv.Optional(CONF_MIN_VALUE, default=1.20): cv.float_,
+                cv.Optional(CONF_MAX_VALUE, default=4.25): cv.float_,
+                cv.Optional(CONF_STEP, default=0.01): cv.float_,
+            }
+        ),
+        cv.Optional(CONF_VOLTAGE_CALIBRATION): JK_NUMBER_SCHEMA.extend(
+            {
+                # @FIXME The exact limits are unknown
+                cv.Optional(CONF_MIN_VALUE, default=10.0): cv.float_,
+                cv.Optional(CONF_MAX_VALUE, default=100.0): cv.float_,
+                cv.Optional(CONF_STEP, default=0.01): cv.float_,
+            }
+        ),
+        cv.Optional(CONF_CURRENT_CALIBRATION): JK_NUMBER_SCHEMA.extend(
+            {
+                # @FIXME Exact limits are unknown
+                cv.Optional(CONF_MIN_VALUE, default=0.0): cv.float_,
+                cv.Optional(CONF_MAX_VALUE, default=100.0): cv.float_,
+                cv.Optional(CONF_STEP, default=0.001): cv.float_,
+                cv.Optional(
+                    CONF_UNIT_OF_MEASUREMENT, default=UNIT_AMPERE
+                ): cv.string_strict,
+            }
+        ),
+        cv.Optional(CONF_POWER_OFF_VOLTAGE): JK_NUMBER_SCHEMA.extend(
+            {
+                # @FIXME The upper limit is unknown
+                cv.Optional(CONF_MIN_VALUE, default=1.20): cv.float_,
+                cv.Optional(CONF_MAX_VALUE, default=4.25): cv.float_,
+                cv.Optional(CONF_STEP, default=0.01): cv.float_,
+            }
+        ),
+        cv.Optional(CONF_MAX_BALANCE_CURRENT): JK_NUMBER_SCHEMA.extend(
+            {
+                cv.Optional(CONF_MIN_VALUE, default=0.3): cv.float_,
+                cv.Optional(CONF_MAX_VALUE, default=5.0): cv.float_,
+                cv.Optional(CONF_STEP, default=0.1): cv.float_,
+                cv.Optional(
+                    CONF_UNIT_OF_MEASUREMENT, default=UNIT_AMPERE
+                ): cv.string_strict,
+            }
+        ),
+        cv.Optional(CONF_MAX_CHARGE_CURRENT): JK_NUMBER_SCHEMA.extend(
+            {
+                cv.Optional(CONF_MIN_VALUE, default=1.0): cv.float_,
+                cv.Optional(CONF_MAX_VALUE, default=200.0): cv.float_,
+                cv.Optional(CONF_STEP, default=0.1): cv.float_,
+                cv.Optional(
+                    CONF_UNIT_OF_MEASUREMENT, default=UNIT_AMPERE
+                ): cv.string_strict,
+            }
+        ),
+        cv.Optional(CONF_MAX_DISCHARGE_CURRENT): JK_NUMBER_SCHEMA.extend(
+            {
+                cv.Optional(CONF_MIN_VALUE, default=1.0): cv.float_,
+                cv.Optional(CONF_MAX_VALUE, default=200.0): cv.float_,
+                cv.Optional(CONF_STEP, default=0.1): cv.float_,
+                cv.Optional(
+                    CONF_UNIT_OF_MEASUREMENT, default=UNIT_AMPERE
+                ): cv.string_strict,
+            }
+        ),
+    }
+)
+
+
+async def to_code(config):
+    hub = await cg.get_variable(config[CONF_JK_BMS_BLE_ID])
+    for key, address in NUMBERS.items():
+        if key in config:
+            conf = config[key]
+            var = cg.new_Pvariable(conf[CONF_ID])
+            await cg.register_component(var, conf)
+            await number.register_number(
+                var,
+                conf,
+                min_value=conf[CONF_MIN_VALUE],
+                max_value=conf[CONF_MAX_VALUE],
+                step=conf[CONF_STEP],
+            )
+            cg.add(getattr(hub, f"set_{key}_number")(var))
+            cg.add(var.set_parent(hub))
+            cg.add(var.set_jk02_holding_register(address[0]))
+            cg.add(var.set_jk04_holding_register(address[1]))
+            cg.add(var.set_factor(address[2]))

--- a/components/jk_bms_ble/number/jk_number.cpp
+++ b/components/jk_bms_ble/number/jk_number.cpp
@@ -1,0 +1,23 @@
+#include "jk_number.h"
+#include "esphome/core/log.h"
+
+namespace esphome {
+namespace jk_bms_ble {
+
+static const char *const TAG = "jk_bms_ble.number";
+
+void JkNumber::dump_config() { LOG_NUMBER("", "JkBmsBle Number", this); }
+void JkNumber::control(float value) {
+  if (this->parent_->get_protocol_version() == PROTOCOL_VERSION_JK02) {
+    uint32_t payload = (uint32_t)(value * this->factor_);
+    if (this->parent_->write_register(this->jk02_holding_register_, payload, sizeof(payload))) {
+      this->publish_state(state);
+    }
+    return;
+  }
+
+  ESP_LOGE(TAG, "This number entity isn't supported by the selected protocol version");
+}
+
+}  // namespace jk_bms_ble
+}  // namespace esphome

--- a/components/jk_bms_ble/number/jk_number.h
+++ b/components/jk_bms_ble/number/jk_number.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include "../jk_bms_ble.h"
+#include "esphome/core/component.h"
+#include "esphome/components/number/number.h"
+
+namespace esphome {
+namespace jk_bms_ble {
+
+class JkBmsBle;
+
+class JkNumber : public number::Number, public Component {
+ public:
+  void set_parent(JkBmsBle *parent) { this->parent_ = parent; };
+  void set_jk02_holding_register(uint8_t jk02_holding_register) {
+    this->jk02_holding_register_ = jk02_holding_register;
+  };
+  void set_jk04_holding_register(uint8_t jk04_holding_register) {
+    this->jk04_holding_register_ = jk04_holding_register;
+  };
+  void set_factor(float factor) { this->factor_ = factor; };
+  void dump_config() override;
+
+ protected:
+  void control(float value) override;
+
+  JkBmsBle *parent_;
+  uint8_t jk02_holding_register_;
+  uint8_t jk04_holding_register_;
+  float factor_{1000.0f};
+};
+
+}  // namespace jk_bms_ble
+}  // namespace esphome

--- a/components/jk_bms_ble/switch/__init__.py
+++ b/components/jk_bms_ble/switch/__init__.py
@@ -3,7 +3,7 @@ from esphome.components import switch
 import esphome.config_validation as cv
 from esphome.const import CONF_ICON, CONF_ID
 
-from .. import CONF_JK_BMS_BLE_ID, JkBmsBle, jk_bms_ble_ns
+from .. import CONF_JK_BMS_BLE_ID, JK_BMS_BLE_COMPONENT_SCHEMA, jk_bms_ble_ns
 
 DEPENDENCIES = ["jk_bms_ble"]
 
@@ -25,9 +25,8 @@ SWITCHES = {
 
 JkSwitch = jk_bms_ble_ns.class_("JkSwitch", switch.Switch, cg.Component)
 
-CONFIG_SCHEMA = cv.Schema(
+CONFIG_SCHEMA = JK_BMS_BLE_COMPONENT_SCHEMA.extend(
     {
-        cv.GenerateID(CONF_JK_BMS_BLE_ID): cv.use_id(JkBmsBle),
         cv.Optional(CONF_CHARGING): switch.SWITCH_SCHEMA.extend(
             {
                 cv.GenerateID(): cv.declare_id(JkSwitch),

--- a/components/jk_bms_ble/switch/jk_switch.cpp
+++ b/components/jk_bms_ble/switch/jk_switch.cpp
@@ -10,18 +10,18 @@ static const char *const TAG = "jk_bms_ble.switch";
 void JkSwitch::dump_config() { LOG_SWITCH("", "JkBmsBle Switch", this); }
 void JkSwitch::write_state(bool state) {
   if (this->parent_->get_protocol_version() == PROTOCOL_VERSION_JK02) {
-    if (this->parent_->write_register(this->jk02_holding_register_, (state) ? 0x01000000 : 0x00000000, 0x04)) {
+    if (this->parent_->write_register(this->jk02_holding_register_, (state) ? 0x00000001 : 0x00000000, 0x04)) {
       this->publish_state(state);
     }
     return;
   }
 
   if (this->jk04_holding_register_ == 0x00) {
-    ESP_LOGE(TAG, "This switch isn't supported by the selected protocol version.");
+    ESP_LOGE(TAG, "This switch isn't supported by the selected protocol version");
     return;
   }
 
-  if (this->parent_->write_register(this->jk04_holding_register_, (state) ? 0x01000000 : 0x00000000, 0x01)) {
+  if (this->parent_->write_register(this->jk04_holding_register_, (state) ? 0x00000001 : 0x00000000, 0x01)) {
     this->publish_state(state);
   }
 }

--- a/esp32-ble-example.yaml
+++ b/esp32-ble-example.yaml
@@ -67,6 +67,38 @@ button:
     retrieve_device_info:
       name: "${name} retrieve device info"
 
+number:
+  - platform: jk_bms_ble
+    jk_bms_ble_id: bms0
+    balance_trigger_voltage:
+      name: "${name} balance trigger voltage"
+    cell_count:
+      name: "${name} cell count"
+    total_battery_capacity:
+      name: "${name} total battery capacity"
+    cell_voltage_overvoltage_protection:
+      name: "${name} cell voltage overvoltage protection"
+    cell_voltage_overvoltage_recovery:
+      name: "${name} cell voltage overvoltage recovery"
+    cell_voltage_undervoltage_protection:
+      name: "${name} cell voltage undervoltage protection"
+    cell_voltage_undervoltage_recovery:
+      name: "${name} cell voltage undervoltage recovery"
+    balance_starting_voltage:
+      name: "${name} balance starting voltage"
+    voltage_calibration:
+      name: "${name} voltage calibration"
+    current_calibration:
+      name: "${name} current calibration"
+    power_off_voltage:
+      name: "${name} power off voltage"
+    max_balance_current:
+      name: "${name} max balance current"
+    max_charge_current:
+      name: "${name} max charge current"
+    max_discharge_current:
+      name: "${name} max discharge current"
+
 sensor:
   - platform: jk_bms_ble
     jk_bms_ble_id: bms0


### PR DESCRIPTION
Closes: #87

| Reg | Len | Payload | Description | Test result |
| ----- | ----- | ---------- | -------------- | ------------- |
| 06 | 04 | 03000000 | Set balance trig voltage to 0.003 | `AA.55.90.EB.06.04.03.00.00.00.00.00.00.00.00.00.00.00.00.87` |
| 21 | 04 | 42d10000 | Set cal voltage to 53.57 | `AA.55.90.EB.21.04.42.D1.00.00.00.00.00.00.00.00.00.00.00.B2` |
| 24 | 04 | 64000000 | Set cal current to 0.100 | `AA.55.90.EB.24.04.64.00.00.00.00.00.00.00.00.00.00.00.00.06` |
| 04 | 04 | 420e0000 | Set Cell OVP to 3.65 | `AA.55.90.EB.04.04.42.0E.00.00.00.00.00.00.00.00.00.00.00.D2` |
| 05 | 04 | b0040000 | Set Cell OVPR to 1.2 | `AA.55.90.EB.05.04.B0.04.00.00.00.00.00.00.00.00.00.00.00.37` |
| 03 | 04 | b0040000 | Set Cell UVPR to 1.2 | `AA.55.90.EB.03.04.B0.04.00.00.00.00.00.00.00.00.00.00.00.35` |
| 02 | 04 | b0040000 | Set Cell UVP to 1.2 | `AA.55.90.EB.02.04.B0.04.00.00.00.00.00.00.00.00.00.00.00.34` |
| 0b | 04 | b0040000 | Set Power Off value to 1.2 | `AA.55.90.EB.0B.04.B0.04.00.00.00.00.00.00.00.00.00.00.00.3D` |
| 26 | 04 | b0040000 | Set Start Balance voltage to 1.2 | `AA.55.90.EB.26.04.B0.04.00.00.00.00.00.00.00.00.00.00.00.58` |
| 13 | 04 | 2c010000 | Set max Balance current to 0.3 | `AA.55.90.EB.13.04.2C.01.00.00.00.00.00.00.00.00.00.00.00.BE` |
| 0c | 04 | e8030000 | Set Max charge Current to 1.0 | `AA.55.90.EB.0C.04.E8.03.00.00.00.00.00.00.00.00.00.00.00.75` |
| 0f | 04 | e8030000 | Set Max discharge Current to 1.0 | `AA.55.90.EB.0F.04.E8.03.00.00.00.00.00.00.00.00.00.00.00.78` |
| 1c | 04 | 10000000 | Set cell count to 16 | `AA.55.90.EB.1C.04.10.00.00.00.00.00.00.00.00.00.00.00.00.AA` |
| 20 | 04 | f0ba0400 | Set battery cap to 310 | `AA.55.90.EB.20.04.F0.BA.04.00.00.00.00.00.00.00.00.00.00.4C` |

