### PR TITLE
Fix preamble synchronization

### DIFF
--- a/components/jk_modbus/jk_modbus.cpp
+++ b/components/jk_modbus/jk_modbus.cpp
@@ -1,5 +1,6 @@
 #include "jk_modbus.h"
 #include "esphome/core/log.h"
+#include "esphome/core/helpers.h"
 
 namespace esphome {
 namespace jk_modbus {

--- a/components/jk_modbus/jk_modbus.cpp
+++ b/components/jk_modbus/jk_modbus.cpp
@@ -9,6 +9,8 @@ static const char *const TAG = "jk_modbus";
 void JkModbus::loop() {
   const uint32_t now = millis();
   if (now - this->last_jk_modbus_byte_ > this->rx_timeout_) {
+    ESP_LOGW(TAG, "Buffer cleared due to timeout: %s",
+             format_hex_pretty(&this->rx_buffer_.front(), this->rx_buffer_.size()).c_str());
     this->rx_buffer_.clear();
     this->last_jk_modbus_byte_ = now;
   }
@@ -19,6 +21,8 @@ void JkModbus::loop() {
     if (this->parse_jk_modbus_byte_(byte)) {
       this->last_jk_modbus_byte_ = now;
     } else {
+      ESP_LOGW(TAG, "Buffer cleared due to reset: %s",
+               format_hex_pretty(&this->rx_buffer_.front(), this->rx_buffer_.size()).c_str());
       this->rx_buffer_.clear();
     }
   }
@@ -47,7 +51,7 @@ bool JkModbus::parse_jk_modbus_byte_(uint8_t byte) {
     return true;
 
   if (raw[0] != 0x4E || raw[1] != 0x57) {
-    ESP_LOGW(TAG, "Invalid header");
+    ESP_LOGW(TAG, "Invalid header: 0x%02X 0x%02X", raw[0], raw[1]);
 
     // return false to reset buffer
     return false;

--- a/components/jk_modbus/jk_modbus.cpp
+++ b/components/jk_modbus/jk_modbus.cpp
@@ -48,14 +48,15 @@ bool JkModbus::parse_jk_modbus_byte_(uint8_t byte) {
   uint8_t address = raw[0];
 
   // Byte 1: Start sequence (0x57)
-  if (at == 1)
+  if (at == 1) {
+    if (raw[0] != 0x4E || raw[1] != 0x57) {
+      ESP_LOGW(TAG, "Invalid header: 0x%02X 0x%02X", raw[0], raw[1]);
+
+      // return false to reset buffer
+      return false;
+    }
+
     return true;
-
-  if (raw[0] != 0x4E || raw[1] != 0x57) {
-    ESP_LOGW(TAG, "Invalid header: 0x%02X 0x%02X", raw[0], raw[1]);
-
-    // return false to reset buffer
-    return false;
   }
 
   // Byte 2: Size (low byte)

--- a/components/jk_modbus/jk_modbus.cpp
+++ b/components/jk_modbus/jk_modbus.cpp
@@ -11,7 +11,7 @@ void JkModbus::loop() {
   const uint32_t now = millis();
   if (now - this->last_jk_modbus_byte_ > this->rx_timeout_) {
     ESP_LOGVV(TAG, "Buffer cleared due to timeout: %s",
-             format_hex_pretty(&this->rx_buffer_.front(), this->rx_buffer_.size()).c_str());
+              format_hex_pretty(&this->rx_buffer_.front(), this->rx_buffer_.size()).c_str());
     this->rx_buffer_.clear();
     this->last_jk_modbus_byte_ = now;
   }
@@ -23,7 +23,7 @@ void JkModbus::loop() {
       this->last_jk_modbus_byte_ = now;
     } else {
       ESP_LOGVV(TAG, "Buffer cleared due to reset: %s",
-               format_hex_pretty(&this->rx_buffer_.front(), this->rx_buffer_.size()).c_str());
+                format_hex_pretty(&this->rx_buffer_.front(), this->rx_buffer_.size()).c_str());
       this->rx_buffer_.clear();
     }
   }

--- a/components/jk_modbus/jk_modbus.cpp
+++ b/components/jk_modbus/jk_modbus.cpp
@@ -10,7 +10,7 @@ static const char *const TAG = "jk_modbus";
 void JkModbus::loop() {
   const uint32_t now = millis();
   if (now - this->last_jk_modbus_byte_ > this->rx_timeout_) {
-    ESP_LOGW(TAG, "Buffer cleared due to timeout: %s",
+    ESP_LOGVV(TAG, "Buffer cleared due to timeout: %s",
              format_hex_pretty(&this->rx_buffer_.front(), this->rx_buffer_.size()).c_str());
     this->rx_buffer_.clear();
     this->last_jk_modbus_byte_ = now;
@@ -22,7 +22,7 @@ void JkModbus::loop() {
     if (this->parse_jk_modbus_byte_(byte)) {
       this->last_jk_modbus_byte_ = now;
     } else {
-      ESP_LOGW(TAG, "Buffer cleared due to reset: %s",
+      ESP_LOGVV(TAG, "Buffer cleared due to reset: %s",
                format_hex_pretty(&this->rx_buffer_.front(), this->rx_buffer_.size()).c_str());
       this->rx_buffer_.clear();
     }


### PR DESCRIPTION
```
substitutions:
  external_components_source: github://syssi/esphome-jk-bms@debug-decoder
```