### PR TITLE
Remove redundant .extend(cv.COMPONENT_SCHEMA) from switch and button schemas

### DIFF
--- a/components/heltec_balancer_ble/button/__init__.py
+++ b/components/heltec_balancer_ble/button/__init__.py
@@ -36,15 +36,15 @@ CONFIG_SCHEMA = HELTEC_BALANCER_BLE_COMPONENT_SCHEMA.extend(
         cv.Optional(CONF_RETRIEVE_SETTINGS): button.button_schema(
             HeltecButton,
             icon=ICON_RETRIEVE_SETTINGS,
-        ).extend(cv.COMPONENT_SCHEMA),
+        ),
         cv.Optional(CONF_RETRIEVE_DEVICE_INFO): button.button_schema(
             HeltecButton,
             icon=ICON_RETRIEVE_DEVICE_INFO,
-        ).extend(cv.COMPONENT_SCHEMA),
+        ),
         cv.Optional(CONF_RETRIEVE_FACTORY_DEFAULTS): button.button_schema(
             HeltecButton,
             icon=ICON_RETRIEVE_FACTORY_DEFAULTS,
-        ).extend(cv.COMPONENT_SCHEMA),
+        ),
     }
 )
 

--- a/components/heltec_balancer_ble/switch/__init__.py
+++ b/components/heltec_balancer_ble/switch/__init__.py
@@ -30,7 +30,7 @@ CONFIG_SCHEMA = HELTEC_BALANCER_BLE_COMPONENT_SCHEMA.extend(
         cv.Optional(CONF_BALANCER): switch.switch_schema(
             HeltecSwitch,
             icon=ICON_BALANCER,
-        ).extend(cv.COMPONENT_SCHEMA),
+        ),
     }
 )
 

--- a/components/jk_balancer/switch/__init__.py
+++ b/components/jk_balancer/switch/__init__.py
@@ -24,7 +24,7 @@ CONFIG_SCHEMA = JK_BALANCER_COMPONENT_SCHEMA.extend(
         cv.Optional(CONF_BALANCER): switch.switch_schema(
             JkSwitch,
             icon=ICON_BALANCER,
-        ).extend(cv.COMPONENT_SCHEMA),
+        ),
     }
 )
 

--- a/components/jk_bms/switch/__init__.py
+++ b/components/jk_bms/switch/__init__.py
@@ -28,15 +28,15 @@ CONFIG_SCHEMA = JK_BMS_COMPONENT_SCHEMA.extend(
         cv.Optional(CONF_CHARGING): switch.switch_schema(
             JkSwitch,
             icon=ICON_CHARGING,
-        ).extend(cv.COMPONENT_SCHEMA),
+        ),
         cv.Optional(CONF_DISCHARGING): switch.switch_schema(
             JkSwitch,
             icon=ICON_DISCHARGING,
-        ).extend(cv.COMPONENT_SCHEMA),
+        ),
         # cv.Optional(CONF_BALANCER): switch.switch_schema(
         #     JkSwitch,
         #     icon=ICON_BALANCER,
-        # ).extend(cv.COMPONENT_SCHEMA),
+        # ),
     }
 )
 

--- a/components/jk_bms_ble/button/__init__.py
+++ b/components/jk_bms_ble/button/__init__.py
@@ -28,11 +28,11 @@ CONFIG_SCHEMA = JK_BMS_BLE_COMPONENT_SCHEMA.extend(
         cv.Optional(CONF_RETRIEVE_SETTINGS): button.button_schema(
             JkButton,
             icon=ICON_RETRIEVE_SETTINGS,
-        ).extend(cv.COMPONENT_SCHEMA),
+        ),
         cv.Optional(CONF_RETRIEVE_DEVICE_INFO): button.button_schema(
             JkButton,
             icon=ICON_RETRIEVE_DEVICE_INFO,
-        ).extend(cv.COMPONENT_SCHEMA),
+        ),
     }
 )
 

--- a/components/jk_bms_ble/switch/__init__.py
+++ b/components/jk_bms_ble/switch/__init__.py
@@ -56,47 +56,47 @@ CONFIG_SCHEMA = JK_BMS_BLE_COMPONENT_SCHEMA.extend(
         cv.Optional(CONF_CHARGING): switch.switch_schema(
             JkSwitch,
             icon=ICON_CHARGING,
-        ).extend(cv.COMPONENT_SCHEMA),
+        ),
         cv.Optional(CONF_DISCHARGING): switch.switch_schema(
             JkSwitch,
             icon=ICON_DISCHARGING,
-        ).extend(cv.COMPONENT_SCHEMA),
+        ),
         cv.Optional(CONF_BALANCER): switch.switch_schema(
             JkSwitch,
             icon=ICON_BALANCER,
-        ).extend(cv.COMPONENT_SCHEMA),
+        ),
         cv.Optional(CONF_EMERGENCY): switch.switch_schema(
             JkSwitch,
             icon=ICON_EMERGENCY,
-        ).extend(cv.COMPONENT_SCHEMA),
+        ),
         cv.Optional(CONF_HEATING): switch.switch_schema(
             JkSwitch,
             icon=ICON_HEATING,
-        ).extend(cv.COMPONENT_SCHEMA),
+        ),
         cv.Optional(CONF_DISABLE_TEMPERATURE_SENSORS): switch.switch_schema(
             JkSwitch,
             icon=ICON_DISABLE_TEMPERATURE_SENSORS,
-        ).extend(cv.COMPONENT_SCHEMA),
+        ),
         cv.Optional(CONF_DISPLAY_ALWAYS_ON): switch.switch_schema(
             JkSwitch,
             icon=ICON_DISPLAY_ALWAYS_ON,
-        ).extend(cv.COMPONENT_SCHEMA),
+        ),
         cv.Optional(CONF_SMART_SLEEP): switch.switch_schema(
             JkSwitch,
             icon=ICON_SMART_SLEEP,
-        ).extend(cv.COMPONENT_SCHEMA),
+        ),
         cv.Optional(CONF_DISABLE_PCL_MODULE): switch.switch_schema(
             JkSwitch,
             icon=ICON_DISABLE_PCL_MODULE,
-        ).extend(cv.COMPONENT_SCHEMA),
+        ),
         cv.Optional(CONF_TIMED_STORED_DATA): switch.switch_schema(
             JkSwitch,
             icon=ICON_TIMED_STORED_DATA,
-        ).extend(cv.COMPONENT_SCHEMA),
+        ),
         cv.Optional(CONF_CHARGING_FLOAT_MODE): switch.switch_schema(
             JkSwitch,
             icon=ICON_CHARGING_FLOAT_MODE,
-        ).extend(cv.COMPONENT_SCHEMA),
+        ),
     }
 )
 


### PR DESCRIPTION
## Summary
- Remove `.extend(cv.COMPONENT_SCHEMA)` from all `switch.switch_schema()` and `button.button_schema()` calls
- `switch_schema()` and `button_schema()` include the component schema internally since ESPHome ~2023 — the explicit `.extend()` is redundant