### PR TITLE
Modbus: Expose setup passcode using a text sensor

### DIFF
--- a/esp32-jk-pb-modbus-example.yaml
+++ b/esp32-jk-pb-modbus-example.yaml
@@ -1787,7 +1787,7 @@ text_sensor:
     modbus_controller_id: bms0
     name: "${name} password"
     register_type: holding
-    address: 0x1470 # 0x1400 base + 0x0070 offset
+    address: 0x1470  # 0x1400 base + 0x0070 offset
     register_count: 8
     response_size: 16
     raw_encode: ANSI

--- a/esp32-jk-pb-modbus-example.yaml
+++ b/esp32-jk-pb-modbus-example.yaml
@@ -1785,7 +1785,7 @@ select:
 text_sensor:
   - platform: modbus_controller
     modbus_controller_id: bms0
-    name: "${name} password"
+    name: "${name} setup passcode"
     register_type: holding
     address: 0x1470  # 0x1400 base + 0x0070 offset
     register_count: 8

--- a/esp32-jk-pb-modbus-example.yaml
+++ b/esp32-jk-pb-modbus-example.yaml
@@ -1786,7 +1786,6 @@ text_sensor:
   - platform: modbus_controller
     modbus_controller_id: bms0
     name: "${name} password"
-    update_interval: 60s
     register_type: holding
     address: 0x1470 # 0x1400 base + 0x0070 offset
     register_count: 8

--- a/esp32-jk-pb-modbus-example.yaml
+++ b/esp32-jk-pb-modbus-example.yaml
@@ -1783,6 +1783,16 @@ select:
       "On": 1
 
 text_sensor:
+  - platform: modbus_controller
+    modbus_controller_id: bms0
+    name: "${name} password"
+    update_interval: 60s
+    register_type: holding
+    address: 0x1470 # 0x1400 base + 0x0070 offset
+    register_count: 8
+    response_size: 16
+    raw_encode: ANSI
+
   - platform: template
     name: "${name} total runtime formatted"
     update_interval: 60s


### PR DESCRIPTION
This PR adds support for reading the Password field from the JK BMS directly via modbus_controller

Introduced a text_sensor that:

- Reads from register address 0x1470 (base block 0x1400 + offset 0x0070).
- Uses 8 registers (16 bytes) to capture the ASCII string.
- Decodes the string using raw_encode: ANSI (no custom lambda required).

For example:
<img width="567" height="83" alt="image" src="https://github.com/user-attachments/assets/8627121e-0a60-4fbe-8c59-7ee6b2f6164a" />
