### PR TITLE
Add UART-TTL command support (write registers)

### DIFF
--- a/components/jk_bms/__init__.py
+++ b/components/jk_bms/__init__.py
@@ -3,7 +3,7 @@ from esphome.components import jk_modbus
 import esphome.config_validation as cv
 from esphome.const import CONF_ID
 
-AUTO_LOAD = ["jk_modbus", "binary_sensor", "sensor", "text_sensor"]
+AUTO_LOAD = ["jk_modbus", "binary_sensor", "sensor", "switch", "text_sensor"]
 CODEOWNERS = ["@syssi"]
 MULTI_CONF = True
 
@@ -22,6 +22,12 @@ CONFIG_SCHEMA = (
     )
     .extend(cv.polling_component_schema("5s"))
     .extend(jk_modbus.jk_modbus_device_schema(0x4E))
+)
+
+JK_BMS_COMPONENT_SCHEMA = cv.Schema(
+    {
+        cv.GenerateID(CONF_JK_BMS_ID): cv.use_id(JkBms),
+    }
 )
 
 

--- a/components/jk_bms/binary_sensor.py
+++ b/components/jk_bms/binary_sensor.py
@@ -1,21 +1,16 @@
 import esphome.codegen as cg
 from esphome.components import binary_sensor
 import esphome.config_validation as cv
-from esphome.const import (
-    CONF_ID,
-    DEVICE_CLASS_CONNECTIVITY,
-    ENTITY_CATEGORY_DIAGNOSTIC,
-)
+from esphome.const import CONF_ID, DEVICE_CLASS_CONNECTIVITY, ENTITY_CATEGORY_DIAGNOSTIC
 
-from . import CONF_JK_BMS_ID, JkBms
+from . import CONF_JK_BMS_ID, JK_BMS_COMPONENT_SCHEMA
+from .const import CONF_CHARGING, CONF_DISCHARGING
 
 DEPENDENCIES = ["jk_bms"]
 
 CODEOWNERS = ["@syssi"]
 
-CONF_CHARGING = "charging"
 CONF_CHARGING_SWITCH = "charging_switch"
-CONF_DISCHARGING = "discharging"
 CONF_DISCHARGING_SWITCH = "discharging_switch"
 CONF_BALANCING = "balancing"
 CONF_BALANCING_SWITCH = "balancing_switch"
@@ -41,9 +36,8 @@ BINARY_SENSORS = [
     CONF_ONLINE_STATUS,
 ]
 
-CONFIG_SCHEMA = cv.Schema(
+CONFIG_SCHEMA = JK_BMS_COMPONENT_SCHEMA.extend(
     {
-        cv.GenerateID(CONF_JK_BMS_ID): cv.use_id(JkBms),
         cv.Optional(CONF_CHARGING): binary_sensor.binary_sensor_schema(
             icon=ICON_CHARGING
         ),

--- a/components/jk_bms/binary_sensor.py
+++ b/components/jk_bms/binary_sensor.py
@@ -10,8 +10,12 @@ DEPENDENCIES = ["jk_bms"]
 
 CODEOWNERS = ["@syssi"]
 
-CONF_CHARGING_SWITCH = "charging_switch" # @DEPRECATED and superseded by switch.charging
-CONF_DISCHARGING_SWITCH = "discharging_switch" # @DEPRECATED and superseded by switch.discharging
+CONF_CHARGING_SWITCH = (
+    "charging_switch"  # @DEPRECATED and superseded by switch.charging
+)
+CONF_DISCHARGING_SWITCH = (
+    "discharging_switch"  # @DEPRECATED and superseded by switch.discharging
+)
 CONF_BALANCING = "balancing"
 CONF_BALANCING_SWITCH = "balancing_switch"
 CONF_DEDICATED_CHARGER_SWITCH = "dedicated_charger_switch"

--- a/components/jk_bms/binary_sensor.py
+++ b/components/jk_bms/binary_sensor.py
@@ -10,8 +10,8 @@ DEPENDENCIES = ["jk_bms"]
 
 CODEOWNERS = ["@syssi"]
 
-CONF_CHARGING_SWITCH = "charging_switch"
-CONF_DISCHARGING_SWITCH = "discharging_switch"
+CONF_CHARGING_SWITCH = "charging_switch" # @DEPRECATED and superseded by switch.charging
+CONF_DISCHARGING_SWITCH = "discharging_switch" # @DEPRECATED and superseded by switch.discharging
 CONF_BALANCING = "balancing"
 CONF_BALANCING_SWITCH = "balancing_switch"
 CONF_DEDICATED_CHARGER_SWITCH = "dedicated_charger_switch"

--- a/components/jk_bms/const.py
+++ b/components/jk_bms/const.py
@@ -1,0 +1,5 @@
+"""Constants for the jk bms component."""
+
+CONF_BALANCER = "balancer"
+CONF_CHARGING = "charging"
+CONF_DISCHARGING = "discharging"

--- a/components/jk_bms/jk_bms.cpp
+++ b/components/jk_bms/jk_bms.cpp
@@ -53,7 +53,8 @@ void JkBms::on_jk_modbus_data(const uint8_t &function, const std::vector<uint8_t
     return;
   }
 
-  ESP_LOGW(TAG, "Invalid size (%zu) for JK BMS frame!", data.size());
+  ESP_LOGW(TAG, "Unhandled response (%zu bytes) received: %s", data.size(),
+           format_hex_pretty(&data.front(), data.size()).c_str());
 }
 
 void JkBms::on_status_data_(const std::vector<uint8_t> &data) {

--- a/components/jk_bms/jk_bms.cpp
+++ b/components/jk_bms/jk_bms.cpp
@@ -10,7 +10,7 @@ static const char *const TAG = "jk_bms";
 static const uint8_t MAX_NO_RESPONSE_COUNT = 5;
 
 static const uint8_t FUNCTION_READ_ALL = 0x06;
-static const uint8_t WRITE_REGISTER = 0x02;
+static const uint8_t FUNCTION_WRITE_REGISTER = 0x02;
 
 static const uint8_t ERRORS_SIZE = 14;
 static const char *const ERRORS[ERRORS_SIZE] = {
@@ -50,6 +50,11 @@ void JkBms::on_jk_modbus_data(const uint8_t &function, const std::vector<uint8_t
 
   if (function == FUNCTION_READ_ALL) {
     this->on_status_data_(data);
+    return;
+  }
+
+  if (function == FUNCTION_WRITE_REGISTER) {
+    ESP_LOGI(TAG, "Register 0x%02X updated", data[0]);
     return;
   }
 

--- a/components/jk_bms/jk_bms.cpp
+++ b/components/jk_bms/jk_bms.cpp
@@ -10,7 +10,6 @@ static const char *const TAG = "jk_bms";
 static const uint8_t MAX_NO_RESPONSE_COUNT = 5;
 
 static const uint8_t FUNCTION_READ_ALL = 0x06;
-static const uint8_t ADDRESS_READ_ALL = 0x00;
 static const uint8_t WRITE_REGISTER = 0x02;
 
 static const uint8_t ERRORS_SIZE = 14;
@@ -258,6 +257,7 @@ void JkBms::on_status_data_(const std::vector<uint8_t> &data) {
 
   // 0x9D 0x01: Active balance switch                              1 (on)                     Bool     0 (off), 1 (on)
   this->publish_state_(this->balancing_switch_binary_sensor_, (bool) data[offset + 6 + 3 * 25]);
+  this->publish_state_(this->balancer_switch_, (bool) data[offset + 6 + 3 * 25]);
 
   // 0x9E 0x00 0x5A: Power tube temperature protection value                90°C            1.0 °C     0-100°C
   this->publish_state_(this->power_tube_temperature_protection_sensor_, (float) jk_get_16bit(offset + 8 + 3 * 25));
@@ -310,9 +310,11 @@ void JkBms::on_status_data_(const std::vector<uint8_t> &data) {
 
   // 0xAB 0x01: Charging MOS tube switch                                     1 (on)         Bool       0 (off), 1 (on)
   this->publish_state_(this->charging_switch_binary_sensor_, (bool) data[offset + 15 + 3 * 36]);
+  this->publish_state_(this->charging_switch_, (bool) data[offset + 15 + 3 * 36]);
 
   // 0xAC 0x01: Discharge MOS tube switch                                    1 (on)         Bool       0 (off), 1 (on)
   this->publish_state_(this->discharging_switch_binary_sensor_, (bool) data[offset + 17 + 3 * 36]);
+  this->publish_state_(this->discharging_switch_, (bool) data[offset + 17 + 3 * 36]);
 
   // 0xAD 0x04 0x11: Current calibration                       1041mA * 0.001 = 1.041A     0.001 A     0.1-2.0A
   this->publish_state_(this->current_calibration_sensor_, (float) jk_get_16bit(offset + 19 + 3 * 36) * 0.001f);
@@ -376,7 +378,7 @@ void JkBms::on_status_data_(const std::vector<uint8_t> &data) {
 
 void JkBms::update() {
   this->track_online_status_();
-  this->read_registers(FUNCTION_READ_ALL, ADDRESS_READ_ALL);
+  this->read_registers();
 
   if (this->enable_fake_traffic_) {
     // Start: 0x4E, 0x57, 0x01, 0x1B, 0x00, 0x00, 0x00, 0x00, 0x06, 0x00, 0x01
@@ -525,6 +527,13 @@ void JkBms::publish_state_(sensor::Sensor *sensor, float value) {
     return;
 
   sensor->publish_state(value);
+}
+
+void JkBms::publish_state_(switch_::Switch *obj, const bool &state) {
+  if (obj == nullptr)
+    return;
+
+  obj->publish_state(state);
 }
 
 void JkBms::publish_state_(text_sensor::TextSensor *text_sensor, const std::string &state) {

--- a/components/jk_bms/jk_bms.h
+++ b/components/jk_bms/jk_bms.h
@@ -4,6 +4,7 @@
 #include "esphome/components/binary_sensor/binary_sensor.h"
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/text_sensor/text_sensor.h"
+#include "esphome/components/switch/switch.h"
 #include "esphome/components/jk_modbus/jk_modbus.h"
 
 namespace esphome {
@@ -212,6 +213,10 @@ class JkBms : public PollingComponent, public jk_modbus::JkModbusDevice {
     protocol_version_sensor_ = protocol_version_sensor;
   }
 
+  void set_charging_switch(switch_::Switch *charging_switch) { charging_switch_ = charging_switch; }
+  void set_discharging_switch(switch_::Switch *discharging_switch) { discharging_switch_ = discharging_switch; }
+  void set_balancer_switch(switch_::Switch *balancer_switch) { balancer_switch_ = balancer_switch; }
+
   void set_errors_text_sensor(text_sensor::TextSensor *errors_text_sensor) { errors_text_sensor_ = errors_text_sensor; }
   void set_operation_mode_text_sensor(text_sensor::TextSensor *operation_mode_text_sensor) {
     operation_mode_text_sensor_ = operation_mode_text_sensor;
@@ -244,6 +249,15 @@ class JkBms : public PollingComponent, public jk_modbus::JkModbusDevice {
   void update() override;
 
  protected:
+  binary_sensor::BinarySensor *balancing_binary_sensor_;
+  binary_sensor::BinarySensor *balancing_switch_binary_sensor_;
+  binary_sensor::BinarySensor *charging_binary_sensor_;
+  binary_sensor::BinarySensor *charging_switch_binary_sensor_;
+  binary_sensor::BinarySensor *discharging_binary_sensor_;
+  binary_sensor::BinarySensor *discharging_switch_binary_sensor_;
+  binary_sensor::BinarySensor *dedicated_charger_switch_binary_sensor_;
+  binary_sensor::BinarySensor *online_status_binary_sensor_;
+
   sensor::Sensor *min_cell_voltage_sensor_;
   sensor::Sensor *max_cell_voltage_sensor_;
   sensor::Sensor *min_voltage_cell_sensor_;
@@ -306,14 +320,9 @@ class JkBms : public PollingComponent, public jk_modbus::JkModbusDevice {
   sensor::Sensor *actual_battery_capacity_sensor_;
   sensor::Sensor *protocol_version_sensor_;
 
-  binary_sensor::BinarySensor *balancing_binary_sensor_;
-  binary_sensor::BinarySensor *balancing_switch_binary_sensor_;
-  binary_sensor::BinarySensor *charging_binary_sensor_;
-  binary_sensor::BinarySensor *charging_switch_binary_sensor_;
-  binary_sensor::BinarySensor *discharging_binary_sensor_;
-  binary_sensor::BinarySensor *discharging_switch_binary_sensor_;
-  binary_sensor::BinarySensor *dedicated_charger_switch_binary_sensor_;
-  binary_sensor::BinarySensor *online_status_binary_sensor_;
+  switch_::Switch *charging_switch_;
+  switch_::Switch *discharging_switch_;
+  switch_::Switch *balancer_switch_;
 
   text_sensor::TextSensor *errors_text_sensor_;
   text_sensor::TextSensor *operation_mode_text_sensor_;
@@ -334,6 +343,7 @@ class JkBms : public PollingComponent, public jk_modbus::JkModbusDevice {
   void on_status_data_(const std::vector<uint8_t> &data);
   void publish_state_(binary_sensor::BinarySensor *binary_sensor, const bool &state);
   void publish_state_(sensor::Sensor *sensor, float value);
+  void publish_state_(switch_::Switch *obj, const bool &state);
   void publish_state_(text_sensor::TextSensor *text_sensor, const std::string &state);
   void publish_device_unavailable_();
   void reset_online_status_tracker_();

--- a/components/jk_bms/sensor.py
+++ b/components/jk_bms/sensor.py
@@ -22,7 +22,7 @@ from esphome.const import (
     UNIT_WATT,
 )
 
-from . import CONF_JK_BMS_ID, JkBms
+from . import CONF_JK_BMS_ID, JK_BMS_COMPONENT_SCHEMA
 
 DEPENDENCIES = ["jk_bms"]
 
@@ -239,9 +239,8 @@ SENSORS = [
 ]
 
 # pylint: disable=too-many-function-args
-CONFIG_SCHEMA = cv.Schema(
+CONFIG_SCHEMA = JK_BMS_COMPONENT_SCHEMA.extend(
     {
-        cv.GenerateID(CONF_JK_BMS_ID): cv.use_id(JkBms),
         cv.Optional(CONF_MIN_CELL_VOLTAGE): sensor.sensor_schema(
             unit_of_measurement=UNIT_VOLT,
             icon=ICON_EMPTY,

--- a/components/jk_bms/switch/__init__.py
+++ b/components/jk_bms/switch/__init__.py
@@ -1,0 +1,60 @@
+import esphome.codegen as cg
+from esphome.components import switch
+import esphome.config_validation as cv
+from esphome.const import CONF_ICON, CONF_ID
+
+from .. import CONF_JK_BMS_ID, JK_BMS_COMPONENT_SCHEMA, jk_bms_ns
+from ..const import CONF_BALANCER, CONF_CHARGING, CONF_DISCHARGING
+
+DEPENDENCIES = ["jk_bms"]
+
+CODEOWNERS = ["@syssi"]
+
+ICON_CHARGING = "mdi:battery-charging-50"
+ICON_DISCHARGING = "mdi:battery-charging-50"
+ICON_BALANCER = "mdi:seesaw"
+
+SWITCHES = {
+    CONF_CHARGING: 0xAB,
+    CONF_DISCHARGING: 0xAC,
+    # The BMS (v11) doesn't accept updates of register 0x9D at the moment
+    CONF_BALANCER: 0x9D,
+}
+
+JkSwitch = jk_bms_ns.class_("JkSwitch", switch.Switch, cg.Component)
+
+CONFIG_SCHEMA = JK_BMS_COMPONENT_SCHEMA.extend(
+    {
+        cv.Optional(CONF_CHARGING): switch.SWITCH_SCHEMA.extend(
+            {
+                cv.GenerateID(): cv.declare_id(JkSwitch),
+                cv.Optional(CONF_ICON, default=ICON_CHARGING): cv.icon,
+            }
+        ).extend(cv.COMPONENT_SCHEMA),
+        cv.Optional(CONF_DISCHARGING): switch.SWITCH_SCHEMA.extend(
+            {
+                cv.GenerateID(): cv.declare_id(JkSwitch),
+                cv.Optional(CONF_ICON, default=ICON_DISCHARGING): cv.icon,
+            }
+        ).extend(cv.COMPONENT_SCHEMA),
+        # cv.Optional(CONF_BALANCER): switch.SWITCH_SCHEMA.extend(
+        #     {
+        #         cv.GenerateID(): cv.declare_id(JkSwitch),
+        #         cv.Optional(CONF_ICON, default=ICON_BALANCER): cv.icon,
+        #     }
+        # ).extend(cv.COMPONENT_SCHEMA),
+    }
+)
+
+
+async def to_code(config):
+    hub = await cg.get_variable(config[CONF_JK_BMS_ID])
+    for key, address in SWITCHES.items():
+        if key in config:
+            conf = config[key]
+            var = cg.new_Pvariable(conf[CONF_ID])
+            await cg.register_component(var, conf)
+            await switch.register_switch(var, conf)
+            cg.add(getattr(hub, f"set_{key}_switch")(var))
+            cg.add(var.set_parent(hub))
+            cg.add(var.set_holding_register(address))

--- a/components/jk_bms/switch/jk_switch.cpp
+++ b/components/jk_bms/switch/jk_switch.cpp
@@ -1,0 +1,17 @@
+#include "jk_switch.h"
+#include "esphome/core/log.h"
+#include "esphome/core/application.h"
+
+namespace esphome {
+namespace jk_bms {
+
+static const char *const TAG = "jk_bms.switch";
+
+void JkSwitch::dump_config() { LOG_SWITCH("", "JkBms Switch", this); }
+void JkSwitch::write_state(bool state) {
+  this->parent_->write_register(this->holding_register_, (uint8_t) state);
+  this->publish_state(state);
+}
+
+}  // namespace jk_bms
+}  // namespace esphome

--- a/components/jk_bms/switch/jk_switch.h
+++ b/components/jk_bms/switch/jk_switch.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "../jk_bms.h"
+#include "esphome/core/component.h"
+#include "esphome/components/switch/switch.h"
+
+namespace esphome {
+namespace jk_bms {
+
+class JkBms;
+class JkSwitch : public switch_::Switch, public Component {
+ public:
+  void set_parent(JkBms *parent) { this->parent_ = parent; };
+  void set_holding_register(uint8_t holding_register) { this->holding_register_ = holding_register; };
+  void dump_config() override;
+  void loop() override {}
+  float get_setup_priority() const override { return setup_priority::DATA; }
+
+ protected:
+  void write_state(bool state) override;
+  JkBms *parent_;
+  uint8_t holding_register_;
+};
+
+}  // namespace jk_bms
+}  // namespace esphome

--- a/components/jk_bms/text_sensor.py
+++ b/components/jk_bms/text_sensor.py
@@ -3,7 +3,7 @@ from esphome.components import text_sensor
 import esphome.config_validation as cv
 from esphome.const import CONF_ICON, CONF_ID, CONF_PASSWORD, ICON_EMPTY, ICON_TIMELAPSE
 
-from . import CONF_JK_BMS_ID, JkBms
+from . import CONF_JK_BMS_ID, JK_BMS_COMPONENT_SCHEMA
 
 DEPENDENCIES = ["jk_bms"]
 
@@ -33,9 +33,8 @@ TEXT_SENSORS = [
     CONF_TOTAL_RUNTIME_FORMATTED,
 ]
 
-CONFIG_SCHEMA = cv.Schema(
+CONFIG_SCHEMA = JK_BMS_COMPONENT_SCHEMA.extend(
     {
-        cv.GenerateID(CONF_JK_BMS_ID): cv.use_id(JkBms),
         cv.Optional(CONF_OPERATION_MODE): text_sensor.TEXT_SENSOR_SCHEMA.extend(
             {
                 cv.GenerateID(): cv.declare_id(text_sensor.TextSensor),

--- a/components/jk_bms_ble/binary_sensor.py
+++ b/components/jk_bms_ble/binary_sensor.py
@@ -4,13 +4,12 @@ import esphome.config_validation as cv
 from esphome.const import CONF_ID, DEVICE_CLASS_CONNECTIVITY, ENTITY_CATEGORY_DIAGNOSTIC
 
 from . import CONF_JK_BMS_BLE_ID, JkBmsBle
+from .const import CONF_CHARGING, CONF_DISCHARGING
 
 DEPENDENCIES = ["jk_bms_ble"]
 
 CODEOWNERS = ["@syssi"]
 
-CONF_CHARGING = "charging"
-CONF_DISCHARGING = "discharging"
 CONF_BALANCING = "balancing"
 CONF_ONLINE_STATUS = "online_status"
 

--- a/components/jk_bms_ble/const.py
+++ b/components/jk_bms_ble/const.py
@@ -1,0 +1,5 @@
+"""Constants for the jk bms ble component."""
+
+CONF_BALANCER = "balancer"
+CONF_CHARGING = "charging"
+CONF_DISCHARGING = "discharging"

--- a/components/jk_bms_ble/switch/__init__.py
+++ b/components/jk_bms_ble/switch/__init__.py
@@ -4,14 +4,12 @@ import esphome.config_validation as cv
 from esphome.const import CONF_ICON, CONF_ID
 
 from .. import CONF_JK_BMS_BLE_ID, JK_BMS_BLE_COMPONENT_SCHEMA, jk_bms_ble_ns
+from ..const import CONF_BALANCER, CONF_CHARGING, CONF_DISCHARGING
 
 DEPENDENCIES = ["jk_bms_ble"]
 
 CODEOWNERS = ["@syssi"]
 
-CONF_CHARGING = "charging"
-CONF_DISCHARGING = "discharging"
-CONF_BALANCER = "balancer"
 CONF_EMERGENCY = "emergency"
 CONF_DISABLE_TEMPERATURE_SENSORS = "disable_temperature_sensors"
 CONF_DISPLAY_ALWAYS_ON = "display_always_on"

--- a/components/jk_modbus/jk_modbus.cpp
+++ b/components/jk_modbus/jk_modbus.cpp
@@ -1,11 +1,21 @@
 #include "jk_modbus.h"
 #include "esphome/core/log.h"
+#include "esphome/core/hal.h"
 #include "esphome/core/helpers.h"
 
 namespace esphome {
 namespace jk_modbus {
 
 static const char *const TAG = "jk_modbus";
+
+static const uint8_t FUNCTION_WRITE_REGISTER = 0x02;
+static const uint8_t FUNCTION_READ_REGISTER = 0x03;
+static const uint8_t FUNCTION_PASSWORD = 0x05;
+static const uint8_t FUNCTION_READ_ALL_REGISTERS = 0x06;
+
+static const uint8_t ADDRESS_READ_ALL = 0x00;
+
+static const uint8_t FRAME_SOURCE_GPS = 0x02;
 
 void JkModbus::loop() {
   const uint32_t now = millis();
@@ -108,7 +118,6 @@ float JkModbus::get_setup_priority() const {
   return setup_priority::BUS - 1.0f;
 }
 
-// The manufacturer states that no write operations are possible via the serial interface.
 void JkModbus::send(uint8_t function, uint8_t address, uint8_t value) {
   uint8_t frame[22];
   frame[0] = 0x4E;      // start sequence
@@ -120,16 +129,16 @@ void JkModbus::send(uint8_t function, uint8_t address, uint8_t value) {
   frame[6] = 0x00;      // bms terminal number
   frame[7] = 0x00;      // bms terminal number
   frame[8] = function;  // command word: 0x01 (activation), 0x02 (write), 0x03 (read), 0x05 (password), 0x06 (read all)
-  frame[9] = 0x02;      // frame source: 0x00 (bms), 0x01 (bluetooth), 0x02 (gps), 0x03 (computer)
-  frame[10] = 0x02;     // frame type: 0x00 (read data), 0x01 (reply frame), 0x02 (BMS active upload)
-  frame[11] = address;  // register: 0x00 (read all registers), 0x8E...0xBF (holding registers)
-  frame[12] = value;    // data
-  frame[13] = 0x00;     // record number
-  frame[14] = 0x00;     // record number
-  frame[15] = 0x00;     // record number
-  frame[16] = 0x00;     // record number
-  frame[17] = 0x68;     // end sequence
-  auto crc = chksum(frame, 17);
+  frame[9] = FRAME_SOURCE_GPS;  // frame source: 0x00 (bms), 0x01 (bluetooth), 0x02 (gps), 0x03 (computer)
+  frame[10] = 0x00;             // frame type: 0x00 (read data), 0x01 (reply frame), 0x02 (BMS active upload)
+  frame[11] = address;          // register: 0x00 (read all registers), 0x8E...0xBF (holding registers)
+  frame[12] = value;            // data
+  frame[13] = 0x00;             // record number
+  frame[14] = 0x00;             // record number
+  frame[15] = 0x00;             // record number
+  frame[16] = 0x00;             // record number
+  frame[17] = 0x68;             // end sequence
+  auto crc = chksum(frame, 18);
   frame[18] = 0x00;  // crc unused
   frame[19] = 0x00;  // crc unused
   frame[20] = crc >> 8;
@@ -139,25 +148,34 @@ void JkModbus::send(uint8_t function, uint8_t address, uint8_t value) {
   this->flush();
 }
 
-void JkModbus::read_registers(uint8_t function, uint8_t address) {
+void JkModbus::authenticate_() { this->send(FUNCTION_PASSWORD, 0x00, 0x00); }
+
+void JkModbus::write_register(uint8_t address, uint8_t value) {
+  this->authenticate_();
+  delay(100);  // NOLINT
+  this->send(FUNCTION_WRITE_REGISTER, address, value);
+}
+
+void JkModbus::read_registers() {
   uint8_t frame[21];
-  frame[0] = 0x4E;      // start sequence
-  frame[1] = 0x57;      // start sequence
-  frame[2] = 0x00;      // data length lb
-  frame[3] = 0x13;      // data length hb
-  frame[4] = 0x00;      // bms terminal number
-  frame[5] = 0x00;      // bms terminal number
-  frame[6] = 0x00;      // bms terminal number
-  frame[7] = 0x00;      // bms terminal number
-  frame[8] = function;  // command word: 0x01 (activation), 0x02 (write), 0x03 (read), 0x05 (password), 0x06 (read all)
-  frame[9] = 0x03;      // frame source: 0x00 (bms), 0x01 (bluetooth), 0x02 (gps), 0x03 (computer)
-  frame[10] = 0x00;     // frame type: 0x00 (read data), 0x01 (reply frame), 0x02 (BMS active upload)
-  frame[11] = address;  // register: 0x00 (read all registers), 0x8E...0xBF (holding registers)
-  frame[12] = 0x00;     // record number
-  frame[13] = 0x00;     // record number
-  frame[14] = 0x00;     // record number
-  frame[15] = 0x00;     // record number
-  frame[16] = 0x68;     // end sequence
+  frame[0] = 0x4E;                         // start sequence
+  frame[1] = 0x57;                         // start sequence
+  frame[2] = 0x00;                         // data length lb
+  frame[3] = 0x13;                         // data length hb
+  frame[4] = 0x00;                         // bms terminal number
+  frame[5] = 0x00;                         // bms terminal number
+  frame[6] = 0x00;                         // bms terminal number
+  frame[7] = 0x00;                         // bms terminal number
+  frame[8] = FUNCTION_READ_ALL_REGISTERS;  // command word: 0x01 (activation), 0x02 (write), 0x03 (read), 0x05
+                                           // (password), 0x06 (read all)
+  frame[9] = FRAME_SOURCE_GPS;             // frame source: 0x00 (bms), 0x01 (bluetooth), 0x02 (gps), 0x03 (computer)
+  frame[10] = 0x00;                        // frame type: 0x00 (read data), 0x01 (reply frame), 0x02 (BMS active upload)
+  frame[11] = ADDRESS_READ_ALL;            // register: 0x00 (read all registers), 0x8E...0xBF (holding registers)
+  frame[12] = 0x00;                        // record number
+  frame[13] = 0x00;                        // record number
+  frame[14] = 0x00;                        // record number
+  frame[15] = 0x00;                        // record number
+  frame[16] = 0x68;                        // end sequence
   auto crc = chksum(frame, 17);
   frame[17] = 0x00;  // crc unused
   frame[18] = 0x00;  // crc unused

--- a/components/jk_modbus/jk_modbus.cpp
+++ b/components/jk_modbus/jk_modbus.cpp
@@ -152,7 +152,7 @@ void JkModbus::authenticate_() { this->send(FUNCTION_PASSWORD, 0x00, 0x00); }
 
 void JkModbus::write_register(uint8_t address, uint8_t value) {
   this->authenticate_();
-  delay(100);  // NOLINT
+  delay(200);  // NOLINT
   this->send(FUNCTION_WRITE_REGISTER, address, value);
 }
 

--- a/components/jk_modbus/jk_modbus.cpp
+++ b/components/jk_modbus/jk_modbus.cpp
@@ -152,7 +152,7 @@ void JkModbus::authenticate_() { this->send(FUNCTION_PASSWORD, 0x00, 0x00); }
 
 void JkModbus::write_register(uint8_t address, uint8_t value) {
   this->authenticate_();
-  delay(200);  // NOLINT
+  delay(150);  // NOLINT
   this->send(FUNCTION_WRITE_REGISTER, address, value);
 }
 

--- a/components/jk_modbus/jk_modbus.h
+++ b/components/jk_modbus/jk_modbus.h
@@ -21,10 +21,12 @@ class JkModbus : public uart::UARTDevice, public Component {
   float get_setup_priority() const override;
 
   void send(uint8_t function, uint8_t address, uint8_t value);
-  void read_registers(uint8_t function, uint8_t address);
+  void write_register(uint8_t address, uint8_t value);
+  void read_registers();
   void set_rx_timeout(uint16_t rx_timeout) { rx_timeout_ = rx_timeout; }
 
  protected:
+  void authenticate_();
   bool parse_jk_modbus_byte_(uint8_t byte);
 
   std::vector<uint8_t> rx_buffer_;
@@ -40,7 +42,8 @@ class JkModbusDevice {
   virtual void on_jk_modbus_data(const uint8_t &function, const std::vector<uint8_t> &data) = 0;
 
   void send(int8_t function, uint8_t address, uint8_t value) { this->parent_->send(function, address, value); }
-  void read_registers(uint8_t function, uint8_t address) { this->parent_->read_registers(function, address); }
+  void write_register(uint8_t address, uint8_t value) { this->parent_->write_register(address, value); }
+  void read_registers() { this->parent_->read_registers(); }
 
  protected:
   friend JkModbus;

--- a/esp32-ble-uart-hybrid-example.yaml
+++ b/esp32-ble-uart-hybrid-example.yaml
@@ -99,12 +99,8 @@ binary_sensor:
       name: "${name} balancing switch"
     charging:
       name: "${name} charging"
-    charging_switch:
-      name: "${name} charging switch"
     discharging:
       name: "${name} discharging"
-    discharging_switch:
-      name: "${name} discharging switch"
     dedicated_charger_switch:
       name: "${name} dedicated charger switch"
 

--- a/esp32-example-multiple-devices.yaml
+++ b/esp32-example-multiple-devices.yaml
@@ -128,6 +128,21 @@ sensor:
       name: "${bms1} power"
     # ...
 
+switch:
+  - platform: jk_bms
+    jk_bms_id: bms0
+    charging:
+      name: "${bms0} charging"
+    discharging:
+      name: "${bms0} discharging"
+
+  - platform: jk_bms
+    jk_bms_id: bms1
+    charging:
+      name: "${bms1} charging"
+    discharging:
+      name: "${bms1} discharging"
+
 text_sensor:
   - platform: jk_bms
     jk_bms_id: bms0

--- a/esp32-example.yaml
+++ b/esp32-example.yaml
@@ -65,12 +65,8 @@ binary_sensor:
       name: "${name} balancing switch"
     charging:
       name: "${name} charging"
-    charging_switch:
-      name: "${name} charging switch"
     discharging:
       name: "${name} discharging"
-    discharging_switch:
-      name: "${name} discharging switch"
     dedicated_charger_switch:
       name: "${name} dedicated charger switch"
     online_status:
@@ -242,6 +238,13 @@ sensor:
       name: "${name} actual battery capacity"
 #    protocol_version:
 #      name: "${name} protocol version"
+
+switch:
+  - platform: jk_bms
+    charging:
+      name: "${name} charging"
+    discharging:
+      name: "${name} discharging"
 
 text_sensor:
   - platform: jk_bms

--- a/esp8266-example.yaml
+++ b/esp8266-example.yaml
@@ -64,12 +64,8 @@ binary_sensor:
       name: "${name} balancing switch"
     charging:
       name: "${name} charging"
-    charging_switch:
-      name: "${name} charging switch"
     discharging:
       name: "${name} discharging"
-    discharging_switch:
-      name: "${name} discharging switch"
     dedicated_charger_switch:
       name: "${name} dedicated charger switch"
     online_status:
@@ -241,6 +237,13 @@ sensor:
       name: "${name} actual battery capacity"
 #    protocol_version:
 #      name: "${name} protocol version"
+
+switch:
+  - platform: jk_bms
+    charging:
+      name: "${name} charging"
+    discharging:
+      name: "${name} discharging"
 
 text_sensor:
   - platform: jk_bms


### PR DESCRIPTION
See #341

```
substitutions:
  external_components_source: github://syssi/esphome-jk-bms@add-controls

external_components:
  - source: ${external_components_source}
    refresh: 0s
```

- [x] Handle short response frames