### PR TITLE
BREAKING: Correct little-endian error bitmask reading, extend to 32-bit

### DIFF
--- a/components/jk_bms_ble/jk_bms_ble.cpp
+++ b/components/jk_bms_ble/jk_bms_ble.cpp
@@ -1,6 +1,7 @@
 #include "jk_bms_ble.h"
 #include "esphome/core/log.h"
 #include "esphome/core/version.h"
+#include <cinttypes>
 
 #if ESPHOME_VERSION_CODE >= VERSION_CODE(2025, 12, 0)
 #define ADDR_STR(x) x
@@ -27,24 +28,39 @@ static const uint8_t COMMAND_DEVICE_INFO = 0x97;
 static const uint16_t MIN_RESPONSE_SIZE = 300;
 static const uint16_t MAX_RESPONSE_SIZE = 384 + 16;
 
-static const uint8_t ERRORS_SIZE = 16;
-static constexpr const char *const ERRORS[ERRORS_SIZE] = {
-    "Charge Overtemperature",               // 0000 0000 0000 0001
-    "Charge Undertemperature",              // 0000 0000 0000 0010
-    "Coprocessor communication error",      // 0000 0000 0000 0100
-    "Cell Undervoltage",                    // 0000 0000 0000 1000
-    "Battery pack undervoltage",            // 0000 0000 0001 0000
-    "Discharge overcurrent",                // 0000 0000 0010 0000
-    "Discharge short circuit",              // 0000 0000 0100 0000
-    "Discharge overtemperature",            // 0000 0000 1000 0000
-    "Wire resistance",                      // 0000 0001 0000 0000
-    "Mosfet overtemperature",               // 0000 0010 0000 0000
-    "Cell count is not equal to settings",  // 0000 0100 0000 0000
-    "Current sensor anomaly",               // 0000 1000 0000 0000
-    "Cell Overvoltage",                     // 0001 0000 0000 0000
-    "Battery pack overvoltage",             // 0010 0000 0000 0000
-    "Charge overcurrent protection",        // 0100 0000 0000 0000
-    "Charge short circuit",                 // 1000 0000 0000 0000
+static const char *const ERRORS_JK02[] = {
+    "Wire resistance",                      // bit 0
+    "MOSFET overtemperature",               // bit 1
+    "Cell count is not equal to settings",  // bit 2
+    "",                                     // bit 3 (Previously: "Current sensor anomaly")
+    "Battery is fully charged",             // bit 4
+    "Battery pack overvoltage",             // bit 5
+    "Charge overcurrent",                   // bit 6
+    "Charge short circuit",                 // bit 7
+    "Charge overtemperature",               // bit 8
+    "Charge undertemperature",              // bit 9
+    "Coprocessor communication error",      // bit 10
+    "Cell undervoltage",                    // bit 11
+    "Battery pack undervoltage",            // bit 12
+    "Discharge overcurrent",                // bit 13
+    "Discharge short circuit",              // bit 14
+    "Discharge overtemperature",            // bit 15
+    "Charging MOSFET abnormal",             // bit 16
+    "Discharging MOSFET abnormal",          // bit 17
+    "GPS disconnected",                     // bit 18
+    "Modify password in time",              // bit 19
+    "Discharge on failed",                  // bit 20
+    "Battery overtemperature",              // bit 21
+    "Temperature sensor anomaly",           // bit 22
+    "PL module anomaly",                    // bit 23
+    "SCP release failed",                   // bit 24
+    "Discharge OCP II",                     // bit 25
+    "Discharge OCP III",                    // bit 26
+    "Discharge undertemperature alarm",     // bit 27
+    "GPS remote lock",                      // bit 28
+    "",                                     // bit 29
+    "",                                     // bit 30
+    "",                                     // bit 31
 };
 
 uint8_t crc(const uint8_t data[], const uint16_t len) {
@@ -158,7 +174,6 @@ void JkBmsBle::dump_config() {  // NOLINT(google-readability-function-size,reada
   LOG_SENSOR("", "Total Runtime", this->total_runtime_sensor_);
   LOG_SENSOR("", "Heating Current", this->heating_current_sensor_);
   LOG_SENSOR("", "Balancing Current", this->balancing_current_sensor_);
-  LOG_SENSOR("", "Errors Bitmask", this->errors_bitmask_sensor_);
   LOG_SENSOR("", "Emergency Time Countdown", this->emergency_time_countdown_sensor_);
   LOG_SENSOR("", "Charge Status ID", this->charge_status_id_sensor_);
   LOG_SENSOR("", "Charge Status Time Elapsed", this->charge_status_time_elapsed_sensor_);
@@ -167,6 +182,7 @@ void JkBmsBle::dump_config() {  // NOLINT(google-readability-function-size,reada
   LOG_TEXT_SENSOR("", "Operation Status", this->operation_status_text_sensor_);
   LOG_TEXT_SENSOR("", "Total Runtime Formatted", this->total_runtime_formatted_text_sensor_);
   LOG_TEXT_SENSOR("", "Errors", this->errors_text_sensor_);
+  LOG_TEXT_SENSOR("", "Errors Bitmask Hex", this->errors_bitmask_hex_text_sensor_);
   LOG_TEXT_SENSOR("", "Charge Status", this->charge_status_text_sensor_);
   LOG_TEXT_SENSOR("", "Software Version", this->software_version_text_sensor_);
   LOG_TEXT_SENSOR("", "Hardware Version", this->hardware_version_text_sensor_);
@@ -561,39 +577,20 @@ void JkBmsBle::decode_jk02_cell_info_(const std::vector<uint8_t> &data) {
 
   // 134   2   0xD2 0x00              MOS Temperature       0.1          °C
   if (frame_version == FRAME_VERSION_JK02_32S) {
-    uint16_t raw_errors_bitmask = (uint16_t(data[134 + offset]) << 8) | (uint16_t(data[134 + 1 + offset]) << 0);
-    this->publish_state_(this->errors_bitmask_sensor_, (float) raw_errors_bitmask);
-    this->publish_state_(this->errors_text_sensor_, this->error_bits_to_string_(raw_errors_bitmask));
+    // 166-169: errors bitmask, little-endian 32-bit
+    uint32_t raw_errors_bitmask = jk_get_32bit(134 + offset);
+    this->publish_state_(this->errors_bitmask_hex_text_sensor_, this->to_hex_string_(raw_errors_bitmask));
+    this->publish_state_(this->errors_text_sensor_, this->error_bits_to_string_(raw_errors_bitmask, ERRORS_JK02, 32));
   } else {
     this->publish_state_(this->power_tube_temperature_sensor_, (float) ((int16_t) jk_get_16bit(134 + offset)) * 0.1f);
   }
 
-  // 136   2   0x00 0x00              System alarms
-  //           0x00 0x01                Charge overtemperature               0000 0000 0000 0001
-  //           0x00 0x02                Charge undertemperature              0000 0000 0000 0010
-  //           0x00 0x04                Coprocessor communication error      0000 0000 0000 0100
-  //           0x00 0x08                Cell undervoltage                    0000 0000 0000 1000
-  //           0x00 0x10                Battery pack undervoltage            0000 0000 0001 0000
-  //           0x00 0x20                Discharge overcurrent                0000 0000 0010 0000
-  //           0x00 0x40                Discharge short circuit              0000 0000 0100 0000
-  //           0x00 0x80                Discharge overtemperature            0000 0000 1000 0000
-  //           0x01 0x00                Wire resistance                      0000 0001 0000 0000
-  //           0x02 0x00                Mosfet overtemperature               0000 0010 0000 0000
-  //           0x04 0x00                Cell count is not equal to settings  0000 0100 0000 0000
-  //           0x08 0x00                Current sensor anomaly               0000 1000 0000 0000
-  //           0x10 0x00                Cell Overvoltage                     0001 0000 0000 0000
-  //           0x20 0x00                Battery pack overvoltage             0010 0000 0000 0000
-  //           0x40 0x00                Charge overcurrent protection        0100 0000 0000 0000
-  //           0x80 0x00                Charge short circuit                 1000 0000 0000 0000
-  //
-  //           0x14 0x00                Cell Over Voltage +                  0001 0100 0000 0000
-  //                                    Cell count is not equal to settings
-  //           0x04 0x08                Cell Undervoltage +                  0000 0100 0000 1000
-  //                                    Cell count is not equal to settings
+  // 136-137: errors bitmask (JK02_24S only), little-endian 16-bit
+  // JK02_32S extends this to 32 bits at offset 134; the upper 16 bits are not available here.
   if (frame_version != FRAME_VERSION_JK02_32S) {
-    uint16_t raw_errors_bitmask = (uint16_t(data[136 + offset]) << 8) | (uint16_t(data[136 + 1 + offset]) << 0);
-    this->publish_state_(this->errors_bitmask_sensor_, (float) raw_errors_bitmask);
-    this->publish_state_(this->errors_text_sensor_, this->error_bits_to_string_(raw_errors_bitmask));
+    uint32_t raw_errors_bitmask = jk_get_16bit(136 + offset);
+    this->publish_state_(this->errors_bitmask_hex_text_sensor_, this->to_hex_string_(raw_errors_bitmask));
+    this->publish_state_(this->errors_text_sensor_, this->error_bits_to_string_(raw_errors_bitmask, ERRORS_JK02, 16));
   }
 
   // 138   2   0x00 0x00              Balance current      0.001         A
@@ -1621,7 +1618,6 @@ void JkBmsBle::publish_device_unavailable_() {
   this->publish_state_(total_charging_cycle_capacity_sensor_, NAN);
   this->publish_state_(total_runtime_sensor_, NAN);
   this->publish_state_(balancing_current_sensor_, NAN);
-  this->publish_state_(errors_bitmask_sensor_, NAN);
   this->publish_state_(heating_current_sensor_, NAN);
 
   for (auto &cell : this->cells_) {
@@ -1668,19 +1664,23 @@ void JkBmsBle::publish_state_(text_sensor::TextSensor *text_sensor, const std::s
   text_sensor->publish_state(state);
 }
 
-std::string JkBmsBle::error_bits_to_string_(const uint16_t mask) {
+std::string JkBmsBle::to_hex_string_(const uint32_t mask) {
+  char buf[11];
+  snprintf(buf, sizeof(buf), "0x%08" PRIX32, mask);
+  return std::string(buf);
+}
+
+std::string JkBmsBle::error_bits_to_string_(const uint32_t mask, const char *const *errors, const uint8_t errors_size) {
   bool first = true;
   std::string errors_list;
 
   if (mask) {
-    for (int i = 0; i < ERRORS_SIZE; i++) {
-      if (mask & (1 << i)) {
-        if (first) {
-          first = false;
-        } else {
+    for (int i = 0; i < errors_size; i++) {
+      if ((mask & (1 << i)) && errors[i][0] != '\0') {
+        if (!first)
           errors_list.append(";");
-        }
-        errors_list.append(ERRORS[i]);
+        first = false;
+        errors_list.append(errors[i]);
       }
     }
   }

--- a/components/jk_bms_ble/jk_bms_ble.h
+++ b/components/jk_bms_ble/jk_bms_ble.h
@@ -254,9 +254,6 @@ class JkBmsBle :
   void set_balancing_current_sensor(sensor::Sensor *balancing_current_sensor) {
     balancing_current_sensor_ = balancing_current_sensor;
   }
-  void set_errors_bitmask_sensor(sensor::Sensor *errors_bitmask_sensor) {
-    errors_bitmask_sensor_ = errors_bitmask_sensor;
-  }
   void set_emergency_time_countdown_sensor(sensor::Sensor *emergency_time_countdown_sensor) {
     emergency_time_countdown_sensor_ = emergency_time_countdown_sensor;
   }
@@ -276,6 +273,9 @@ class JkBmsBle :
     battery_type_id_sensor_ = battery_type_id_sensor;
   }
 
+  void set_errors_bitmask_hex_text_sensor(text_sensor::TextSensor *errors_bitmask_hex_text_sensor) {
+    errors_bitmask_hex_text_sensor_ = errors_bitmask_hex_text_sensor;
+  }
   void set_errors_text_sensor(text_sensor::TextSensor *errors_text_sensor) { errors_text_sensor_ = errors_text_sensor; }
   void set_operation_status_text_sensor(text_sensor::TextSensor *operation_status_text_sensor) {
     operation_status_text_sensor_ = operation_status_text_sensor;
@@ -408,7 +408,6 @@ class JkBmsBle :
   sensor::Sensor *total_charging_cycle_capacity_sensor_{nullptr};
   sensor::Sensor *total_runtime_sensor_{nullptr};
   sensor::Sensor *balancing_current_sensor_{nullptr};
-  sensor::Sensor *errors_bitmask_sensor_{nullptr};
   sensor::Sensor *emergency_time_countdown_sensor_{nullptr};
   sensor::Sensor *heating_current_sensor_{nullptr};
   sensor::Sensor *charge_status_id_sensor_{nullptr};
@@ -428,6 +427,7 @@ class JkBmsBle :
   switch_::Switch *disable_pcl_module_switch_{nullptr};
   switch_::Switch *charging_float_mode_switch_{nullptr};
 
+  text_sensor::TextSensor *errors_bitmask_hex_text_sensor_{nullptr};
   text_sensor::TextSensor *errors_text_sensor_{nullptr};
   text_sensor::TextSensor *operation_status_text_sensor_{nullptr};
   text_sensor::TextSensor *total_runtime_formatted_text_sensor_{nullptr};
@@ -460,7 +460,8 @@ class JkBmsBle :
   void publish_device_unavailable_();
   void reset_online_status_tracker_();
   void track_online_status_();
-  std::string error_bits_to_string_(uint16_t bitmask);
+  std::string to_hex_string_(uint32_t mask);
+  std::string error_bits_to_string_(uint32_t bitmask, const char *const *errors, uint8_t errors_size);
   std::string charge_status_id_to_string_(uint8_t status);
   std::string battery_type_id_to_string_(uint8_t code);
 

--- a/components/jk_bms_ble/sensor.py
+++ b/components/jk_bms_ble/sensor.py
@@ -53,7 +53,6 @@ CONF_CHARGING_CYCLES = "charging_cycles"
 CONF_TOTAL_CHARGING_CYCLE_CAPACITY = "total_charging_cycle_capacity"
 CONF_TOTAL_RUNTIME = "total_runtime"
 CONF_BALANCING_CURRENT = "balancing_current"
-CONF_ERRORS_BITMASK = "errors_bitmask"
 CONF_EMERGENCY_TIME_COUNTDOWN = "emergency_time_countdown"
 CONF_HEATING_CURRENT = "heating_current"
 CONF_CHARGE_STATUS_ID = "charge_status_id"
@@ -71,7 +70,6 @@ ICON_MIN_VOLTAGE_CELL = "mdi:battery-minus-outline"
 ICON_MAX_VOLTAGE_CELL = "mdi:battery-plus-outline"
 ICON_CAPACITY_REMAINING = "mdi:battery-50"
 ICON_CHARGING_CYCLES = "mdi:battery-sync"
-ICON_ERRORS_BITMASK = "mdi:alert-circle-outline"
 ICON_CELL_RESISTANCE = "mdi:omega"
 ICON_BALANCER = "mdi:seesaw"
 ICON_CHARGE_STATUS_ID = "mdi:battery-clock"
@@ -251,13 +249,6 @@ SENSOR_DEFS = {
         "device_class": DEVICE_CLASS_CURRENT,
         "state_class": STATE_CLASS_MEASUREMENT,
     },
-    CONF_ERRORS_BITMASK: {
-        "unit_of_measurement": UNIT_EMPTY,
-        "icon": ICON_ERRORS_BITMASK,
-        "accuracy_decimals": 0,
-        "device_class": DEVICE_CLASS_EMPTY,
-        "entity_category": ENTITY_CATEGORY_DIAGNOSTIC,
-    },
     CONF_EMERGENCY_TIME_COUNTDOWN: {
         "unit_of_measurement": UNIT_SECONDS,
         "icon": ICON_TIMELAPSE,
@@ -309,6 +300,13 @@ CONFIG_SCHEMA = (
     .extend({cv.Optional(key): _CELL_VOLTAGE_SCHEMA for key in CELL_VOLTAGES})
     .extend({cv.Optional(key): _CELL_RESISTANCE_SCHEMA for key in CELL_RESISTANCES})
     .extend({cv.Optional(key): _TEMPERATURE_SCHEMA for key in TEMPERATURES})
+    .extend(
+        {
+            cv.Optional("errors_bitmask"): cv.invalid(
+                "sensor.errors_bitmask has been removed; use text_sensor.errors_bitmask_hex instead"
+            ),
+        }
+    )
 )
 
 

--- a/components/jk_bms_ble/text_sensor.py
+++ b/components/jk_bms_ble/text_sensor.py
@@ -10,6 +10,7 @@ DEPENDENCIES = ["jk_bms_ble"]
 CODEOWNERS = ["@syssi", "@txubelaxu"]
 
 CONF_ERRORS = "errors"
+CONF_ERRORS_BITMASK_HEX = "errors_bitmask_hex"
 CONF_OPERATION_STATUS = "operation_status"
 CONF_TOTAL_RUNTIME_FORMATTED = "total_runtime_formatted"
 CONF_CHARGE_STATUS = "charge_status"
@@ -24,6 +25,7 @@ ICON_BATTERY_TYPE = "mdi:battery-heart-variant"
 
 TEXT_SENSORS = [
     CONF_ERRORS,
+    CONF_ERRORS_BITMASK_HEX,
     CONF_OPERATION_STATUS,
     CONF_TOTAL_RUNTIME_FORMATTED,
     CONF_CHARGE_STATUS,
@@ -37,6 +39,9 @@ CONFIG_SCHEMA = JK_BMS_BLE_COMPONENT_SCHEMA.extend(
         cv.Optional(CONF_ERRORS): text_sensor.text_sensor_schema(
             icon=ICON_ERRORS,
             entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+        ),
+        cv.Optional(CONF_ERRORS_BITMASK_HEX): text_sensor.text_sensor_schema(
+            text_sensor.TextSensor, icon=ICON_ERRORS
         ),
         cv.Optional(CONF_OPERATION_STATUS): text_sensor.text_sensor_schema(
             icon=ICON_OPERATION_STATUS

--- a/docs/protocol-design-ble.md
+++ b/docs/protocol-design-ble.md
@@ -126,8 +126,7 @@ uint8_t crc(const uint8_t data[], const uint16_t len) {
 |          158-161 |      4 | Charge current | int32 | 0.001 | A | - |
 |          162-163 |      2 | Temperature Sensor 1 | int16 | 0.1 | °C | - |
 |          164-165 |      2 | Temperature Sensor 2 | int16 | 0.1 | °C | - |
-|          166-167 |      2 | Errors bitmask | uint16 | - | - | See errors bitmask notes below |
-|          168-169 |      2 | (Reserved in JK02_32S) | - | - | - | JK02_24S system alarm position; unused in JK02_32S |
+|          166-169 |      4 | Errors bitmask | uint32 | - | - | Little-endian; see errors bitmask notes below |
 |          170-171 |      2 | Balance current | int16 | 0.001 | A | - |
 |              172 |      1 | Balancing action | Raw | - | - | 0=Off, 1=Charging balancer, 2=Discharging balancer |
 |              173 |      1 | State of charge | uint8 | 1 | % | - |
@@ -161,23 +160,48 @@ uint8_t crc(const uint8_t data[], const uint16_t len) {
 |              281 |      1 | Dry contact switch status | Raw | - | - | JK02_32S only; see dry contact bitmask notes below |
 |              299 |      1 | CRC checksum | uint8 | - | - | - |
 
-Errors bitmask notes for bytes 166-167 (big-endian; bit0 = LSB of byte 167):
-- bit0: Charge overtemperature
-- bit1: Charge undertemperature
-- bit2: Coprocessor communication error
-- bit3: Cell undervoltage
-- bit4: Battery pack undervoltage
-- bit5: Discharge overcurrent
-- bit6: Discharge short circuit
-- bit7: Discharge overtemperature
-- bit8: Wire resistance
-- bit9: MOSFET overtemperature
-- bit10: Cell count mismatch
-- bit11: Current sensor anomaly
-- bit12: Cell overvoltage
-- bit13: Battery pack overvoltage
-- bit14: Charge overcurrent protection
-- bit15: Charge short circuit
+Errors bitmask notes (little-endian):
+- JK02_32S: bytes 166–169, 32-bit
+- JK02_24S: bytes 136–137, 16-bit (bits 0–15 only; bits 16–31 are a JK02_32S extension)
+
+Both variants share the same bit layout. Published as a zero-padded hex string via `text_sensor.errors_bitmask_hex` (e.g. `0x00000000`).
+
+#### Errors bitmask bit layout
+
+| Bit | Label | Notes |
+|----:|-------|-------|
+|  0 | Wire resistance | |
+|  1 | MOSFET overtemperature | |
+|  2 | Cell count is not equal to settings | |
+|  3 | *(unused)* | |
+|  4 | Battery is fully charged | |
+|  5 | Battery pack overvoltage | |
+|  6 | Charge overcurrent | |
+|  7 | Charge short circuit | |
+|  8 | Charge overtemperature | |
+|  9 | Charge undertemperature | |
+| 10 | Coprocessor communication error | |
+| 11 | Cell undervoltage | |
+| 12 | Battery pack undervoltage | |
+| 13 | Discharge overcurrent | |
+| 14 | Discharge short circuit | |
+| 15 | Discharge overtemperature | |
+| 16 | Charging MOSFET abnormal | JK02_32S only |
+| 17 | Discharging MOSFET abnormal | JK02_32S only |
+| 18 | GPS disconnected | JK02_32S only |
+| 19 | Modify password in time | JK02_32S only |
+| 20 | Discharge on failed | JK02_32S only |
+| 21 | Battery overtemperature | JK02_32S only |
+| 22 | Temperature sensor anomaly | JK02_32S only |
+| 23 | PL module anomaly | JK02_32S only |
+| 24 | SCP release failed | JK02_32S only |
+| 25 | Discharge OCP II | JK02_32S only |
+| 26 | Discharge OCP III | JK02_32S only |
+| 27 | Discharge undertemperature alarm | JK02_32S only |
+| 28 | GPS remote lock | JK02_32S only |
+| 29 | *(unused)* | JK02_32S only |
+| 30 | *(unused)* | JK02_32S only |
+| 31 | *(unused)* | JK02_32S only |
 
 Dry contact bitmask notes for byte 281 (JK02_32S only):
 - bit1 (0x02): DRY1 active

--- a/esp32-ble-example-multiple-devices.yaml
+++ b/esp32-ble-example-multiple-devices.yaml
@@ -244,6 +244,9 @@ text_sensor:
     errors:
       name: "errors"
       device_id: device0
+    errors_bitmask_hex:
+      name: "${bms0} errors bitmask hex"
+      device_id: device0
     total_runtime_formatted:
       name: "total runtime formatted"
       device_id: device0
@@ -258,6 +261,9 @@ text_sensor:
     jk_bms_ble_id: bms1
     errors:
       name: "errors"
+      device_id: device1
+    errors_bitmask_hex:
+      name: "${bms1} errors bitmask hex"
       device_id: device1
     total_runtime_formatted:
       name: "total runtime formatted"

--- a/esp32-ble-example.yaml
+++ b/esp32-ble-example.yaml
@@ -294,8 +294,6 @@ sensor:
       name: "total runtime"
     balancing_current:
       name: "balancing current"
-    errors_bitmask:
-      name: "errors bitmask"
 
 switch:
   - platform: jk_bms_ble
@@ -315,6 +313,8 @@ text_sensor:
   - platform: jk_bms_ble
     errors:
       name: "errors"
+    errors_bitmask_hex:
+      name: "errors bitmask hex"
     total_runtime_formatted:
       name: "total runtime formatted"
     software_version:

--- a/esp32-ble-v11-example.yaml
+++ b/esp32-ble-v11-example.yaml
@@ -310,8 +310,6 @@ sensor:
       name: "total runtime"
     balancing_current:
       name: "balancing current"
-    errors_bitmask:
-      name: "errors bitmask"
     emergency_time_countdown:
       name: "emergency time countdown"
     detail_log_count:
@@ -351,6 +349,8 @@ text_sensor:
   - platform: jk_bms_ble
     errors:
       name: "errors"
+    errors_bitmask_hex:
+      name: "errors bitmask hex"
     total_runtime_formatted:
       name: "total runtime formatted"
     software_version:

--- a/esp32-ble-v14-example-multiple-devices.yaml
+++ b/esp32-ble-v14-example-multiple-devices.yaml
@@ -592,9 +592,6 @@ sensor:
     balancing_current:
       name: "balancing current"
       device_id: device0
-    errors_bitmask:
-      name: "errors bitmask"
-      device_id: device0
     emergency_time_countdown:
       name: "emergency time countdown"
       device_id: device0
@@ -827,9 +824,6 @@ sensor:
     balancing_current:
       name: "balancing current"
       device_id: device1
-    errors_bitmask:
-      name: "errors bitmask"
-      device_id: device1
     emergency_time_countdown:
       name: "emergency time countdown"
       device_id: device1
@@ -928,6 +922,9 @@ text_sensor:
     errors:
       name: "errors"
       device_id: device0
+    errors_bitmask_hex:
+      name: "${bms0} errors bitmask hex"
+      device_id: device0
     total_runtime_formatted:
       name: "total runtime formatted"
       device_id: device0
@@ -942,6 +939,9 @@ text_sensor:
     jk_bms_ble_id: bms1
     errors:
       name: "errors"
+      device_id: device1
+    errors_bitmask_hex:
+      name: "${bms1} errors bitmask hex"
       device_id: device1
     total_runtime_formatted:
       name: "total runtime formatted"

--- a/esp32-ble-v14-example.yaml
+++ b/esp32-ble-v14-example.yaml
@@ -322,8 +322,6 @@ sensor:
       name: "total runtime"
     balancing_current:
       name: "balancing current"
-    errors_bitmask:
-      name: "errors bitmask"
     emergency_time_countdown:
       name: "emergency time countdown"
     charge_status_id:
@@ -368,6 +366,8 @@ text_sensor:
   - platform: jk_bms_ble
     errors:
       name: "errors"
+    errors_bitmask_hex:
+      name: "errors bitmask hex"
     total_runtime_formatted:
       name: "total runtime formatted"
     charge_status:

--- a/esp32-ble-v15-example.yaml
+++ b/esp32-ble-v15-example.yaml
@@ -326,8 +326,6 @@ sensor:
       name: "total runtime"
     balancing_current:
       name: "balancing current"
-    errors_bitmask:
-      name: "errors bitmask"
     emergency_time_countdown:
       name: "emergency time countdown"
     charge_status_id:
@@ -372,6 +370,8 @@ text_sensor:
   - platform: jk_bms_ble
     errors:
       name: "errors"
+    errors_bitmask_hex:
+      name: "errors bitmask hex"
     total_runtime_formatted:
       name: "total runtime formatted"
     charge_status:

--- a/esp32-ble-v19-example.yaml
+++ b/esp32-ble-v19-example.yaml
@@ -328,8 +328,6 @@ sensor:
       name: "total runtime"
     balancing_current:
       name: "balancing current"
-    errors_bitmask:
-      name: "errors bitmask"
     emergency_time_countdown:
       name: "emergency time countdown"
     charge_status_id:
@@ -374,6 +372,8 @@ text_sensor:
   - platform: jk_bms_ble
     errors:
       name: "errors"
+    errors_bitmask_hex:
+      name: "errors bitmask hex"
     total_runtime_formatted:
       name: "total runtime formatted"
     charge_status:

--- a/tests/components/jk_bms_ble/jk_bms_ble_test.cpp
+++ b/tests/components/jk_bms_ble/jk_bms_ble_test.cpp
@@ -139,14 +139,14 @@ TEST(JkBmsBleJk02CellInfoTest, Temperatures) {
 
 TEST(JkBmsBleJk02CellInfoTest, NoErrors) {
   TestableJkBmsBle bms;
-  sensor::Sensor errors_bitmask;
+  text_sensor::TextSensor errors_bitmask_hex;
   text_sensor::TextSensor errors_text;
-  bms.set_errors_bitmask_sensor(&errors_bitmask);
+  bms.set_errors_bitmask_hex_text_sensor(&errors_bitmask_hex);
   bms.set_errors_text_sensor(&errors_text);
 
   bms.decode_jk02_cell_info_(CELL_INFO_JK02_24S_V10);
 
-  EXPECT_FLOAT_EQ(errors_bitmask.state, 0.0f);
+  EXPECT_EQ(errors_bitmask_hex.state, "0x00000000");
   EXPECT_EQ(errors_text.state, "");
 }
 

--- a/tests/esp32-ble-b2a25s-example.yaml
+++ b/tests/esp32-ble-b2a25s-example.yaml
@@ -314,8 +314,6 @@ sensor:
       name: "total runtime"
     balancing_current:
       name: "balancing current"
-    errors_bitmask:
-      name: "errors bitmask"
     emergency_time_countdown:
       name: "emergency time countdown"
     charge_status_id:
@@ -353,6 +351,8 @@ text_sensor:
   - platform: jk_bms_ble
     errors:
       name: "errors"
+    errors_bitmask_hex:
+      name: "errors bitmask hex"
     total_runtime_formatted:
       name: "total runtime formatted"
     charge_status:

--- a/tests/test_component_schemas.py
+++ b/tests/test_component_schemas.py
@@ -116,7 +116,7 @@ class TestJkBmsBleSensorLists:
         assert "total_voltage" in ble_sensor.SENSOR_DEFS
         assert "detail_log_count" in ble_sensor.SENSOR_DEFS
         assert "battery_type_id" in ble_sensor.SENSOR_DEFS
-        assert len(ble_sensor.SENSOR_DEFS) == 28
+        assert len(ble_sensor.SENSOR_DEFS) == 27
 
 
 class TestJkBmsBleBinarySensorConstants:
@@ -160,7 +160,7 @@ class TestJkBleTextSensorConstants:
         assert ble_text_sensor.CONF_OPERATION_STATUS in ble_text_sensor.TEXT_SENSORS
         assert ble_text_sensor.CONF_CHARGE_STATUS in ble_text_sensor.TEXT_SENSORS
         assert ble_text_sensor.CONF_BATTERY_TYPE in ble_text_sensor.TEXT_SENSORS
-        assert len(ble_text_sensor.TEXT_SENSORS) == 7
+        assert len(ble_text_sensor.TEXT_SENSORS) == 8
 
 
 class TestJkBmsDisplaySensorLists:


### PR DESCRIPTION
The numeric `errors_bitmask` sensor published the raw bitmask as a float. This worked for 16-bit values, but `JK02_32S` devices report a 32-bit error register. IEEE 754 single-precision floats have only 24 bits of mantissa, so values above 2²⁴ (16,777,216) cannot be represented exactly — individual error bits in the upper range would be lost or corrupted. The sensor was therefore replaced with errors_bitmask_hex, a text sensor that formats the full 32-bit value as a hex string (e.g. 0x000A0000), preserving all bits exactly. The known error list was also extended from 16 to 29 entries to cover the additional bits introduced by the 32S hardware.