### PR TITLE
Initialize BLE char handle members to 0

### DIFF
--- a/components/heltec_balancer_ble/heltec_balancer_ble.h
+++ b/components/heltec_balancer_ble/heltec_balancer_ble.h
@@ -191,7 +191,7 @@ class HeltecBalancerBle : public esphome::ble_client::BLEClientNode, public Poll
   std::vector<uint8_t> frame_buffer_;
   bool status_notification_received_ = false;
   uint8_t no_response_count_{0};
-  uint16_t char_handle_;
+  uint16_t char_handle_{0};
   uint32_t last_cell_info_{0};
   uint32_t throttle_;
 

--- a/components/jk_bms_ble/jk_bms_ble.h
+++ b/components/jk_bms_ble/jk_bms_ble.h
@@ -421,8 +421,8 @@ class JkBmsBle : public esphome::ble_client::BLEClientNode, public PollingCompon
   std::vector<uint8_t> frame_buffer_;
   bool status_notification_received_ = false;
   uint8_t no_response_count_{0};
-  uint16_t char_handle_;
-  uint16_t notify_handle_;
+  uint16_t char_handle_{0};
+  uint16_t notify_handle_{0};
   uint32_t last_cell_info_{0};
   uint32_t throttle_;
 


### PR DESCRIPTION
## Summary

- `char_handle_` and `notify_handle_` in `jk_bms_ble` and `char_handle_` in `heltec_balancer_ble` were declared without initializers, leaving them with indeterminate values from construction until the first BLE connection.
- Adds `{0}` in-class member initializers to guarantee a defined state at construction.