### PR TITLE
Compute {min,max}_voltage_cell, delta_cell_voltage and average_cell_voltage

### DIFF
--- a/components/heltec_balancer_ble/heltec_balancer_ble.cpp
+++ b/components/heltec_balancer_ble/heltec_balancer_ble.cpp
@@ -430,8 +430,8 @@ void HeltecBalancerBle::decode_cell_info_(const std::vector<uint8_t> &data) {
 
   this->publish_state_(this->min_cell_voltage_sensor_, min_cell_voltage);
   this->publish_state_(this->max_cell_voltage_sensor_, max_cell_voltage);
-  this->publish_state_(this->max_voltage_cell_sensor_, (float) max_voltage_cell);
   this->publish_state_(this->min_voltage_cell_sensor_, (float) min_voltage_cell);
+  this->publish_state_(this->max_voltage_cell_sensor_, (float) max_voltage_cell);
   this->publish_state_(this->delta_cell_voltage_sensor_, max_cell_voltage - min_cell_voltage);
   this->publish_state_(this->average_cell_voltage_sensor_, average_cell_voltage);
 

--- a/components/heltec_balancer_ble/heltec_balancer_ble.cpp
+++ b/components/heltec_balancer_ble/heltec_balancer_ble.cpp
@@ -390,34 +390,49 @@ void HeltecBalancerBle::decode_cell_info_(const std::vector<uint8_t> &data) {
   this->publish_state_(this->total_voltage_sensor_, ieee_float_(heltec_get_32bit(201)));
 
   // 205   4   0xDE 0x40 0x51 0x40              Average cell voltage
-  this->publish_state_(this->average_cell_voltage_sensor_, ieee_float_(heltec_get_32bit(205)));
+  // this->publish_state_(this->average_cell_voltage_sensor_, ieee_float_(heltec_get_32bit(205)));
 
   // 209   4   0x00 0x17 0x08 0x3C              Delta Cell Voltage
-  this->publish_state_(this->delta_cell_voltage_sensor_, ieee_float_(heltec_get_32bit(209)));
+  // this->publish_state_(this->delta_cell_voltage_sensor_, ieee_float_(heltec_get_32bit(209)));
 
   // 213   1   0x0A                             Max voltage cell
-  this->publish_state_(this->max_voltage_cell_sensor_, (float) data[213] + 1);
+  // this->publish_state_(this->max_voltage_cell_sensor_, (float) data[213] + 1);
 
   // 214   1   0x00                             Min voltage cell
-  this->publish_state_(this->min_voltage_cell_sensor_, (float) data[214] + 1);
+  // this->publish_state_(this->min_voltage_cell_sensor_, (float) data[214] + 1);
 
-  uint8_t cells = 24;
+  uint8_t cells_enabled = 0;
   float min_cell_voltage = 100.0f;
   float max_cell_voltage = -100.0f;
-  for (uint8_t i = 0; i < cells; i++) {
+  float average_cell_voltage = 0.0f;
+  uint8_t min_voltage_cell = 0;
+  uint8_t max_voltage_cell = 0;
+  for (uint8_t i = 0; i < 24; i++) {
     float cell_voltage = ieee_float_(heltec_get_32bit(i * 4 + 9));
     float cell_resistance = ieee_float_(heltec_get_32bit(i * 4 + 105));
+    if(cell_voltage > 0) {
+      average_cell_voltage = average_cell_voltage + cell_voltage;
+      cells_enabled++;
+    }
     if (cell_voltage > 0 && cell_voltage < min_cell_voltage) {
       min_cell_voltage = cell_voltage;
+      min_voltage_cell = i + 1;
     }
     if (cell_voltage > max_cell_voltage) {
       max_cell_voltage = cell_voltage;
+      max_voltage_cell = i + 1;
     }
     this->publish_state_(this->cells_[i].cell_voltage_sensor_, cell_voltage);
     this->publish_state_(this->cells_[i].cell_resistance_sensor_, cell_resistance);
   }
+  average_cell_voltage = average_cell_voltage / cells_enabled;
+
   this->publish_state_(this->min_cell_voltage_sensor_, min_cell_voltage);
   this->publish_state_(this->max_cell_voltage_sensor_, max_cell_voltage);
+  this->publish_state_(this->max_voltage_cell_sensor_, (float) max_voltage_cell);
+  this->publish_state_(this->min_voltage_cell_sensor_, (float) min_voltage_cell);
+  this->publish_state_(this->delta_cell_voltage_sensor_, max_cell_voltage - min_cell_voltage);
+  this->publish_state_(this->average_cell_voltage_sensor_, average_cell_voltage);
 
   // 215   1   0x0F                             Single number (not exposed at the android app)
   // ESP_LOGI(TAG, "  Cell count?: %d", data[215] + 1);

--- a/components/heltec_balancer_ble/heltec_balancer_ble.cpp
+++ b/components/heltec_balancer_ble/heltec_balancer_ble.cpp
@@ -411,7 +411,7 @@ void HeltecBalancerBle::decode_cell_info_(const std::vector<uint8_t> &data) {
   for (uint8_t i = 0; i < cells; i++) {
     float cell_voltage = ieee_float_(heltec_get_32bit(i * 4 + 9));
     float cell_resistance = ieee_float_(heltec_get_32bit(i * 4 + 105));
-    if(cell_voltage > 0) {
+    if (cell_voltage > 0) {
       average_cell_voltage = average_cell_voltage + cell_voltage;
       cells_enabled++;
     }

--- a/components/heltec_balancer_ble/heltec_balancer_ble.cpp
+++ b/components/heltec_balancer_ble/heltec_balancer_ble.cpp
@@ -401,13 +401,14 @@ void HeltecBalancerBle::decode_cell_info_(const std::vector<uint8_t> &data) {
   // 214   1   0x00                             Min voltage cell
   // this->publish_state_(this->min_voltage_cell_sensor_, (float) data[214] + 1);
 
+  uint8_t cells = 24;
   uint8_t cells_enabled = 0;
   float min_cell_voltage = 100.0f;
   float max_cell_voltage = -100.0f;
   float average_cell_voltage = 0.0f;
   uint8_t min_voltage_cell = 0;
   uint8_t max_voltage_cell = 0;
-  for (uint8_t i = 0; i < 24; i++) {
+  for (uint8_t i = 0; i < cells; i++) {
     float cell_voltage = ieee_float_(heltec_get_32bit(i * 4 + 9));
     float cell_resistance = ieee_float_(heltec_get_32bit(i * 4 + 105));
     if(cell_voltage > 0) {

--- a/components/jk_bms/jk_bms.cpp
+++ b/components/jk_bms/jk_bms.cpp
@@ -119,8 +119,8 @@ void JkBms::on_status_data_(const std::vector<uint8_t> &data) {
 
   this->publish_state_(this->min_cell_voltage_sensor_, min_cell_voltage);
   this->publish_state_(this->max_cell_voltage_sensor_, max_cell_voltage);
-  this->publish_state_(this->max_voltage_cell_sensor_, (float) max_voltage_cell);
   this->publish_state_(this->min_voltage_cell_sensor_, (float) min_voltage_cell);
+  this->publish_state_(this->max_voltage_cell_sensor_, (float) max_voltage_cell);
   this->publish_state_(this->delta_cell_voltage_sensor_, max_cell_voltage - min_cell_voltage);
   this->publish_state_(this->average_cell_voltage_sensor_, average_cell_voltage);
 

--- a/components/jk_bms_ble/jk_bms_ble.cpp
+++ b/components/jk_bms_ble/jk_bms_ble.cpp
@@ -723,8 +723,8 @@ void JkBmsBle::decode_jk04_cell_info_(const std::vector<uint8_t> &data) {
 
   this->publish_state_(this->min_cell_voltage_sensor_, min_cell_voltage);
   this->publish_state_(this->max_cell_voltage_sensor_, max_cell_voltage);
-  this->publish_state_(this->max_voltage_cell_sensor_, (float) max_voltage_cell);
   this->publish_state_(this->min_voltage_cell_sensor_, (float) min_voltage_cell);
+  this->publish_state_(this->max_voltage_cell_sensor_, (float) max_voltage_cell);
   this->publish_state_(this->delta_cell_voltage_sensor_, max_cell_voltage - min_cell_voltage);
   this->publish_state_(this->average_cell_voltage_sensor_, average_cell_voltage);
   this->publish_state_(this->total_voltage_sensor_, total_voltage);

--- a/components/jk_bms_ble/jk_bms_ble.cpp
+++ b/components/jk_bms_ble/jk_bms_ble.cpp
@@ -369,20 +369,34 @@ void JkBmsBle::decode_jk02_cell_info_(const std::vector<uint8_t> &data) {
   uint8_t cells = 24 + (offset / 2);
   float min_cell_voltage = 100.0f;
   float max_cell_voltage = -100.0f;
+  uint8_t min_voltage_cell = 0;
+  uint8_t max_voltage_cell = 0;
   for (uint8_t i = 0; i < cells; i++) {
     float cell_voltage = (float) jk_get_16bit(i * 2 + 6) * 0.001f;
     float cell_resistance = (float) jk_get_16bit(i * 2 + 64 + offset) * 0.001f;
     if (cell_voltage > 0 && cell_voltage < min_cell_voltage) {
       min_cell_voltage = cell_voltage;
+      min_voltage_cell = i + 1;
     }
     if (cell_voltage > max_cell_voltage) {
       max_cell_voltage = cell_voltage;
+      max_voltage_cell = i + 1;
     }
     this->publish_state_(this->cells_[i].cell_voltage_sensor_, cell_voltage);
     this->publish_state_(this->cells_[i].cell_resistance_sensor_, cell_resistance);
   }
   this->publish_state_(this->min_cell_voltage_sensor_, min_cell_voltage);
   this->publish_state_(this->max_cell_voltage_sensor_, max_cell_voltage);
+
+  ESP_LOGE(TAG, "Computed min_cell_voltage: %.3f V", min_cell_voltage);
+  ESP_LOGE(TAG, "Computed max_cell_voltage: %.3f V", max_cell_voltage);
+  ESP_LOGE(TAG, "Computed min_voltage_cell: %d", min_voltage_cell);
+  ESP_LOGE(TAG, "Computed max_voltage_cell: %d", max_voltage_cell);
+  ESP_LOGE(TAG, "Computed delta_cell_voltage: %.4f V", max_cell_voltage - min_cell_voltage);
+
+  ESP_LOGE(TAG, "Reported min_voltage_cell: %d", data[63 + offset] + 1);
+  ESP_LOGE(TAG, "Reported max_voltage_cell: %d", data[62 + offset] + 1);
+  ESP_LOGE(TAG, "Reported delta_cell_voltage: %.3f V", (float) jk_get_16bit(60 + offset) * 0.001f);
 
   // 54    4   0xFF 0xFF 0x00 0x00    Enabled cells bitmask
   //           0x0F 0x00 0x00 0x00    4 cells enabled

--- a/components/jk_bms_ble/jk_bms_ble.cpp
+++ b/components/jk_bms_ble/jk_bms_ble.cpp
@@ -376,7 +376,7 @@ void JkBmsBle::decode_jk02_cell_info_(const std::vector<uint8_t> &data) {
   for (uint8_t i = 0; i < cells; i++) {
     float cell_voltage = (float) jk_get_16bit(i * 2 + 6) * 0.001f;
     float cell_resistance = (float) jk_get_16bit(i * 2 + 64 + offset) * 0.001f;
-    if(cell_voltage > 0) {
+    if (cell_voltage > 0) {
       average_cell_voltage = average_cell_voltage + cell_voltage;
       cells_enabled++;
     }
@@ -704,7 +704,7 @@ void JkBmsBle::decode_jk04_cell_info_(const std::vector<uint8_t> &data) {
     float cell_voltage = (float) ieee_float_(jk_get_32bit(i * 4 + 6));
     float cell_resistance = (float) ieee_float_(jk_get_32bit(i * 4 + 102));
     total_voltage = total_voltage + cell_voltage;
-    if(cell_voltage > 0) {
+    if (cell_voltage > 0) {
       average_cell_voltage = average_cell_voltage + cell_voltage;
       cells_enabled++;
     }

--- a/components/jk_bms_ble/jk_bms_ble.cpp
+++ b/components/jk_bms_ble/jk_bms_ble.cpp
@@ -367,13 +367,19 @@ void JkBmsBle::decode_jk02_cell_info_(const std::vector<uint8_t> &data) {
   // 10    2   0x01 0x0D              Voltage cell 03       0.001        V
   // ...
   uint8_t cells = 24 + (offset / 2);
+  uint8_t cells_enabled = 0;
   float min_cell_voltage = 100.0f;
   float max_cell_voltage = -100.0f;
+  float average_cell_voltage = 0.0f;
   uint8_t min_voltage_cell = 0;
   uint8_t max_voltage_cell = 0;
   for (uint8_t i = 0; i < cells; i++) {
     float cell_voltage = (float) jk_get_16bit(i * 2 + 6) * 0.001f;
     float cell_resistance = (float) jk_get_16bit(i * 2 + 64 + offset) * 0.001f;
+    if(cell_voltage > 0) {
+      average_cell_voltage = average_cell_voltage + cell_voltage;
+      cells_enabled++;
+    }
     if (cell_voltage > 0 && cell_voltage < min_cell_voltage) {
       min_cell_voltage = cell_voltage;
       min_voltage_cell = i + 1;
@@ -385,18 +391,14 @@ void JkBmsBle::decode_jk02_cell_info_(const std::vector<uint8_t> &data) {
     this->publish_state_(this->cells_[i].cell_voltage_sensor_, cell_voltage);
     this->publish_state_(this->cells_[i].cell_resistance_sensor_, cell_resistance);
   }
+  average_cell_voltage = average_cell_voltage / cells_enabled;
+
   this->publish_state_(this->min_cell_voltage_sensor_, min_cell_voltage);
   this->publish_state_(this->max_cell_voltage_sensor_, max_cell_voltage);
-
-  ESP_LOGE(TAG, "Computed min_cell_voltage: %.3f V", min_cell_voltage);
-  ESP_LOGE(TAG, "Computed max_cell_voltage: %.3f V", max_cell_voltage);
-  ESP_LOGE(TAG, "Computed min_voltage_cell: %d", min_voltage_cell);
-  ESP_LOGE(TAG, "Computed max_voltage_cell: %d", max_voltage_cell);
-  ESP_LOGE(TAG, "Computed delta_cell_voltage: %.4f V", max_cell_voltage - min_cell_voltage);
-
-  ESP_LOGE(TAG, "Reported min_voltage_cell: %d", data[63 + offset] + 1);
-  ESP_LOGE(TAG, "Reported max_voltage_cell: %d", data[62 + offset] + 1);
-  ESP_LOGE(TAG, "Reported delta_cell_voltage: %.3f V", (float) jk_get_16bit(60 + offset) * 0.001f);
+  this->publish_state_(this->max_voltage_cell_sensor_, (float) max_voltage_cell);
+  this->publish_state_(this->min_voltage_cell_sensor_, (float) min_voltage_cell);
+  this->publish_state_(this->delta_cell_voltage_sensor_, max_cell_voltage - min_cell_voltage);
+  this->publish_state_(this->average_cell_voltage_sensor_, average_cell_voltage);
 
   // 54    4   0xFF 0xFF 0x00 0x00    Enabled cells bitmask
   //           0x0F 0x00 0x00 0x00    4 cells enabled
@@ -410,15 +412,17 @@ void JkBmsBle::decode_jk02_cell_info_(const std::vector<uint8_t> &data) {
            data[56 + offset], data[57 + offset]);
 
   // 58    2   0x00 0x0D              Average Cell Voltage  0.001        V
-  this->publish_state_(this->average_cell_voltage_sensor_, (float) jk_get_16bit(58 + offset) * 0.001f);
+  // this->publish_state_(this->average_cell_voltage_sensor_, (float) jk_get_16bit(58 + offset) * 0.001f);
 
   // 60    2   0x00 0x00              Delta Cell Voltage    0.001        V
-  this->publish_state_(this->delta_cell_voltage_sensor_, (float) jk_get_16bit(60 + offset) * 0.001f);
+  // this->publish_state_(this->delta_cell_voltage_sensor_, (float) jk_get_16bit(60 + offset) * 0.001f);
 
   // 62    1   0x00                   Max voltage cell      1
-  this->publish_state_(this->max_voltage_cell_sensor_, (float) data[62 + offset] + 1);
+  // this->publish_state_(this->max_voltage_cell_sensor_, (float) data[62 + offset] + 1);
+
   // 63    1   0x00                   Min voltage cell      1
-  this->publish_state_(this->min_voltage_cell_sensor_, (float) data[63 + offset] + 1);
+  // this->publish_state_(this->min_voltage_cell_sensor_, (float) data[63 + offset] + 1);
+
   // 64    2   0x9D 0x01              Resistance Cell 01    0.001        Ohm
   // 66    2   0x96 0x01              Resistance Cell 02    0.001        Ohm
   // 68    2   0x8C 0x01              Resistance Cell 03    0.001        Ohm
@@ -689,8 +693,10 @@ void JkBmsBle::decode_jk04_cell_info_(const std::vector<uint8_t> &data) {
   // 198   4   0x00 0x00 0x00 0x00    Cell resistance 25                 Ohm
   //                                  https://github.com/jblance/mpp-solar/issues/98#issuecomment-823701486
   uint8_t cells = 24;
+  uint8_t cells_enabled = 0;
   float min_cell_voltage = 100.0f;
   float max_cell_voltage = -100.0f;
+  float average_cell_voltage = 0.0f;
   float total_voltage = 0.0f;
   uint8_t min_voltage_cell = 0;
   uint8_t max_voltage_cell = 0;
@@ -698,6 +704,10 @@ void JkBmsBle::decode_jk04_cell_info_(const std::vector<uint8_t> &data) {
     float cell_voltage = (float) ieee_float_(jk_get_32bit(i * 4 + 6));
     float cell_resistance = (float) ieee_float_(jk_get_32bit(i * 4 + 102));
     total_voltage = total_voltage + cell_voltage;
+    if(cell_voltage > 0) {
+      average_cell_voltage = average_cell_voltage + cell_voltage;
+      cells_enabled++;
+    }
     if (cell_voltage > 0 && cell_voltage < min_cell_voltage) {
       min_cell_voltage = cell_voltage;
       min_voltage_cell = i + 1;
@@ -709,18 +719,21 @@ void JkBmsBle::decode_jk04_cell_info_(const std::vector<uint8_t> &data) {
     this->publish_state_(this->cells_[i].cell_voltage_sensor_, cell_voltage);
     this->publish_state_(this->cells_[i].cell_resistance_sensor_, cell_resistance);
   }
+  average_cell_voltage = average_cell_voltage / cells_enabled;
 
   this->publish_state_(this->min_cell_voltage_sensor_, min_cell_voltage);
   this->publish_state_(this->max_cell_voltage_sensor_, max_cell_voltage);
   this->publish_state_(this->max_voltage_cell_sensor_, (float) max_voltage_cell);
   this->publish_state_(this->min_voltage_cell_sensor_, (float) min_voltage_cell);
+  this->publish_state_(this->delta_cell_voltage_sensor_, max_cell_voltage - min_cell_voltage);
+  this->publish_state_(this->average_cell_voltage_sensor_, average_cell_voltage);
   this->publish_state_(this->total_voltage_sensor_, total_voltage);
 
   // 202   4   0x03 0x95 0x56 0x40    Average Cell Voltage               V
-  this->publish_state_(this->average_cell_voltage_sensor_, (float) ieee_float_(jk_get_32bit(202)));
+  // this->publish_state_(this->average_cell_voltage_sensor_, (float) ieee_float_(jk_get_32bit(202)));
 
   // 206   4   0x00 0xBE 0x90 0x3B    Delta Cell Voltage                 V
-  this->publish_state_(this->delta_cell_voltage_sensor_, (float) ieee_float_(jk_get_32bit(206)));
+  // this->publish_state_(this->delta_cell_voltage_sensor_, (float) ieee_float_(jk_get_32bit(206)));
 
   // 210   4   0x00 0x00 0x00 0x00    Unknown210
   ESP_LOGD(TAG, "Unknown210: 0x%02X 0x%02X 0x%02X 0x%02X (always 0x00 0x00 0x00 0x00)", data[210], data[211], data[212],

--- a/components/jk_bms_display/jk_bms_display.cpp
+++ b/components/jk_bms_display/jk_bms_display.cpp
@@ -177,8 +177,8 @@ void JkBmsDisplay::on_jk_bms_display_status_data_(const std::vector<uint8_t> &da
 
   this->publish_state_(this->min_cell_voltage_sensor_, min_cell_voltage);
   this->publish_state_(this->max_cell_voltage_sensor_, max_cell_voltage);
-  this->publish_state_(this->max_voltage_cell_sensor_, (float) max_voltage_cell);
   this->publish_state_(this->min_voltage_cell_sensor_, (float) min_voltage_cell);
+  this->publish_state_(this->max_voltage_cell_sensor_, (float) max_voltage_cell);
   this->publish_state_(this->delta_cell_voltage_sensor_, max_cell_voltage - min_cell_voltage);
   this->publish_state_(this->average_cell_voltage_sensor_, average_cell_voltage);
 

--- a/components/jk_bms_display/jk_bms_display.cpp
+++ b/components/jk_bms_display/jk_bms_display.cpp
@@ -157,7 +157,7 @@ void JkBmsDisplay::on_jk_bms_display_status_data_(const std::vector<uint8_t> &da
   uint8_t max_voltage_cell = 0;
   for (uint8_t i = 0; i < cells; i++) {
     float cell_voltage = (float) jk_bms_get_16bit(i * 2 + 24 + offset) * 0.001f;
-    if(cell_voltage > 0) {
+    if (cell_voltage > 0) {
       average_cell_voltage = average_cell_voltage + cell_voltage;
       cells_enabled++;
     }


### PR DESCRIPTION
```
substitutions:
  name: jk-bms
  device_description: "Monitor and control a JK-BMS v11 via bluetooth"
  external_components_source: github://syssi/esphome-jk-bms@debug-delta
```

```
[11:36:09][I][jk_bms_ble:330]: Cell info frame (version 3, 300 bytes) received
[11:36:09][E][jk_bms_ble:391]: Computed min_cell_voltage: 3.615 V
[11:36:09][E][jk_bms_ble:392]: Computed max_cell_voltage: 3.762 V
[11:36:09][E][jk_bms_ble:393]: Computed min_voltage_cell: 1
[11:36:09][E][jk_bms_ble:394]: Computed max_voltage_cell: 13
[11:36:09][E][jk_bms_ble:395]: Computed delta_cell_voltage: 0.14700 V
[11:36:09][E][jk_bms_ble:397]: Reported min_voltage_cell: 1
[11:36:09][E][jk_bms_ble:398]: Reported max_voltage_cell: 13
[11:36:09][E][jk_bms_ble:399]: Reported delta_cell_voltage: 0.147 V
``` 