### PR TITLE
Change the `sensor.balancing` device class to `EMPTY`

### DIFF
--- a/components/jk_bms_ble/sensor.py
+++ b/components/jk_bms_ble/sensor.py
@@ -215,7 +215,7 @@ CONFIG_SCHEMA = JK_BMS_BLE_COMPONENT_SCHEMA.extend(
             unit_of_measurement=UNIT_EMPTY,
             icon=ICON_BALANCER,
             accuracy_decimals=0,
-            device_class=DEVICE_CLASS_CURRENT,
+            device_class=DEVICE_CLASS_EMPTY,
             state_class=STATE_CLASS_MEASUREMENT,
         ),
         cv.Optional(CONF_MIN_CELL_VOLTAGE): sensor.sensor_schema(


### PR DESCRIPTION
Changes the device_class from `CURRENT` to `EMPTY`, as the `balancing` property only indicates the balancing direction.
Issue: https://github.com/syssi/esphome-jk-bms/issues/638.
