### PR TITLE
Use recommended ESP-IDF platform version

### DIFF
--- a/esp32-ble-b2a8s20p-v11-example.yaml
+++ b/esp32-ble-b2a8s20p-v11-example.yaml
@@ -19,7 +19,6 @@ esp32:
   board: wemos_d1_mini32
   framework:
     type: esp-idf
-    version: latest
 
 external_components:
   - source: ${external_components_source}

--- a/esp32-ble-example-multiple-devices.yaml
+++ b/esp32-ble-example-multiple-devices.yaml
@@ -21,7 +21,6 @@ esp32:
   board: wemos_d1_mini32
   framework:
     type: esp-idf
-    version: latest
 
 external_components:
   - source: ${external_components_source}

--- a/esp32-ble-example.yaml
+++ b/esp32-ble-example.yaml
@@ -19,7 +19,6 @@ esp32:
   board: wemos_d1_mini32
   framework:
     type: esp-idf
-    version: latest
 
 external_components:
   - source: ${external_components_source}

--- a/esp32-ble-jk04-example.yaml
+++ b/esp32-ble-jk04-example.yaml
@@ -19,7 +19,6 @@ esp32:
   board: wemos_d1_mini32
   framework:
     type: esp-idf
-    version: latest
 
 external_components:
   - source: ${external_components_source}

--- a/esp32-ble-scanner.yaml
+++ b/esp32-ble-scanner.yaml
@@ -13,7 +13,6 @@ esp32:
   board: wemos_d1_mini32
   framework:
     type: esp-idf
-    version: latest
 
 wifi:
   ssid: !secret wifi_ssid

--- a/esp32-ble-uart-hybrid-example.yaml
+++ b/esp32-ble-uart-hybrid-example.yaml
@@ -25,7 +25,6 @@ esp32:
   board: wemos_d1_mini32
   framework:
     type: esp-idf
-    version: latest
 
 external_components:
   - source: ${external_components_source}

--- a/esp32-example-multiple-devices.yaml
+++ b/esp32-example-multiple-devices.yaml
@@ -20,7 +20,6 @@ esp32:
   board: wemos_d1_mini32
   framework:
     type: esp-idf
-    version: latest
 
 external_components:
   - source: ${external_components_source}

--- a/esp32-example.yaml
+++ b/esp32-example.yaml
@@ -16,7 +16,6 @@ esp32:
   board: wemos_d1_mini32
   framework:
     type: esp-idf
-    version: latest
 
 external_components:
   - source: ${external_components_source}

--- a/esp32-heltec-balancer-ble-example.yaml
+++ b/esp32-heltec-balancer-ble-example.yaml
@@ -15,7 +15,6 @@ esp32:
   board: wemos_d1_mini32
   framework:
     type: esp-idf
-    version: latest
 
 external_components:
   - source: ${external_components_source}


### PR DESCRIPTION
Fixes

```
/config/esphome/.esphome/build/jk-bms60a/sdkconfig.jk-bms60a:770 CONFIG_ESP_TASK_WDT was replaced with CONFIG_ESP_TASK_WDT_INIT
/config/esphome/.esphome/build/jk-bms60a/sdkconfig.jk-bms60a:947 CONFIG_HAL_ASSERTION_SILIENT was replaced with CONFIG_HAL_ASSERTION_SILENT
-- Configuring incomplete, errors occurred!
See also "/data/jk-bms60a/.pioenvs/jk-bms60a/CMakeFiles/CMakeOutput.log".

fatal: not a git repository (or any parent up to mount point /)
Stopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set).
CMake Error at /data/cache/platformio/packages/framework-espidf/tools/cmake/tool_version_check.cmake:36 (message):
  

  Tool doesn't match supported version from list ['esp-2022r1-11.2.0']:
  /data/cache/platformio/packages/toolchain-xtensa-esp32@8.4.0+2021r2-patch5/bin/xtensa-esp32-elf-gcc


  Please try to run 'idf.py fullclean' to solve it.
```