### PR TITLE
Add JK-B2A20S20P, hw 10.XW, sw 10.10 as supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ All JK-BMS models with software version `>=6.0` are using the implemented protoc
 * JK-B2A8S20P, hw 11.XW, sw 11.17, using `JK02_32S` (reported by [@senfkorn](https://github.com/syssi/esphome-jk-bms/issues/147))
 * JK-B2A8S20P, hw 11.XW, sw 11.26, using `JK02_32S` (reported by [@riker65](https://github.com/syssi/esphome-jk-bms/issues/276))
 * JK-B2A20S20P, hw 10.XW, sw 10.09 (reported by [@markusgg84](https://github.com/syssi/esphome-jk-bms/discussions/173))
+* JK-B2A20S20P, hw 10.XW, sw 10.10, using `JK02_24S` (reported by [@cygeus](https://github.com/syssi/esphome-jk-bms/issues/455))
 * JK-B2A20S20P, hw 10.XW, sw 11.21h, using `JK02_32S` (reported by [@Salve87](https://github.com/syssi/esphome-jk-bms/issues/308#issuecomment-1505614325))
 * JK-B2A20S20P, hw 11.XW, sw 11.24H, using `JK02_32S` (reported by [@austin202220](https://github.com/syssi/esphome-jk-bms/discussions/232))
 * JK-B2A20S20P, hw 11.XW, sw 11.25H, using `JK02_32S` (reported by [@iovcharyk](https://github.com/syssi/esphome-jk-bms/issues/249))


### PR DESCRIPTION
Marking JK-B2A20S20P, hw 10.XW, sw 10.10 as supported.
This closes #455.