### PR TITLE
Add missing CODEOWNERS to platform files

### DIFF
--- a/components/jk_balancer_modbus/__init__.py
+++ b/components/jk_balancer_modbus/__init__.py
@@ -4,6 +4,7 @@ import esphome.config_validation as cv
 from esphome.const import CONF_ADDRESS, CONF_ID
 
 DEPENDENCIES = ["uart"]
+CODEOWNERS = ["@syssi"]
 MULTI_CONF = True
 
 jk_balancer_modbus_ns = cg.esphome_ns.namespace("jk_balancer_modbus")

--- a/components/jk_modbus/__init__.py
+++ b/components/jk_modbus/__init__.py
@@ -6,6 +6,7 @@ from esphome.const import CONF_ADDRESS, CONF_FLOW_CONTROL_PIN, CONF_ID
 from esphome.cpp_helpers import gpio_pin_expression
 
 DEPENDENCIES = ["uart"]
+CODEOWNERS = ["@syssi"]
 MULTI_CONF = True
 
 jk_modbus_ns = cg.esphome_ns.namespace("jk_modbus")


### PR DESCRIPTION
Add `CODEOWNERS = ["@syssi"]` to `jk_modbus/__init__.py` and `jk_balancer_modbus/__init__.py` for consistency with other ESPHome components.