### PR TITLE
Fix text_sensor_schema positional arg and add diagnostic entity categories

### DIFF
--- a/components/heltec_balancer_ble/text_sensor.py
+++ b/components/heltec_balancer_ble/text_sensor.py
@@ -1,7 +1,7 @@
 import esphome.codegen as cg
 from esphome.components import text_sensor
 import esphome.config_validation as cv
-from esphome.const import ICON_TIMELAPSE
+from esphome.const import ENTITY_CATEGORY_DIAGNOSTIC, ICON_TIMELAPSE
 
 from . import CONF_HELTEC_BALANCER_BLE_ID, HELTEC_BALANCER_BLE_COMPONENT_SCHEMA
 
@@ -29,19 +29,21 @@ TEXT_SENSORS = [
 CONFIG_SCHEMA = HELTEC_BALANCER_BLE_COMPONENT_SCHEMA.extend(
     {
         cv.Optional(CONF_ERRORS): text_sensor.text_sensor_schema(
-            text_sensor.TextSensor, icon=ICON_ERRORS
+            icon=ICON_ERRORS,
+            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
         ),
         cv.Optional(CONF_OPERATION_STATUS): text_sensor.text_sensor_schema(
-            text_sensor.TextSensor, icon=ICON_OPERATION_STATUS
+            icon=ICON_OPERATION_STATUS
         ),
         cv.Optional(CONF_TOTAL_RUNTIME_FORMATTED): text_sensor.text_sensor_schema(
-            text_sensor.TextSensor, icon=ICON_TIMELAPSE
+            icon=ICON_TIMELAPSE
         ),
         cv.Optional(CONF_BUZZER_MODE): text_sensor.text_sensor_schema(
-            text_sensor.TextSensor, icon=ICON_OPERATION_STATUS
+            icon=ICON_OPERATION_STATUS
         ),
         cv.Optional(CONF_BATTERY_TYPE): text_sensor.text_sensor_schema(
-            text_sensor.TextSensor, icon=ICON_OPERATION_STATUS
+            icon=ICON_OPERATION_STATUS,
+            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
         ),
     }
 )

--- a/components/jk_balancer/text_sensor.py
+++ b/components/jk_balancer/text_sensor.py
@@ -1,6 +1,7 @@
 import esphome.codegen as cg
 from esphome.components import text_sensor
 import esphome.config_validation as cv
+from esphome.const import ENTITY_CATEGORY_DIAGNOSTIC
 
 from . import CONF_JK_BALANCER_ID, JK_BALANCER_COMPONENT_SCHEMA
 
@@ -19,7 +20,8 @@ TEXT_SENSORS = [
 CONFIG_SCHEMA = JK_BALANCER_COMPONENT_SCHEMA.extend(
     {
         cv.Optional(CONF_ERRORS): text_sensor.text_sensor_schema(
-            text_sensor.TextSensor, icon=ICON_ERRORS
+            icon=ICON_ERRORS,
+            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
         ),
     }
 )

--- a/components/jk_bms/text_sensor.py
+++ b/components/jk_bms/text_sensor.py
@@ -1,7 +1,12 @@
 import esphome.codegen as cg
 from esphome.components import text_sensor
 import esphome.config_validation as cv
-from esphome.const import CONF_PASSWORD, ICON_EMPTY, ICON_TIMELAPSE
+from esphome.const import (
+    CONF_PASSWORD,
+    ENTITY_CATEGORY_DIAGNOSTIC,
+    ICON_EMPTY,
+    ICON_TIMELAPSE,
+)
 
 from . import CONF_JK_BMS_ID, JK_BMS_COMPONENT_SCHEMA
 
@@ -36,28 +41,30 @@ TEXT_SENSORS = [
 CONFIG_SCHEMA = JK_BMS_COMPONENT_SCHEMA.extend(
     {
         cv.Optional(CONF_OPERATION_MODE): text_sensor.text_sensor_schema(
-            text_sensor.TextSensor, icon=ICON_OPERATION_MODE
+            icon=ICON_OPERATION_MODE
         ),
         cv.Optional(CONF_ERRORS): text_sensor.text_sensor_schema(
-            text_sensor.TextSensor, icon=ICON_ERRORS
+            icon=ICON_ERRORS,
+            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
         ),
         cv.Optional(CONF_BATTERY_TYPE): text_sensor.text_sensor_schema(
-            text_sensor.TextSensor, icon=ICON_BATTERY_TYPE
+            icon=ICON_BATTERY_TYPE
         ),
-        cv.Optional(CONF_PASSWORD): text_sensor.text_sensor_schema(
-            text_sensor.TextSensor, icon=ICON_PASSWORD
-        ),
+        cv.Optional(CONF_PASSWORD): text_sensor.text_sensor_schema(icon=ICON_PASSWORD),
         cv.Optional(CONF_DEVICE_TYPE): text_sensor.text_sensor_schema(
-            text_sensor.TextSensor, icon=ICON_EMPTY
+            icon=ICON_EMPTY,
+            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
         ),
         cv.Optional(CONF_SOFTWARE_VERSION): text_sensor.text_sensor_schema(
-            text_sensor.TextSensor, icon=ICON_EMPTY
+            icon=ICON_EMPTY,
+            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
         ),
         cv.Optional(CONF_MANUFACTURER): text_sensor.text_sensor_schema(
-            text_sensor.TextSensor, icon=ICON_EMPTY
+            icon=ICON_EMPTY,
+            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
         ),
         cv.Optional(CONF_TOTAL_RUNTIME_FORMATTED): text_sensor.text_sensor_schema(
-            text_sensor.TextSensor, icon=ICON_TIMELAPSE
+            icon=ICON_TIMELAPSE
         ),
     }
 )

--- a/components/jk_bms_ble/text_sensor.py
+++ b/components/jk_bms_ble/text_sensor.py
@@ -1,7 +1,7 @@
 import esphome.codegen as cg
 from esphome.components import text_sensor
 import esphome.config_validation as cv
-from esphome.const import ICON_EMPTY, ICON_TIMELAPSE
+from esphome.const import ENTITY_CATEGORY_DIAGNOSTIC, ICON_EMPTY, ICON_TIMELAPSE
 
 from . import CONF_JK_BMS_BLE_ID, JK_BMS_BLE_COMPONENT_SCHEMA
 
@@ -32,22 +32,25 @@ TEXT_SENSORS = [
 CONFIG_SCHEMA = JK_BMS_BLE_COMPONENT_SCHEMA.extend(
     {
         cv.Optional(CONF_ERRORS): text_sensor.text_sensor_schema(
-            text_sensor.TextSensor, icon=ICON_ERRORS
+            icon=ICON_ERRORS,
+            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
         ),
         cv.Optional(CONF_OPERATION_STATUS): text_sensor.text_sensor_schema(
-            text_sensor.TextSensor, icon=ICON_OPERATION_STATUS
+            icon=ICON_OPERATION_STATUS
         ),
         cv.Optional(CONF_TOTAL_RUNTIME_FORMATTED): text_sensor.text_sensor_schema(
-            text_sensor.TextSensor, icon=ICON_TIMELAPSE
+            icon=ICON_TIMELAPSE
         ),
         cv.Optional(CONF_CHARGE_STATUS): text_sensor.text_sensor_schema(
-            text_sensor.TextSensor, icon=ICON_CHARGE_STATUS
+            icon=ICON_CHARGE_STATUS
         ),
         cv.Optional(CONF_SOFTWARE_VERSION): text_sensor.text_sensor_schema(
-            text_sensor.TextSensor, icon=ICON_EMPTY
+            icon=ICON_EMPTY,
+            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
         ),
         cv.Optional(CONF_HARDWARE_VERSION): text_sensor.text_sensor_schema(
-            text_sensor.TextSensor, icon=ICON_EMPTY
+            icon=ICON_EMPTY,
+            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
         ),
     }
 )


### PR DESCRIPTION
## Summary

- Remove positional `text_sensor.TextSensor` argument from `text_sensor_schema(...)` calls in all four components (T1)
- Add `entity_category=ENTITY_CATEGORY_DIAGNOSTIC` to diagnostic sensors: `errors`, `device_type`, `software_version`, `hardware_version`, `manufacturer`, `battery_type` (T2)

Follows the pattern established in `esphome-tianpower-bms`.