### PR TITLE
Ensure cell resistance sensors are also marked as unavailable on disconnect

### DIFF
--- a/components/heltec_balancer_ble/heltec_balancer_ble.cpp
+++ b/components/heltec_balancer_ble/heltec_balancer_ble.cpp
@@ -863,6 +863,7 @@ void HeltecBalancerBle::publish_device_unavailable_() {
 
   for (auto &cell : this->cells_) {
     this->publish_state_(cell.cell_voltage_sensor_, NAN);
+    this->publish_state_(cell.cell_resistance_sensor_, NAN);
   }
 }
 


### PR DESCRIPTION
makes logical sense to NAN cell resistance sensors here too