### PR TITLE
Fix BLE scanner UUID API for ESPHome 2026.4.0

### DIFF
--- a/esp32-ble-scanner.yaml
+++ b/esp32-ble-scanner.yaml
@@ -41,9 +41,9 @@ esp32_ble_tracker:
             ESP_LOGI("ble_adv", "  Name: %s", x.get_name().c_str());
             ESP_LOGI("ble_adv", "  MAC address: %s", x.address_str().c_str());
             ESP_LOGD("ble_adv", "  Advertised service UUIDs:");
+            char uuidstr[esphome::esp32_ble::UUID_STR_LEN];
             for (auto uuid : x.get_service_uuids()) {
-              char buf[ESPBTUUID::UUID_STR_LEN];
-              ESP_LOGD("ble_adv", "    - %s", uuid.to_str(buf));
+              ESP_LOGD("ble_adv", "    - %s", uuid.to_str(uuidstr));
             }
           }
 

--- a/esp32-ble-scanner.yaml
+++ b/esp32-ble-scanner.yaml
@@ -6,6 +6,7 @@ esphome:
   name: ${name}
   friendly_name: ${name}
   comment: ${device_description}
+  min_version: "2026.1.0"
   project:
     name: "syssi.esphome-jk-bms"
     version: 2.4.0

--- a/esp32-heltec-balancer-ble-scanner.yaml
+++ b/esp32-heltec-balancer-ble-scanner.yaml
@@ -41,9 +41,9 @@ esp32_ble_tracker:
             ESP_LOGI("ble_adv", "  Name: %s", x.get_name().c_str());
             ESP_LOGI("ble_adv", "  MAC address: %s", x.address_str().c_str());
             ESP_LOGD("ble_adv", "  Advertised service UUIDs:");
+            char uuidstr[esphome::esp32_ble::UUID_STR_LEN];
             for (auto uuid : x.get_service_uuids()) {
-              char buf[ESPBTUUID::UUID_STR_LEN];
-              ESP_LOGD("ble_adv", "    - %s", uuid.to_str(buf));
+              ESP_LOGD("ble_adv", "    - %s", uuid.to_str(uuidstr));
             }
           }
 

--- a/esp32-heltec-balancer-ble-scanner.yaml
+++ b/esp32-heltec-balancer-ble-scanner.yaml
@@ -6,6 +6,7 @@ esphome:
   name: ${name}
   friendly_name: ${name}
   comment: ${device_description}
+  min_version: "2026.1.0"
   project:
     name: "syssi.esphome-jk-bms"
     version: 2.4.0


### PR DESCRIPTION
Fix BLE scanner UUID API compatibility with ESPHome 2026.4.0

 was removed in ESPHome 2026.4.0. Replace with  and move the buffer declaration outside the loop.

Reported in: https://github.com/syssi/esphome-jk-bms/issues/936