### PR TITLE
Replace static const char arrays with constexpr

### DIFF
--- a/components/heltec_balancer_ble/heltec_balancer_ble.cpp
+++ b/components/heltec_balancer_ble/heltec_balancer_ble.cpp
@@ -42,7 +42,7 @@ static const uint16_t MIN_RESPONSE_SIZE = 20;   // Write acknowledge frame
 static const uint16_t MAX_RESPONSE_SIZE = 300;  // Cell info frame
 
 static const uint8_t OPERATION_STATUS_SIZE = 13;
-static const char *const OPERATION_STATUS[OPERATION_STATUS_SIZE] = {
+static constexpr const char *const OPERATION_STATUS[OPERATION_STATUS_SIZE] = {
     "Unknown",                                   // 0x00
     "Wrong cell count",                          // 0x01
     "AcqLine Res test",                          // 0x02
@@ -59,7 +59,7 @@ static const char *const OPERATION_STATUS[OPERATION_STATUS_SIZE] = {
 };
 
 static const uint8_t BUZZER_MODES_SIZE = 4;
-static const char *const BUZZER_MODES[BUZZER_MODES_SIZE] = {
+static constexpr const char *const BUZZER_MODES[BUZZER_MODES_SIZE] = {
     "Unknown",       // 0x00
     "Off",           // 0x01
     "Beep once",     // 0x02
@@ -67,7 +67,7 @@ static const char *const BUZZER_MODES[BUZZER_MODES_SIZE] = {
 };
 
 static const uint8_t BATTERY_TYPES_SIZE = 5;
-static const char *const BATTERY_TYPES[BATTERY_TYPES_SIZE] = {
+static constexpr const char *const BATTERY_TYPES[BATTERY_TYPES_SIZE] = {
     "Unknown",  // 0x00
     "NCM",      // 0x01
     "LFP",      // 0x02
@@ -76,7 +76,7 @@ static const char *const BATTERY_TYPES[BATTERY_TYPES_SIZE] = {
 };
 
 static const uint8_t CELL_ERRORS_SIZE = 8;
-static const char *const CELL_ERRORS[CELL_ERRORS_SIZE] = {
+static constexpr const char *const CELL_ERRORS[CELL_ERRORS_SIZE] = {
     "Battery detection failed",  "Overvoltage",        "Undervoltage",   "Polarity error",
     "Excessive line resistance", "System overheating", "Charging fault", "Discharge fault",
 };

--- a/components/jk_balancer/jk_balancer.cpp
+++ b/components/jk_balancer/jk_balancer.cpp
@@ -15,7 +15,7 @@ static const uint8_t FUNCTION_SET_TRIGGER_VOLTAGE = 0xF2;
 static const uint8_t FUNCTION_SET_MAX_BALANCE_CURRENT = 0xF4;
 
 static const uint8_t ERRORS_SIZE = 3;
-static const char *const ERRORS[ERRORS_SIZE] = {
+static constexpr const char *const ERRORS[ERRORS_SIZE] = {
     "Wrong cell count",
     "Resistance too high",
     "Overvoltage",

--- a/components/jk_bms/jk_bms.cpp
+++ b/components/jk_bms/jk_bms.cpp
@@ -13,7 +13,7 @@ static const uint8_t FUNCTION_READ_ALL = 0x06;
 static const uint8_t FUNCTION_WRITE_REGISTER = 0x02;
 
 static const uint8_t ERRORS_SIZE = 14;
-static const char *const ERRORS[ERRORS_SIZE] = {
+static constexpr const char *const ERRORS[ERRORS_SIZE] = {
     "Low capacity",                              // Byte 0.0, warning
     "Power tube overtemperature",                // Byte 0.1, alarm
     "Charging overvoltage",                      // Byte 0.2, alarm
@@ -31,7 +31,7 @@ static const char *const ERRORS[ERRORS_SIZE] = {
 };
 
 static const uint8_t OPERATION_MODES_SIZE = 4;
-static const char *const OPERATION_MODES[OPERATION_MODES_SIZE] = {
+static constexpr const char *const OPERATION_MODES[OPERATION_MODES_SIZE] = {
     "Charging enabled",     // 0x00
     "Discharging enabled",  // 0x01
     "Balancer enabled",     // 0x02
@@ -39,7 +39,7 @@ static const char *const OPERATION_MODES[OPERATION_MODES_SIZE] = {
 };
 
 static const uint8_t BATTERY_TYPES_SIZE = 3;
-static const char *const BATTERY_TYPES[BATTERY_TYPES_SIZE] = {
+static constexpr const char *const BATTERY_TYPES[BATTERY_TYPES_SIZE] = {
     "Lithium Iron Phosphate",  // 0x00
     "Ternary Lithium",         // 0x01
     "Lithium Titanate",        // 0x02

--- a/components/jk_bms_ble/jk_bms_ble.cpp
+++ b/components/jk_bms_ble/jk_bms_ble.cpp
@@ -31,7 +31,7 @@ static const uint16_t MIN_RESPONSE_SIZE = 300;
 static const uint16_t MAX_RESPONSE_SIZE = 384 + 16;
 
 static const uint8_t ERRORS_SIZE = 16;
-static const char *const ERRORS[ERRORS_SIZE] = {
+static constexpr const char *const ERRORS[ERRORS_SIZE] = {
     "Charge Overtemperature",               // 0000 0000 0000 0001
     "Charge Undertemperature",              // 0000 0000 0000 0010
     "Coprocessor communication error",      // 0000 0000 0000 0100


### PR DESCRIPTION
## Summary

Replace `static const char *const` array declarations with `static constexpr const char *const` in all affected components.

Using `static constexpr const char *const` for string arrays ensures that the data is placed in the read-only segment (Flash) at compile time rather than occupying RAM at runtime. This is consistent with the ESPHome core coding style, as seen for example in `bme68x_bsec2.cpp`.

**Affected files:**
- `components/jk_bms/jk_bms.cpp` (ERRORS, OPERATION_MODES, BATTERY_TYPES)
- `components/jk_balancer/jk_balancer.cpp` (ERRORS)
- `components/heltec_balancer_ble/heltec_balancer_ble.cpp` (OPERATION_STATUS, BUZZER_MODES, BATTERY_TYPES, CELL_ERRORS)
- `components/jk_bms_ble/jk_bms_ble.cpp` (ERRORS)