### PR TITLE
Relax `max_discharge_current` validation (Closes: #381)

### DIFF
--- a/components/jk_bms_ble/number/__init__.py
+++ b/components/jk_bms_ble/number/__init__.py
@@ -260,7 +260,7 @@ CONFIG_SCHEMA = JK_BMS_BLE_COMPONENT_SCHEMA.extend(
         cv.Optional(CONF_MAX_DISCHARGE_CURRENT): JK_NUMBER_SCHEMA.extend(
             {
                 cv.Optional(CONF_MIN_VALUE, default=1.0): cv.float_,
-                cv.Optional(CONF_MAX_VALUE, default=200.0): cv.float_,
+                cv.Optional(CONF_MAX_VALUE, default=200.1): cv.float_,
                 cv.Optional(CONF_STEP, default=0.1): cv.float_,
                 cv.Optional(
                     CONF_UNIT_OF_MEASUREMENT, default=UNIT_AMPERE


### PR DESCRIPTION
See https://github.com/syssi/esphome-jk-bms/issues/190