### PR TITLE
Improve error bitmask decoding

### DIFF
--- a/components/jk_bms_ble/jk_bms_ble.cpp
+++ b/components/jk_bms_ble/jk_bms_ble.cpp
@@ -25,22 +25,22 @@ static const uint16_t MAX_RESPONSE_SIZE = 320;
 
 static const uint8_t ERRORS_SIZE = 16;
 static const char *const ERRORS[ERRORS_SIZE] = {
-    "Charge Overtemperature",               // 0000 0000 0000 0001
-    "Charge Undertemperature",              // 0000 0000 0000 0010
-    "Error 0x00 0x04",                      // 0000 0000 0000 0100
-    "Cell Undervoltage",                    // 0000 0000 0000 1000
-    "Error 0x00 0x10",                      // 0000 0000 0001 0000
-    "Error 0x00 0x20",                      // 0000 0000 0010 0000
-    "Error 0x00 0x40",                      // 0000 0000 0100 0000
-    "Error 0x00 0x80",                      // 0000 0000 1000 0000
-    "Error 0x01 0x00",                      // 0000 0001 0000 0000
-    "Error 0x02 0x00",                      // 0000 0010 0000 0000
+    "Charge overtemperature",               // 0000 0000 0000 0001
+    "Charge undertemperature",              // 0000 0000 0000 0010
+    "Coprocessor communication error",      // 0000 0000 0000 0100
+    "Cell undervoltage",                    // 0000 0000 0000 1000
+    "Battery pack undervoltage",            // 0000 0000 0001 0000
+    "Discharge overcurrent",                // 0000 0000 0010 0000
+    "Discharge short circuit",              // 0000 0000 0100 0000
+    "Discharge overtemperature",            // 0000 0000 1000 0000
+    "Wire resistance",                      // 0000 0001 0000 0000
+    "Mosfet overtemperature",               // 0000 0010 0000 0000
     "Cell count is not equal to settings",  // 0000 0100 0000 0000
     "Current sensor anomaly",               // 0000 1000 0000 0000
     "Cell Overvoltage",                     // 0001 0000 0000 0000
-    "Error 0x20 0x00",                      // 0010 0000 0000 0000
+    "Battery pack overvoltage",             // 0010 0000 0000 0000
     "Charge overcurrent protection",        // 0100 0000 0000 0000
-    "Error 0x80 0x00",                      // 1000 0000 0000 0000
+    "Charge short circuit",                 // 1000 0000 0000 0000
 };
 
 uint8_t crc(const uint8_t data[], const uint16_t len) {

--- a/components/jk_bms_ble/jk_bms_ble.cpp
+++ b/components/jk_bms_ble/jk_bms_ble.cpp
@@ -25,10 +25,10 @@ static const uint16_t MAX_RESPONSE_SIZE = 320;
 
 static const uint8_t ERRORS_SIZE = 16;
 static const char *const ERRORS[ERRORS_SIZE] = {
-    "Charge overtemperature",               // 0000 0000 0000 0001
-    "Charge undertemperature",              // 0000 0000 0000 0010
+    "Charge Overtemperature",               // 0000 0000 0000 0001
+    "Charge Undertemperature",              // 0000 0000 0000 0010
     "Coprocessor communication error",      // 0000 0000 0000 0100
-    "Cell undervoltage",                    // 0000 0000 0000 1000
+    "Cell Undervoltage",                    // 0000 0000 0000 1000
     "Battery pack undervoltage",            // 0000 0000 0001 0000
     "Discharge overcurrent",                // 0000 0000 0010 0000
     "Discharge short circuit",              // 0000 0000 0100 0000
@@ -460,20 +460,20 @@ void JkBmsBle::decode_jk02_cell_info_(const std::vector<uint8_t> &data) {
   // 136   2   0x00 0x00              System alarms
   //           0x00 0x01                Charge overtemperature               0000 0000 0000 0001
   //           0x00 0x02                Charge undertemperature              0000 0000 0000 0010
-  //           0x00 0x04                                                     0000 0000 0000 0100
-  //           0x00 0x08                Cell Undervoltage                    0000 0000 0000 1000
-  //           0x00 0x10                                                     0000 0000 0001 0000
-  //           0x00 0x20                                                     0000 0000 0010 0000
-  //           0x00 0x40                                                     0000 0000 0100 0000
-  //           0x00 0x80                                                     0000 0000 1000 0000
-  //           0x01 0x00                                                     0000 0001 0000 0000
-  //           0x02 0x00                                                     0000 0010 0000 0000
+  //           0x00 0x04                Coprocessor communication error      0000 0000 0000 0100
+  //           0x00 0x08                Cell undervoltage                    0000 0000 0000 1000
+  //           0x00 0x10                Battery pack undervoltage            0000 0000 0001 0000
+  //           0x00 0x20                Discharge overcurrent                0000 0000 0010 0000
+  //           0x00 0x40                Discharge short circuit              0000 0000 0100 0000
+  //           0x00 0x80                Discharge overtemperature            0000 0000 1000 0000
+  //           0x01 0x00                Wire resistance                      0000 0001 0000 0000
+  //           0x02 0x00                Mosfet overtemperature               0000 0010 0000 0000
   //           0x04 0x00                Cell count is not equal to settings  0000 0100 0000 0000
   //           0x08 0x00                Current sensor anomaly               0000 1000 0000 0000
-  //           0x10 0x00                Cell Over Voltage                    0001 0000 0000 0000
-  //           0x20 0x00                                                     0010 0000 0000 0000
-  //           0x40 0x00                                                     0100 0000 0000 0000
-  //           0x80 0x00                                                     1000 0000 0000 0000
+  //           0x10 0x00                Cell Overvoltage                     0001 0000 0000 0000
+  //           0x20 0x00                Battery pack overvoltage             0010 0000 0000 0000
+  //           0x40 0x00                Charge overcurrent protection        0100 0000 0000 0000
+  //           0x80 0x00                Charge short circuit                 1000 0000 0000 0000
   //
   //           0x14 0x00                Cell Over Voltage +                  0001 0100 0000 0000
   //                                    Cell count is not equal to settings


### PR DESCRIPTION
See https://github.com/jblance/mpp-solar/issues/460#issuecomment-1973313087

#115

TODOs:

- [x] AlarmWireRes=cs.Enum(cs.Bit, OK=0, ALARM=1),
- [x] AlarmMosOTP=cs.Enum(cs.Bit, OK=0, ALARM=1),
- [x] AlarmCellQuantity=cs.Enum(cs.Bit, OK=0, ALARM=1),
- [x] AlarmCurSensorErr=cs.Enum(cs.Bit, OK=0, ALARM=1),
- [x] AlarmCellOVP=cs.Enum(cs.Bit, OK=0, ALARM=1),
- [x] AlarmBatOVP=cs.Enum(cs.Bit, OK=0, ALARM=1),
- [x] AlarmChOCP=cs.Enum(cs.Bit, OK=0, ALARM=1),
- [x] AlarmChSCP=cs.Enum(cs.Bit, OK=0, ALARM=1),
- [x] AlarmChOTP=cs.Enum(cs.Bit, OK=0, ALARM=1),
- [x] AlarmChUTP=cs.Enum(cs.Bit, OK=0, ALARM=1),
- [x] AlarmCPUAuxCommuErr=cs.Enum(cs.Bit, OK=0, ALARM=1),
- [x] AlarmCellUVP=cs.Enum(cs.Bit, OK=0, ALARM=1),
- [x] AlarmBatUVP=cs.Enum(cs.Bit, OK=0, ALARM=1),
- [x] AlarmDchOCP=cs.Enum(cs.Bit, OK=0, ALARM=1),
- [x] AlarmDchSCP=cs.Enum(cs.Bit, OK=0, ALARM=1),
- [x] AlarmDchOTP=cs.Enum(cs.Bit, OK=0, ALARM=1),
- [ ] AlarmChargeMOS=cs.Enum(cs.Bit, OK=0, ALARM=1),
- [ ] AlarmDischargeMOS=cs.Enum(cs.Bit, OK=0, ALARM=1),
- [ ] GPSDisconneted=cs.Enum(cs.Bit, OK=0, ALARM=1),
- [ ] ModifyPWDinTime=cs.Enum(cs.Bit, OK=0, ALARM=1),
- [ ] DischargeOnFailed=cs.Enum(cs.Bit, OK=0, ALARM=1),
- [ ] BatteryOverTemp=cs.Enum(cs.Bit, OK=0, ALARM=1),
- [ ] TemperatureSensorAnomaly=cs.Enum(cs.Bit, OK=0, ALARM=1),
- [ ] PLCModuleAnomaly=cs.Enum(cs.Bit, OK=0, ALARM=1),
- [ ] UnusedBit24=cs.Enum(cs.Bit, OK=0, ALARM=1),
- [ ] UnusedBit25=cs.Enum(cs.Bit, OK=0, ALARM=1),
- [ ] UnusedBit26=cs.Enum(cs.Bit, OK=0, ALARM=1),
- [ ] UnusedBit27=cs.Enum(cs.Bit, OK=0, ALARM=1),
- [ ] UnusedBit28=cs.Enum(cs.Bit, OK=0, ALARM=1),
- [ ] UnusedBit29=cs.Enum(cs.Bit, OK=0, ALARM=1),
- [ ] UnusedBit30=cs.Enum(cs.Bit, OK=0, ALARM=1),
- [ ] UnusedBit31=cs.Enum(cs.Bit, OK=0, ALARM=1)

