### PR TITLE
Use new_text_sensor() instead of deprecated register_text_sensor

### DIFF
--- a/components/heltec_balancer_ble/text_sensor.py
+++ b/components/heltec_balancer_ble/text_sensor.py
@@ -1,7 +1,7 @@
 import esphome.codegen as cg
 from esphome.components import text_sensor
 import esphome.config_validation as cv
-from esphome.const import CONF_ID, ICON_TIMELAPSE
+from esphome.const import ICON_TIMELAPSE
 
 from . import CONF_HELTEC_BALANCER_BLE_ID, HELTEC_BALANCER_BLE_COMPONENT_SCHEMA
 
@@ -52,6 +52,5 @@ async def to_code(config):
     for key in TEXT_SENSORS:
         if key in config:
             conf = config[key]
-            sens = cg.new_Pvariable(conf[CONF_ID])
-            await text_sensor.register_text_sensor(sens, conf)
+            sens = await text_sensor.new_text_sensor(conf)
             cg.add(getattr(hub, f"set_{key}_text_sensor")(sens))

--- a/components/jk_balancer/text_sensor.py
+++ b/components/jk_balancer/text_sensor.py
@@ -31,6 +31,5 @@ async def to_code(config):
     for key in TEXT_SENSORS:
         if key in config:
             conf = config[key]
-            sens = cg.new_Pvariable(conf[CONF_ID])
-            await text_sensor.register_text_sensor(sens, conf)
+            sens = await text_sensor.new_text_sensor(conf)
             cg.add(getattr(hub, f"set_{key}_text_sensor")(sens))

--- a/components/jk_balancer/text_sensor.py
+++ b/components/jk_balancer/text_sensor.py
@@ -1,7 +1,6 @@
 import esphome.codegen as cg
 from esphome.components import text_sensor
 import esphome.config_validation as cv
-from esphome.const import CONF_ID
 
 from . import CONF_JK_BALANCER_ID, JK_BALANCER_COMPONENT_SCHEMA
 

--- a/components/jk_bms/text_sensor.py
+++ b/components/jk_bms/text_sensor.py
@@ -1,7 +1,7 @@
 import esphome.codegen as cg
 from esphome.components import text_sensor
 import esphome.config_validation as cv
-from esphome.const import CONF_ID, CONF_PASSWORD, ICON_EMPTY, ICON_TIMELAPSE
+from esphome.const import CONF_PASSWORD, ICON_EMPTY, ICON_TIMELAPSE
 
 from . import CONF_JK_BMS_ID, JK_BMS_COMPONENT_SCHEMA
 
@@ -68,6 +68,5 @@ async def to_code(config):
     for key in TEXT_SENSORS:
         if key in config:
             conf = config[key]
-            sens = cg.new_Pvariable(conf[CONF_ID])
-            await text_sensor.register_text_sensor(sens, conf)
+            sens = await text_sensor.new_text_sensor(conf)
             cg.add(getattr(hub, f"set_{key}_text_sensor")(sens))

--- a/components/jk_bms_ble/text_sensor.py
+++ b/components/jk_bms_ble/text_sensor.py
@@ -1,7 +1,7 @@
 import esphome.codegen as cg
 from esphome.components import text_sensor
 import esphome.config_validation as cv
-from esphome.const import CONF_ID, ICON_EMPTY, ICON_TIMELAPSE
+from esphome.const import ICON_EMPTY, ICON_TIMELAPSE
 
 from . import CONF_JK_BMS_BLE_ID, JK_BMS_BLE_COMPONENT_SCHEMA
 
@@ -58,6 +58,5 @@ async def to_code(config):
     for key in TEXT_SENSORS:
         if key in config:
             conf = config[key]
-            sens = cg.new_Pvariable(conf[CONF_ID])
-            await text_sensor.register_text_sensor(sens, conf)
+            sens = await text_sensor.new_text_sensor(conf)
             cg.add(getattr(hub, f"set_{key}_text_sensor")(sens))


### PR DESCRIPTION
## Summary
- Replace `cg.new_Pvariable(conf[CONF_ID])` + `await text_sensor.register_text_sensor(sens, conf)` with the modern `await text_sensor.new_text_sensor(conf)`
- Remove now-unused `CONF_ID` imports where applicable
- Aligns with the pattern already used in `sensor.py` via `await sensor.new_sensor(conf)`