### PR TITLE
Add new temperature sensors and swap the order of the existing ones

### DIFF
--- a/components/jk_bms_ble/jk_bms_ble.cpp
+++ b/components/jk_bms_ble/jk_bms_ble.cpp
@@ -580,11 +580,11 @@ void JkBmsBle::decode_jk02_cell_info_(const std::vector<uint8_t> &data) {
   this->publish_state_(this->discharging_power_sensor_, std::abs(std::min(0.0f, power)));  // -500W vs 0W -> 500W
 
   // 130   2   0xBE 0x00              Temperature Sensor 1  0.1          °C
-  this->publish_state_(this->temperatures_[0].temperature_sensor_,
+  this->publish_state_(this->temperatures_[1].temperature_sensor_,
                        (float) ((int16_t) jk_get_16bit(130 + offset)) * 0.1f);
 
   // 132   2   0xBF 0x00              Temperature Sensor 2  0.1          °C
-  this->publish_state_(this->temperatures_[1].temperature_sensor_,
+  this->publish_state_(this->temperatures_[0].temperature_sensor_,
                        (float) ((int16_t) jk_get_16bit(132 + offset)) * 0.1f);
 
   // 134   2   0xD2 0x00              MOS Temperature       0.1          °C
@@ -701,9 +701,9 @@ void JkBmsBle::decode_jk02_cell_info_(const std::vector<uint8_t> &data) {
   //           0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00
   //           0x00
   if (frame_version == FRAME_VERSION_JK02_32S) {
-    this->publish_state_(this->temperatures_[2].temperature_sensor_,
-                         (float) ((int16_t) jk_get_16bit(224 + offset)) * 0.1f);
     this->publish_state_(this->temperatures_[3].temperature_sensor_,
+                         (float) ((int16_t) jk_get_16bit(224 + offset)) * 0.1f);
+    this->publish_state_(this->temperatures_[2].temperature_sensor_,
                          (float) ((int16_t) jk_get_16bit(226 + offset)) * 0.1f);
   }
 

--- a/components/jk_bms_ble/jk_bms_ble.cpp
+++ b/components/jk_bms_ble/jk_bms_ble.cpp
@@ -114,8 +114,10 @@ void JkBmsBle::dump_config() {  // NOLINT(google-readability-function-size,reada
   LOG_SENSOR("", "Charging Power", this->charging_power_sensor_);
   LOG_SENSOR("", "Discharging Power", this->discharging_power_sensor_);
   LOG_SENSOR("", "Power Tube Temperature", this->power_tube_temperature_sensor_);
-  LOG_SENSOR("", "Temperature Sensor 1", this->temperature_sensor_1_sensor_);
-  LOG_SENSOR("", "Temperature Sensor 2", this->temperature_sensor_2_sensor_);
+  LOG_SENSOR("", "Temperature Sensor 1", this->temperatures_[0].temperature_sensor_);
+  LOG_SENSOR("", "Temperature Sensor 2", this->temperatures_[1].temperature_sensor_);
+  LOG_SENSOR("", "Temperature Sensor 3", this->temperatures_[2].temperature_sensor_);
+  LOG_SENSOR("", "Temperature Sensor 4", this->temperatures_[3].temperature_sensor_);
   LOG_SENSOR("", "State Of Charge", this->state_of_charge_sensor_);
   LOG_SENSOR("", "Capacity Remaining", this->capacity_remaining_sensor_);
   LOG_SENSOR("", "Total Battery Capacity Setting", this->total_battery_capacity_setting_sensor_);
@@ -578,10 +580,12 @@ void JkBmsBle::decode_jk02_cell_info_(const std::vector<uint8_t> &data) {
   this->publish_state_(this->discharging_power_sensor_, std::abs(std::min(0.0f, power)));  // -500W vs 0W -> 500W
 
   // 130   2   0xBE 0x00              Temperature Sensor 1  0.1          °C
-  this->publish_state_(this->temperature_sensor_1_sensor_, (float) ((int16_t) jk_get_16bit(130 + offset)) * 0.1f);
+  this->publish_state_(this->temperatures_[0].temperature_sensor_,
+                       (float) ((int16_t) jk_get_16bit(130 + offset)) * 0.1f);
 
   // 132   2   0xBF 0x00              Temperature Sensor 2  0.1          °C
-  this->publish_state_(this->temperature_sensor_2_sensor_, (float) ((int16_t) jk_get_16bit(132 + offset)) * 0.1f);
+  this->publish_state_(this->temperatures_[1].temperature_sensor_,
+                       (float) ((int16_t) jk_get_16bit(132 + offset)) * 0.1f);
 
   // 134   2   0xD2 0x00              MOS Temperature       0.1          °C
   if (frame_version == FRAME_VERSION_JK02_32S) {
@@ -696,6 +700,13 @@ void JkBmsBle::decode_jk02_cell_info_(const std::vector<uint8_t> &data) {
   //           0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00
   //           0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00
   //           0x00
+  if (frame_version == FRAME_VERSION_JK02_32S) {
+    this->publish_state_(this->temperatures_[2].temperature_sensor_,
+                         (float) ((int16_t) jk_get_16bit(224 + offset)) * 0.1f);
+    this->publish_state_(this->temperatures_[3].temperature_sensor_,
+                         (float) ((int16_t) jk_get_16bit(226 + offset)) * 0.1f);
+  }
+
   // 299   1   0xCD                   CRC
 
   this->status_notification_received_ = true;
@@ -1286,8 +1297,6 @@ void JkBmsBle::publish_device_unavailable_() {
   this->publish_state_(power_sensor_, NAN);
   this->publish_state_(charging_power_sensor_, NAN);
   this->publish_state_(discharging_power_sensor_, NAN);
-  this->publish_state_(temperature_sensor_1_sensor_, NAN);
-  this->publish_state_(temperature_sensor_2_sensor_, NAN);
   this->publish_state_(power_tube_temperature_sensor_, NAN);
   this->publish_state_(state_of_charge_sensor_, NAN);
   this->publish_state_(capacity_remaining_sensor_, NAN);
@@ -1301,6 +1310,9 @@ void JkBmsBle::publish_device_unavailable_() {
   for (auto &cell : this->cells_) {
     this->publish_state_(cell.cell_voltage_sensor_, NAN);
     this->publish_state_(cell.cell_resistance_sensor_, NAN);
+  }
+  for (auto &temperature : this->temperatures_) {
+    this->publish_state_(temperature.temperature_sensor_, NAN);
   }
 }
 

--- a/components/jk_bms_ble/jk_bms_ble.h
+++ b/components/jk_bms_ble/jk_bms_ble.h
@@ -121,11 +121,8 @@ class JkBmsBle : public esphome::ble_client::BLEClientNode, public PollingCompon
   void set_discharging_power_sensor(sensor::Sensor *discharging_power_sensor) {
     discharging_power_sensor_ = discharging_power_sensor;
   }
-  void set_temperature_sensor_1_sensor(sensor::Sensor *temperature_sensor_1_sensor) {
-    temperature_sensor_1_sensor_ = temperature_sensor_1_sensor;
-  }
-  void set_temperature_sensor_2_sensor(sensor::Sensor *temperature_sensor_2_sensor) {
-    temperature_sensor_2_sensor_ = temperature_sensor_2_sensor;
+  void set_temperature_sensor(uint8_t temperature, sensor::Sensor *temperature_sensor) {
+    this->temperatures_[temperature].temperature_sensor_ = temperature_sensor;
   }
   void set_power_tube_temperature_sensor(sensor::Sensor *power_tube_temperature_sensor) {
     power_tube_temperature_sensor_ = power_tube_temperature_sensor;
@@ -181,6 +178,9 @@ class JkBmsBle : public esphome::ble_client::BLEClientNode, public PollingCompon
     sensor::Sensor *cell_voltage_sensor_{nullptr};
     sensor::Sensor *cell_resistance_sensor_{nullptr};
   } cells_[32];
+  struct Temperature {
+    sensor::Sensor *temperature_sensor_{nullptr};
+  } temperatures_[4];
 
  protected:
   ProtocolVersion protocol_version_{PROTOCOL_VERSION_JK02};
@@ -216,8 +216,6 @@ class JkBmsBle : public esphome::ble_client::BLEClientNode, public PollingCompon
   sensor::Sensor *power_sensor_;
   sensor::Sensor *charging_power_sensor_;
   sensor::Sensor *discharging_power_sensor_;
-  sensor::Sensor *temperature_sensor_1_sensor_;
-  sensor::Sensor *temperature_sensor_2_sensor_;
   sensor::Sensor *power_tube_temperature_sensor_;
   sensor::Sensor *state_of_charge_sensor_;
   sensor::Sensor *capacity_remaining_sensor_;

--- a/components/jk_bms_ble/sensor.py
+++ b/components/jk_bms_ble/sensor.py
@@ -89,6 +89,8 @@ CONF_CHARGING_POWER = "charging_power"
 CONF_DISCHARGING_POWER = "discharging_power"
 CONF_TEMPERATURE_SENSOR_1 = "temperature_sensor_1"
 CONF_TEMPERATURE_SENSOR_2 = "temperature_sensor_2"
+CONF_TEMPERATURE_SENSOR_3 = "temperature_sensor_3"
+CONF_TEMPERATURE_SENSOR_4 = "temperature_sensor_4"
 CONF_POWER_TUBE_TEMPERATURE = "power_tube_temperature"
 CONF_STATE_OF_CHARGE = "state_of_charge"
 CONF_CAPACITY_REMAINING = "capacity_remaining"
@@ -166,6 +168,13 @@ CELL_RESISTANCES = [
     CONF_CELL_RESISTANCE_24,
 ]
 
+TEMPERATURES = [
+    CONF_TEMPERATURE_SENSOR_1,
+    CONF_TEMPERATURE_SENSOR_2,
+    CONF_TEMPERATURE_SENSOR_3,
+    CONF_TEMPERATURE_SENSOR_4,
+]
+
 SENSORS = [
     CONF_MIN_CELL_VOLTAGE,
     CONF_MAX_CELL_VOLTAGE,
@@ -178,8 +187,6 @@ SENSORS = [
     CONF_POWER,
     CONF_CHARGING_POWER,
     CONF_DISCHARGING_POWER,
-    CONF_TEMPERATURE_SENSOR_1,
-    CONF_TEMPERATURE_SENSOR_2,
     CONF_POWER_TUBE_TEMPERATURE,
     CONF_STATE_OF_CHARGE,
     CONF_CAPACITY_REMAINING,
@@ -622,6 +629,20 @@ CONFIG_SCHEMA = cv.Schema(
             device_class=DEVICE_CLASS_TEMPERATURE,
             state_class=STATE_CLASS_MEASUREMENT,
         ),
+        cv.Optional(CONF_TEMPERATURE_SENSOR_3): sensor.sensor_schema(
+            unit_of_measurement=UNIT_CELSIUS,
+            icon=ICON_EMPTY,
+            accuracy_decimals=1,
+            device_class=DEVICE_CLASS_TEMPERATURE,
+            state_class=STATE_CLASS_MEASUREMENT,
+        ),
+        cv.Optional(CONF_TEMPERATURE_SENSOR_4): sensor.sensor_schema(
+            unit_of_measurement=UNIT_CELSIUS,
+            icon=ICON_EMPTY,
+            accuracy_decimals=1,
+            device_class=DEVICE_CLASS_TEMPERATURE,
+            state_class=STATE_CLASS_MEASUREMENT,
+        ),
         cv.Optional(CONF_POWER_TUBE_TEMPERATURE): sensor.sensor_schema(
             unit_of_measurement=UNIT_CELSIUS,
             icon=ICON_EMPTY,
@@ -700,6 +721,11 @@ async def to_code(config):
             conf = config[key]
             sens = await sensor.new_sensor(conf)
             cg.add(hub.set_cell_resistance_sensor(i, sens))
+    for i, key in enumerate(TEMPERATURES):
+        if key in config:
+            conf = config[key]
+            sens = await sensor.new_sensor(conf)
+            cg.add(hub.set_temperature_sensor(i, sens))
     for key in SENSORS:
         if key in config:
             conf = config[key]

--- a/esp32-ble-example.yaml
+++ b/esp32-ble-example.yaml
@@ -241,6 +241,10 @@ sensor:
       name: "${name} temperature sensor 1"
     temperature_sensor_2:
       name: "${name} temperature sensor 2"
+    # temperature_sensor_3:
+    #   name: "${name} temperature sensor 3"
+    # temperature_sensor_4:
+    #   name: "${name} temperature sensor 4"
     power_tube_temperature:
       name: "${name} power tube temperature"
     state_of_charge:

--- a/esp32-ble-v11-example.yaml
+++ b/esp32-ble-v11-example.yaml
@@ -241,6 +241,10 @@ sensor:
       name: "${name} temperature sensor 1"
     temperature_sensor_2:
       name: "${name} temperature sensor 2"
+    temperature_sensor_3:
+      name: "${name} temperature sensor 3"
+    temperature_sensor_4:
+      name: "${name} temperature sensor 4"
     power_tube_temperature:
       name: "${name} power tube temperature"
     state_of_charge:


### PR DESCRIPTION
See #390

Can be tested using:

```
substitutions:
  external_components_source: github://syssi/esphome-jk-bms@add-new-temperature-sensors
```

\+ extend the YAML configuration by the new sensors:

```
    temperature_sensor_3:
      name: "${name} temperature sensor 3"
    temperature_sensor_4:
      name: "${name} temperature sensor 4"
```