### PR TITLE
Fix out-of-bounds reads and division by zero on malformed frames

### DIFF
--- a/components/heltec_balancer_ble/heltec_balancer_ble.cpp
+++ b/components/heltec_balancer_ble/heltec_balancer_ble.cpp
@@ -279,7 +279,7 @@ void HeltecBalancerBle::assemble(const uint8_t *data, uint16_t length) {
   }
 
   // Flush buffer on every preamble
-  if (data[0] == SOF_RESPONSE_BYTE1 && data[1] == SOF_RESPONSE_BYTE2) {
+  if (length >= 2 && data[0] == SOF_RESPONSE_BYTE1 && data[1] == SOF_RESPONSE_BYTE2) {
     this->frame_buffer_.clear();
   }
 

--- a/components/jk_bms/jk_bms.cpp
+++ b/components/jk_bms/jk_bms.cpp
@@ -106,7 +106,7 @@ void JkBms::on_status_data_(const std::vector<uint8_t> &data) {
   // 0x0E 0x0E 0xF2: Cell 14        3826 * 0.001 = 3.826V                        0.001 V
   uint8_t cells = data[1] / 3;
 
-  if (data.size() < (size_t)(data[1] + 223)) {
+  if (data.size() < (size_t) (data[1] + 223)) {
     ESP_LOGW(TAG, "Status frame too short (%zu bytes) for %d cells", data.size(), cells);
     return;
   }

--- a/components/jk_bms/jk_bms.cpp
+++ b/components/jk_bms/jk_bms.cpp
@@ -54,6 +54,10 @@ void JkBms::on_jk_modbus_data(const uint8_t &function, const std::vector<uint8_t
   }
 
   if (function == FUNCTION_WRITE_REGISTER) {
+    if (data.empty()) {
+      ESP_LOGW(TAG, "Write register response is empty");
+      return;
+    }
     ESP_LOGI(TAG, "Register 0x%02X updated", data[0]);
     return;
   }
@@ -68,7 +72,12 @@ void JkBms::on_status_data_(const std::vector<uint8_t> &data) {
     return (uint32_t(jk_get_16bit(i + 0)) << 16) | (uint32_t(jk_get_16bit(i + 2)) << 0);
   };
 
-  ESP_LOGI(TAG, "Status frame received");
+  ESP_LOGI(TAG, "Status frame (%zu bytes) received", data.size());
+
+  if (data.size() < 2) {
+    ESP_LOGW(TAG, "Status frame too short (%zu bytes)", data.size());
+    return;
+  }
 
   // Status request
   // -> 0x4E 0x57 0x00 0x13 0x00 0x00 0x00 0x00 0x06 0x03 0x00 0x00 0x00 0x00 0x00 0x00 0x68 0x00 0x00 0x01 0x29
@@ -97,6 +106,11 @@ void JkBms::on_status_data_(const std::vector<uint8_t> &data) {
   // 0x0E 0x0E 0xF2: Cell 14        3826 * 0.001 = 3.826V                        0.001 V
   uint8_t cells = data[1] / 3;
 
+  if (data.size() < (size_t)(data[1] + 223)) {
+    ESP_LOGW(TAG, "Status frame too short (%zu bytes) for %d cells", data.size(), cells);
+    return;
+  }
+
   float min_cell_voltage = 100.0f;
   float max_cell_voltage = -100.0f;
   float average_cell_voltage = 0.0f;
@@ -115,7 +129,8 @@ void JkBms::on_status_data_(const std::vector<uint8_t> &data) {
     }
     this->publish_state_(this->cells_[i].cell_voltage_sensor_, cell_voltage);
   }
-  average_cell_voltage = average_cell_voltage / cells;
+  if (cells > 0)
+    average_cell_voltage = average_cell_voltage / cells;
 
   this->publish_state_(this->min_cell_voltage_sensor_, min_cell_voltage);
   this->publish_state_(this->max_cell_voltage_sensor_, max_cell_voltage);

--- a/components/jk_bms_ble/jk_bms_ble.cpp
+++ b/components/jk_bms_ble/jk_bms_ble.cpp
@@ -307,7 +307,7 @@ void JkBmsBle::assemble(const uint8_t *data, uint16_t length) {
   }
 
   // Flush buffer on every preamble
-  if (data[0] == 0x55 && data[1] == 0xAA && data[2] == 0xEB && data[3] == 0x90) {
+  if (length >= 4 && data[0] == 0x55 && data[1] == 0xAA && data[2] == 0xEB && data[3] == 0x90) {
     this->frame_buffer_.clear();
   }
 


### PR DESCRIPTION
## Summary

- **jk_bms_ble**, **heltec_balancer_ble**: guard the preamble check in `assemble()` with a length check before accessing the raw BLE notification bytes. A notification shorter than the preamble (4 / 2 bytes respectively) caused an out-of-bounds read on the incoming data pointer.
- **jk_bms**: guard `on_jk_modbus_data()` against an empty write-register response; add a size check in `on_status_data_()` that validates the frame is large enough to cover the variable-length cell section plus all fixed trailing fields; guard the average cell voltage division against a zero cell count.

Mirrors ESPHome core batch fixes [#14643](https://github.com/esphome/esphome/pull/14643) and [#14651](https://github.com/esphome/esphome/pull/14651) ("Fix crashes from malformed external input").

## Test plan

- [x] Verify normal BLE operation with a JK BMS device is unaffected
- [x] Verify normal BLE operation with a Heltec balancer is unaffected
- [x] Verify normal Modbus operation with a JK BMS device is unaffected