### PR TITLE
fix heating frame position

### DIFF
--- a/components/jk_bms_ble/jk_bms_ble.cpp
+++ b/components/jk_bms_ble/jk_bms_ble.cpp
@@ -559,11 +559,11 @@ void JkBmsBle::decode_jk02_cell_info_(const std::vector<uint8_t> &data) {
   //           0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00
   //           0x00
 
-  // 224   1   0x01                   Heating status          0x00: off, 0x01: on
-  this->publish_state_(this->heating_binary_sensor_, (bool) data[224 + offset]);
+  // 192   1   0x01                   Heating status          0x00: off, 0x01: on
+  this->publish_state_(this->heating_binary_sensor_, (bool) data[192 + offset]);
 
-  // 236   2   0x01 0xFD              Heating current         0.001         A
-  this->publish_state_(this->heating_current_sensor_, (float) ((int16_t) jk_get_16bit(236 + offset)) * 0.001f);
+  // 204   2   0x01 0xFD              Heating current         0.001         A
+  this->publish_state_(this->heating_current_sensor_, (float) ((int16_t) jk_get_16bit(204 + offset)) * 0.001f);
 
   if (frame_version == FRAME_VERSION_JK02_32S) {
     uint16_t raw_emergency_time_countdown = jk_get_16bit(186 + offset);


### PR DESCRIPTION
My initial PR to add heating did not take the offset into account since i thought my device is a 24s version, but i turnes out it is a 32s.
So my findings in the bluethooth snoops would need to take the offset into account.