### PR TITLE
Add a hybrid communication (BLE + UART) example

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -184,6 +184,7 @@ jobs:
           esphome -s external_components_source components config esp32-ble-example-faker.yaml
           esphome -s external_components_source components config esp32-ble-jk04-example.yaml
           esphome -s external_components_source components config esp32-ble-example-multiple-devices.yaml
+          esphome -s external_components_source components config esp32-ble-uart-mixed-example.yaml
 
       - name: Write yaml-snippets/secrets.yaml
         shell: bash

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -184,7 +184,7 @@ jobs:
           esphome -s external_components_source components config esp32-ble-example-faker.yaml
           esphome -s external_components_source components config esp32-ble-jk04-example.yaml
           esphome -s external_components_source components config esp32-ble-example-multiple-devices.yaml
-          esphome -s external_components_source components config esp32-ble-uart-mixed-example.yaml
+          esphome -s external_components_source components config esp32-ble-uart-hybrid-example.yaml
 
       - name: Write yaml-snippets/secrets.yaml
         shell: bash

--- a/esp32-ble-uart-hybrid-example.yaml
+++ b/esp32-ble-uart-hybrid-example.yaml
@@ -1,6 +1,6 @@
 substitutions:
   name: jk-bms
-  device_description: "Monitor and control a JK-BMS via UART-TTL"
+  device_description: "Monitor a JK-BMS via UART-TTL and control via BLE"
   external_components_source: github://syssi/esphome-jk-bms@main
 
   # BLE settings

--- a/esp32-ble-uart-mixed-example.yaml
+++ b/esp32-ble-uart-mixed-example.yaml
@@ -56,7 +56,7 @@ jk_bms_ble:
   - ble_client_id: client0
     protocol_version: ${protocol_version}
     throttle: 10s
-    id: bms0
+    id: bmsble0
 
 uart:
   id: uart0
@@ -76,6 +76,7 @@ jk_bms:
 
 binary_sensor:
   - platform: jk_bms
+    jk_bms_id: bms0
     balancing:
       name: "${name} balancing"
     balancing_switch:
@@ -93,6 +94,7 @@ binary_sensor:
 
 button:
   - platform: jk_bms_ble
+    jk_bms_ble_id: bmsble0
     retrieve_settings:
       name: "${name} retrieve settings"
     retrieve_device_info:
@@ -100,7 +102,7 @@ button:
 
 number:
   - platform: jk_bms_ble
-    jk_bms_ble_id: bms0
+    jk_bms_ble_id: bmsble0
     balance_trigger_voltage:
       name: "${name} balance trigger voltage"
     balance_starting_voltage:
@@ -112,6 +114,7 @@ number:
 
 sensor:
   - platform: jk_bms
+    jk_bms_id: bms0
     min_cell_voltage:
       name: "${name} min cell voltage"
     max_cell_voltage:
@@ -185,6 +188,7 @@ sensor:
 
 switch:
   - platform: jk_bms_ble
+    jk_bms_ble_id: bmsble0
     charging:
       name: "${name} charging"
     discharging:
@@ -198,6 +202,7 @@ switch:
 
 text_sensor:
   - platform: jk_bms
+    jk_bms_id: bms0
     errors:
       name: "${name} errors"
     operation_mode:

--- a/esp32-ble-uart-mixed-example.yaml
+++ b/esp32-ble-uart-mixed-example.yaml
@@ -1,0 +1,206 @@
+substitutions:
+  name: jk-bms
+  device_description: "Monitor and control a JK-BMS via UART-TTL"
+  external_components_source: github://syssi/esphome-jk-bms@main
+
+  # BLE settings
+  mac_address: C8:47:8C:E1:E2:E1
+  # Defaults to "JK02". Please use "JK04" if you have some old JK-BMS version (f.e. JK-B2A16S hw 3.0, sw. 3.3.0)
+  protocol_version: JK02
+
+  # UART settings
+  tx_pin: GPIO16
+  rx_pin: GPIO17
+
+esphome:
+  name: ${name}
+  comment: ${device_description}
+  project:
+    name: "syssi.esphome-jk-bms"
+    version: 1.3.0
+
+esp32:
+  board: wemos_d1_mini32
+  framework:
+    type: esp-idf
+    version: latest
+
+external_components:
+  - source: ${external_components_source}
+    refresh: 0s
+
+wifi:
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password
+
+ota:
+logger:
+
+# Please use the native `api` component instead of the `mqtt` section
+# if you use Home Assistant. The native API is more lightweight.
+#
+# api:
+mqtt:
+  broker: !secret mqtt_host
+  username: !secret mqtt_username
+  password: !secret mqtt_password
+  id: mqtt_client
+
+esp32_ble_tracker:
+
+ble_client:
+  - mac_address: ${mac_address}
+    id: client0
+
+jk_bms_ble:
+  - ble_client_id: client0
+    protocol_version: ${protocol_version}
+    throttle: 10s
+    id: bms0
+
+uart:
+  id: uart0
+  baud_rate: 115200
+  rx_buffer_size: 384
+  tx_pin: ${tx_pin}
+  rx_pin: ${rx_pin}
+
+jk_modbus:
+  id: modbus0
+  uart_id: uart0
+  rx_timeout: 50ms
+
+jk_bms:
+  id: bms0
+  jk_modbus_id: modbus0
+
+binary_sensor:
+  - platform: jk_bms
+    balancing:
+      name: "${name} balancing"
+    balancing_switch:
+      name: "${name} balancing switch"
+    charging:
+      name: "${name} charging"
+    charging_switch:
+      name: "${name} charging switch"
+    discharging:
+      name: "${name} discharging"
+    discharging_switch:
+      name: "${name} discharging switch"
+    dedicated_charger_switch:
+      name: "${name} dedicated charger switch"
+
+button:
+  - platform: jk_bms_ble
+    retrieve_settings:
+      name: "${name} retrieve settings"
+    retrieve_device_info:
+      name: "${name} retrieve device info"
+
+number:
+  - platform: jk_bms_ble
+    jk_bms_ble_id: bms0
+    balance_trigger_voltage:
+      name: "${name} balance trigger voltage"
+    balance_starting_voltage:
+      name: "${name} balance starting voltage"
+    power_off_voltage:
+      name: "${name} power off voltage"
+    max_balance_current:
+      name: "${name} max balance current"
+
+sensor:
+  - platform: jk_bms
+    min_cell_voltage:
+      name: "${name} min cell voltage"
+    max_cell_voltage:
+      name: "${name} max cell voltage"
+    min_voltage_cell:
+      name: "${name} min voltage cell"
+    max_voltage_cell:
+      name: "${name} max voltage cell"
+    delta_cell_voltage:
+      name: "${name} delta cell voltage"
+    average_cell_voltage:
+      name: "${name} average cell voltage"
+    cell_voltage_1:
+      name: "${name} cell voltage 1"
+    cell_voltage_2:
+      name: "${name} cell voltage 2"
+    cell_voltage_3:
+      name: "${name} cell voltage 3"
+    cell_voltage_4:
+      name: "${name} cell voltage 4"
+    cell_voltage_5:
+      name: "${name} cell voltage 5"
+    cell_voltage_6:
+      name: "${name} cell voltage 6"
+    cell_voltage_7:
+      name: "${name} cell voltage 7"
+    cell_voltage_8:
+      name: "${name} cell voltage 8"
+    cell_voltage_9:
+      name: "${name} cell voltage 9"
+    cell_voltage_10:
+      name: "${name} cell voltage 10"
+    cell_voltage_11:
+      name: "${name} cell voltage 11"
+    cell_voltage_12:
+      name: "${name} cell voltage 12"
+    cell_voltage_13:
+      name: "${name} cell voltage 13"
+    cell_voltage_14:
+      name: "${name} cell voltage 14"
+    cell_voltage_15:
+      name: "${name} cell voltage 15"
+    cell_voltage_16:
+      name: "${name} cell voltage 16"
+    power_tube_temperature:
+      name: "${name} power tube temperature"
+    temperature_sensor_1:
+      name: "${name} temperature sensor 1"
+    temperature_sensor_2:
+      name: "${name} temperature sensor 2"
+    total_voltage:
+      name: "${name} total voltage"
+    current:
+      name: "${name} current"
+    power:
+      name: "${name} power"
+    charging_power:
+      name: "${name} charging power"
+    discharging_power:
+      name: "${name} discharging power"
+    capacity_remaining:
+      name: "${name} capacity remaining"
+    capacity_remaining_derived:
+      name: "${name} capacity remaining derived"
+    errors_bitmask:
+      name: "${name} errors bitmask"
+    operation_mode_bitmask:
+      name: "${name} operation mode bitmask"
+    total_runtime:
+      name: "${name} total runtime"
+
+switch:
+  - platform: jk_bms_ble
+    charging:
+      name: "${name} charging"
+    discharging:
+      name: "${name} discharging"
+    balancer:
+      name: "${name} balancer"
+
+  - platform: ble_client
+    ble_client_id: client0
+    name: "${name} enable bluetooth connection"
+
+text_sensor:
+  - platform: jk_bms
+    errors:
+      name: "${name} errors"
+    operation_mode:
+      name: "${name} operation mode"
+    total_runtime_formatted:
+      name: "${name} total runtime formatted"


### PR DESCRIPTION
...to get the best of both worlds

The UART interface (`jk_bms` component) is used to retrieve data periodically.
The BLE client connection can be used to change settings or turn off charging/discharging. To disconnect/suspend the BLE connection the `enable bluetooth connection` can be turned off.

See https://github.com/syssi/esphome-jk-bms/discussions/261