### PR TITLE
Suspend BLE connection during OTA updates (Closes: #416)

### DIFF
--- a/esp32-ble-example-multiple-devices.yaml
+++ b/esp32-ble-example-multiple-devices.yaml
@@ -35,10 +35,9 @@ wifi:
 ota:
   on_begin:
     then:
-      - lambda: |-
-          id(bluetooth_client0_enabled_switch).turn_off();
-          id(bluetooth_client1_enabled_switch).turn_off();
-      - logger.log: "BLE shutdown for flashing"
+      - switch.turn_off: ble_client_switch0
+      - switch.turn_off: ble_client_switch1
+      - logger.log: "BLE connection suspended for OTA update"
 
 logger:
   level: DEBUG
@@ -195,11 +194,11 @@ switch:
 
   - platform: ble_client
     ble_client_id: client0
-    id: bluetooth_client0_enabled_switch
+    id: ble_client_switch0
     name: "${bms0} enable bluetooth connection"
   - platform: ble_client
     ble_client_id: client1
-    id: bluetooth_client1_enabled_switch
+    id: ble_client_switch1
     name: "${bms1} enable bluetooth connection"
 
 text_sensor:

--- a/esp32-ble-example-multiple-devices.yaml
+++ b/esp32-ble-example-multiple-devices.yaml
@@ -33,6 +33,12 @@ wifi:
   password: !secret wifi_password
 
 ota:
+  on_begin:
+    then:
+      - lambda: |-
+          id(bluetooth_client0_enabled_switch).turn_off();
+          id(bluetooth_client1_enabled_switch).turn_off();
+      - logger.log: "BLE shutdown for flashing"
 
 logger:
   level: DEBUG
@@ -189,9 +195,11 @@ switch:
 
   - platform: ble_client
     ble_client_id: client0
+    id: bluetooth_client0_enabled_switch
     name: "${bms0} enable bluetooth connection"
   - platform: ble_client
     ble_client_id: client1
+    id: bluetooth_client1_enabled_switch
     name: "${bms1} enable bluetooth connection"
 
 text_sensor:

--- a/esp32-ble-example.yaml
+++ b/esp32-ble-example.yaml
@@ -31,10 +31,9 @@ wifi:
 ota:
   on_begin:
     then:
-      - lambda: |-
-          id(bluetooth_enabled_switch).turn_off();
-      - logger.log: "BLE shutdown for flashing"
-      
+      - switch.turn_off: ble_client_switch0
+      - logger.log: "BLE connection suspended for OTA update"
+
 logger:
   level: DEBUG
 
@@ -276,7 +275,7 @@ switch:
 
   - platform: ble_client
     ble_client_id: client0
-    id: bluetooth_enabled_switch
+    id: ble_client_switch0
     name: "${name} enable bluetooth connection"
 
 text_sensor:

--- a/esp32-ble-example.yaml
+++ b/esp32-ble-example.yaml
@@ -29,7 +29,12 @@ wifi:
   password: !secret wifi_password
 
 ota:
-
+  on_begin:
+    then:
+      - lambda: |-
+          id(bluetooth_enabled_switch).turn_off();
+      - logger.log: "BLE shutdown for flashing"
+      
 logger:
   level: DEBUG
 
@@ -271,6 +276,7 @@ switch:
 
   - platform: ble_client
     ble_client_id: client0
+    id: bluetooth_enabled_switch
     name: "${name} enable bluetooth connection"
 
 text_sensor:

--- a/esp32-ble-jk04-example.yaml
+++ b/esp32-ble-jk04-example.yaml
@@ -29,7 +29,12 @@ wifi:
   password: !secret wifi_password
 
 ota:
-
+  on_begin:
+    then:
+      - lambda: |-
+          id(bluetooth_enabled_switch).turn_off();
+      - logger.log: "BLE shutdown for flashing"
+      
 logger:
   level: DEBUG
 
@@ -207,4 +212,5 @@ switch:
 
   - platform: ble_client
     ble_client_id: client0
+    id: bluetooth_enabled_switch
     name: "${name} enable bluetooth connection"

--- a/esp32-ble-jk04-example.yaml
+++ b/esp32-ble-jk04-example.yaml
@@ -31,10 +31,9 @@ wifi:
 ota:
   on_begin:
     then:
-      - lambda: |-
-          id(bluetooth_enabled_switch).turn_off();
-      - logger.log: "BLE shutdown for flashing"
-      
+      - switch.turn_off: ble_client_switch0
+      - logger.log: "BLE connection suspended for OTA update"
+
 logger:
   level: DEBUG
 
@@ -212,5 +211,5 @@ switch:
 
   - platform: ble_client
     ble_client_id: client0
-    id: bluetooth_enabled_switch
+    id: ble_client_switch0
     name: "${name} enable bluetooth connection"

--- a/esp32-ble-uart-hybrid-example.yaml
+++ b/esp32-ble-uart-hybrid-example.yaml
@@ -37,10 +37,9 @@ wifi:
 ota:
   on_begin:
     then:
-      - lambda: |-
-          id(bluetooth_enabled_switch).turn_off();
-      - logger.log: "BLE shutdown for flashing"
-      
+      - switch.turn_off: ble_client_switch0
+      - logger.log: "BLE connection suspended for OTA update"
+
 logger:
   level: DEBUG
 
@@ -215,7 +214,7 @@ switch:
 
   - platform: ble_client
     ble_client_id: client0
-    id: bluetooth_enabled_switch
+    id: ble_client_switch0
     name: "${name} enable bluetooth connection"
 
 text_sensor:

--- a/esp32-ble-uart-hybrid-example.yaml
+++ b/esp32-ble-uart-hybrid-example.yaml
@@ -35,7 +35,12 @@ wifi:
   password: !secret wifi_password
 
 ota:
-
+  on_begin:
+    then:
+      - lambda: |-
+          id(bluetooth_enabled_switch).turn_off();
+      - logger.log: "BLE shutdown for flashing"
+      
 logger:
   level: DEBUG
 
@@ -210,6 +215,7 @@ switch:
 
   - platform: ble_client
     ble_client_id: client0
+    id: bluetooth_enabled_switch
     name: "${name} enable bluetooth connection"
 
 text_sensor:

--- a/esp32-ble-v11-example.yaml
+++ b/esp32-ble-v11-example.yaml
@@ -31,9 +31,8 @@ wifi:
 ota:
   on_begin:
     then:
-      - lambda: |-
-          id(bluetooth_enabled_switch).turn_off();
-      - logger.log: "BLE shutdown for flashing"  
+      - switch.turn_off: ble_client_switch0
+      - logger.log: "BLE connection suspended for OTA update"
 
 logger:
   level: DEBUG
@@ -282,7 +281,7 @@ switch:
 
   - platform: ble_client
     ble_client_id: client0
-    id: bluetooth_enabled_switch
+    id: ble_client_switch0
     name: "${name} enable bluetooth connection"
 
 text_sensor:

--- a/esp32-ble-v11-example.yaml
+++ b/esp32-ble-v11-example.yaml
@@ -29,6 +29,11 @@ wifi:
   password: !secret wifi_password
 
 ota:
+  on_begin:
+    then:
+      - lambda: |-
+          id(bluetooth_enabled_switch).turn_off();
+      - logger.log: "BLE shutdown for flashing"  
 
 logger:
   level: DEBUG
@@ -277,6 +282,7 @@ switch:
 
   - platform: ble_client
     ble_client_id: client0
+    id: bluetooth_enabled_switch
     name: "${name} enable bluetooth connection"
 
 text_sensor:

--- a/esp32-heltec-balancer-ble-example.yaml
+++ b/esp32-heltec-balancer-ble-example.yaml
@@ -25,6 +25,10 @@ wifi:
   password: !secret wifi_password
 
 ota:
+  on_begin:
+    then:
+      - switch.turn_off: ble_client_switch0
+      - logger.log: "BLE connection suspended for OTA update"
 
 logger:
   level: DEBUG
@@ -231,6 +235,11 @@ switch:
   - platform: heltec_balancer_ble
     balancer:
       name: "${name} balancer"
+
+  - platform: ble_client
+    ble_client_id: client0
+    id: ble_client_switch0
+    name: "${name} enable bluetooth connection"
 
 text_sensor:
   - platform: heltec_balancer_ble

--- a/yaml-snippets/esp32-ble-block-traffic.yaml
+++ b/yaml-snippets/esp32-ble-block-traffic.yaml
@@ -20,6 +20,12 @@ wifi:
   password: !secret wifi_password
 
 ota:
+  on_begin:
+    then:
+      - lambda: |-
+          id(bluetooth_enabled_switch).turn_off();
+      - logger.log: "BLE shutdown for flashing"
+        
 logger:
 
 # If you don't use Home Assistant please remove this `api` section and uncomment the `mqtt` component!
@@ -43,4 +49,5 @@ ble_client:
 switch:
   - platform: ble_client
     ble_client_id: client0
+    id: bluetooth_enabled_switch
     name: "${name} enable bluetooth connection"

--- a/yaml-snippets/esp32-ble-block-traffic.yaml
+++ b/yaml-snippets/esp32-ble-block-traffic.yaml
@@ -22,10 +22,9 @@ wifi:
 ota:
   on_begin:
     then:
-      - lambda: |-
-          id(bluetooth_enabled_switch).turn_off();
-      - logger.log: "BLE shutdown for flashing"
-        
+      - switch.turn_off: ble_client_switch0
+      - logger.log: "BLE connection suspended for OTA update"
+
 logger:
 
 # If you don't use Home Assistant please remove this `api` section and uncomment the `mqtt` component!
@@ -49,5 +48,5 @@ ble_client:
 switch:
   - platform: ble_client
     ble_client_id: client0
-    id: bluetooth_enabled_switch
+    id: ble_client_switch0
     name: "${name} enable bluetooth connection"

--- a/yaml-snippets/esp32-ble-energy-dashboard.yaml
+++ b/yaml-snippets/esp32-ble-energy-dashboard.yaml
@@ -27,7 +27,12 @@ wifi:
   password: !secret wifi_password
 
 ota:
-
+  on_begin:
+    then:
+      - lambda: |-
+          id(bluetooth_enabled_switch).turn_off();
+      - logger.log: "BLE shutdown for flashing"
+      
 logger:
   level: DEBUG
 
@@ -94,4 +99,5 @@ sensor:
 switch:
   - platform: ble_client
     ble_client_id: client0
+    id: bluetooth_enabled_switch
     name: "${name} enable bluetooth connection"

--- a/yaml-snippets/esp32-ble-energy-dashboard.yaml
+++ b/yaml-snippets/esp32-ble-energy-dashboard.yaml
@@ -29,10 +29,9 @@ wifi:
 ota:
   on_begin:
     then:
-      - lambda: |-
-          id(bluetooth_enabled_switch).turn_off();
-      - logger.log: "BLE shutdown for flashing"
-      
+      - switch.turn_off: ble_client_switch0
+      - logger.log: "BLE connection suspended for OTA update"
+
 logger:
   level: DEBUG
 
@@ -99,5 +98,5 @@ sensor:
 switch:
   - platform: ble_client
     ble_client_id: client0
-    id: bluetooth_enabled_switch
+    id: ble_client_switch0
     name: "${name} enable bluetooth connection"


### PR DESCRIPTION
This is a workaround to allow OTA flashing by shutting down bluetooth

This is the workaround for issue https://github.com/syssi/esphome-jk-bms/issues/416