### PR TITLE
Mention protocol version 11 (`JK02_32S`)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -187,7 +187,7 @@ jobs:
           esphome -s external_components_source components config esp32-ble-jk04-example.yaml
           esphome -s external_components_source components config esp32-ble-example-multiple-devices.yaml
           esphome -s external_components_source components config esp32-ble-uart-hybrid-example.yaml
-          esphome -s external_components_source components config esp32-ble-b2a8s20p-v11-example.yaml
+          esphome -s external_components_source components config esp32-ble-v11-example.yaml
 
       - name: Write yaml-snippets/secrets.yaml
         shell: bash
@@ -251,4 +251,4 @@ jobs:
       - name: Compile esp32 (jk_bms_ble) example configurations
         run: |
           esphome -s external_components_source components compile esp32-ble-example-faker.yaml
-          esphome -s external_components_source components compile esp32-ble-b2a8s20p-v11-example.yaml
+          esphome -s external_components_source components compile esp32-ble-v11-example.yaml

--- a/esp32-ble-example-multiple-devices.yaml
+++ b/esp32-ble-example-multiple-devices.yaml
@@ -6,7 +6,9 @@ substitutions:
   external_components_source: github://syssi/esphome-jk-bms@main
   bms0_mac_address: C8:47:8C:E1:E2:E1
   bms1_mac_address: C8:47:8C:E1:E2:E2
-  # Defaults to "JK02". Please use "JK04" if you have some old JK-BMS version (f.e. JK-B2A16S hw 3.0, sw. 3.3.0)
+  # Defaults to "JK02" (hardware version >= 6.0 and < 11.0)
+  # Please use "JK02_32S" if you own a new JK-BMS >= hardware version 11.0 (f.e. JK-B2A8S20P hw 11.XW, sw 11.26)
+  # Please use "JK04" if you have some old JK-BMS <= hardware version 3.0 (f.e. JK-B2A16S hw 3.0, sw. 3.3.0)
   bms0_protocol_version: JK02
   bms1_protocol_version: JK02
 

--- a/esp32-ble-example.yaml
+++ b/esp32-ble-example.yaml
@@ -3,9 +3,9 @@ substitutions:
   device_description: "Monitor and control a JK-BMS via bluetooth"
   external_components_source: github://syssi/esphome-jk-bms@main
   mac_address: C8:47:8C:E1:E2:E1
-  # Defaults to "JK02"
-  # Please use "JK02_32S" if you own a JK-B2A8S20P >= hardware version 11+ (f.e. JK-B2A8S20P hw 11.XW, sw 11.26)
-  # Please use "JK04" if you have some old JK-BMS <= hardware version 3 (f.e. JK-B2A16S hw 3.0, sw. 3.3.0)
+  # Defaults to "JK02" (hardware version >= 6.0 and < 11.0)
+  # Please use "JK02_32S" if you own a new JK-BMS >= hardware version 11.0 (f.e. JK-B2A8S20P hw 11.XW, sw 11.26)
+  # Please use "JK04" if you have some old JK-BMS <= hardware version 3.0 (f.e. JK-B2A16S hw 3.0, sw. 3.3.0)
   protocol_version: JK02
 
 esphome:

--- a/esp32-ble-jk04-example.yaml
+++ b/esp32-ble-jk04-example.yaml
@@ -3,9 +3,9 @@ substitutions:
   device_description: "Monitor and control a JK-BMS via bluetooth"
   external_components_source: github://syssi/esphome-jk-bms@main
   mac_address: C8:47:FF:FF:FF:FF
-  # Defaults to "JK02"
-  # Please use "JK02_32S" if you own a JK-B2A8S20P >= hardware version 11+ (f.e. JK-B2A8S20P hw 11.XW, sw 11.26)
-  # Please use "JK04" if you have some old JK-BMS <= hardware version 3 (f.e. JK-B2A16S hw 3.0, sw. 3.3.0)
+  # Defaults to "JK02" (hardware version >= 6.0 and < 11.0)
+  # Please use "JK02_32S" if you own a new JK-BMS >= hardware version 11.0 (f.e. JK-B2A8S20P hw 11.XW, sw 11.26)
+  # Please use "JK04" if you have some old JK-BMS <= hardware version 3.0 (f.e. JK-B2A16S hw 3.0, sw. 3.3.0)
   protocol_version: JK04
 
 esphome:

--- a/esp32-ble-uart-hybrid-example.yaml
+++ b/esp32-ble-uart-hybrid-example.yaml
@@ -5,9 +5,9 @@ substitutions:
 
   # BLE settings
   mac_address: C8:47:8C:E1:E2:E1
-  # Defaults to "JK02"
-  # Please use "JK02_32S" if you own a JK-B2A8S20P >= hardware version 11+ (f.e. JK-B2A8S20P hw 11.XW, sw 11.26)
-  # Please use "JK04" if you have some old JK-BMS <= hardware version 3 (f.e. JK-B2A16S hw 3.0, sw. 3.3.0)
+  # Defaults to "JK02" (hardware version >= 6.0 and < 11.0)
+  # Please use "JK02_32S" if you own a new JK-BMS >= hardware version 11.0 (f.e. JK-B2A8S20P hw 11.XW, sw 11.26)
+  # Please use "JK04" if you have some old JK-BMS <= hardware version 3.0 (f.e. JK-B2A16S hw 3.0, sw. 3.3.0)
   protocol_version: JK02
 
   # UART settings

--- a/esp32-ble-v11-example.yaml
+++ b/esp32-ble-v11-example.yaml
@@ -1,11 +1,11 @@
 substitutions:
   name: jk-bms
-  device_description: "Monitor and control a JK-BMS via bluetooth"
+  device_description: "Monitor and control a JK-BMS v11 via bluetooth"
   external_components_source: github://syssi/esphome-jk-bms@main
   mac_address: C8:47:8C:E1:E2:E1
-  # Defaults to "JK02"
-  # Please use "JK02_32S" if you own a JK-B2A8S20P >= hardware version 11+ (f.e. JK-B2A8S20P hw 11.XW, sw 11.26)
-  # Please use "JK04" if you have some old JK-BMS <= hardware version 3 (f.e. JK-B2A16S hw 3.0, sw. 3.3.0)
+  # Defaults to "JK02" (hardware version >= 6.0 and < 11.0)
+  # Please use "JK02_32S" if you own a new JK-BMS >= hardware version 11.0 (f.e. JK-B2A8S20P hw 11.XW, sw 11.26)
+  # Please use "JK04" if you have some old JK-BMS <= hardware version 3.0 (f.e. JK-B2A16S hw 3.0, sw. 3.3.0)
   protocol_version: JK02_32S
 
 esphome:


### PR DESCRIPTION
All recent JK-BMS models are delivered with software/hardware version 11 now (using the protocol version `JK02_32S`). 