### PR TITLE
Use C++17 concatenated namespace syntax

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -96,7 +96,6 @@ Checks: >-
   -modernize-avoid-variadic-functions,
   -modernize-avoid-c-arrays,
   -modernize-avoid-c-style-cast,
-  -modernize-concat-nested-namespaces,
   -modernize-macro-to-enum,
   -modernize-return-braced-init-list,
   -modernize-type-traits,

--- a/components/heltec_balancer_ble/button/heltec_button.cpp
+++ b/components/heltec_balancer_ble/button/heltec_button.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/log.h"
 #include "esphome/core/application.h"
 
-namespace esphome {
-namespace heltec_balancer_ble {
+namespace esphome::heltec_balancer_ble {
 
 static const char *const TAG = "heltec_balancer_ble.button";
 
@@ -12,5 +11,4 @@ static const uint8_t FUNCTION_READ = 0x01;
 void HeltecButton::dump_config() { LOG_BUTTON("", "HeltecBalancerBle Button", this); }
 void HeltecButton::press_action() { this->parent_->send_command(FUNCTION_READ, this->holding_register_); }
 
-}  // namespace heltec_balancer_ble
-}  // namespace esphome
+}  // namespace esphome::heltec_balancer_ble

--- a/components/heltec_balancer_ble/button/heltec_button.h
+++ b/components/heltec_balancer_ble/button/heltec_button.h
@@ -4,8 +4,7 @@
 #include "esphome/core/component.h"
 #include "esphome/components/button/button.h"
 
-namespace esphome {
-namespace heltec_balancer_ble {
+namespace esphome::heltec_balancer_ble {
 
 class HeltecBalancerBle;
 class HeltecButton : public button::Button, public Component {
@@ -22,5 +21,4 @@ class HeltecButton : public button::Button, public Component {
   uint8_t holding_register_;
 };
 
-}  // namespace heltec_balancer_ble
-}  // namespace esphome
+}  // namespace esphome::heltec_balancer_ble

--- a/components/heltec_balancer_ble/heltec_balancer_ble.cpp
+++ b/components/heltec_balancer_ble/heltec_balancer_ble.cpp
@@ -8,8 +8,7 @@
 #define ADDR_STR(x) (x).c_str()
 #endif
 
-namespace esphome {
-namespace heltec_balancer_ble {
+namespace esphome::heltec_balancer_ble {
 
 static const char *const TAG = "heltec_balancer_ble";
 
@@ -931,5 +930,4 @@ void HeltecBalancerBle::publish_state_(text_sensor::TextSensor *text_sensor, con
   text_sensor->publish_state(state);
 }
 
-}  // namespace heltec_balancer_ble
-}  // namespace esphome
+}  // namespace esphome::heltec_balancer_ble

--- a/components/heltec_balancer_ble/heltec_balancer_ble.h
+++ b/components/heltec_balancer_ble/heltec_balancer_ble.h
@@ -15,8 +15,7 @@
 #include <esp_gattc_api.h>
 #endif
 
-namespace esphome {
-namespace heltec_balancer_ble {
+namespace esphome::heltec_balancer_ble {
 
 #ifdef USE_ESP32
 namespace espbt = esphome::esp32_ble_tracker;
@@ -249,5 +248,4 @@ class HeltecBalancerBle :
   }
 };
 
-}  // namespace heltec_balancer_ble
-}  // namespace esphome
+}  // namespace esphome::heltec_balancer_ble

--- a/components/heltec_balancer_ble/number/heltec_number.cpp
+++ b/components/heltec_balancer_ble/number/heltec_number.cpp
@@ -1,8 +1,7 @@
 #include "heltec_number.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace heltec_balancer_ble {
+namespace esphome::heltec_balancer_ble {
 
 static const char *const TAG = "heltec_balancer_ble.number";
 
@@ -18,5 +17,4 @@ void HeltecNumber::control(float value) {
   }
 }
 
-}  // namespace heltec_balancer_ble
-}  // namespace esphome
+}  // namespace esphome::heltec_balancer_ble

--- a/components/heltec_balancer_ble/number/heltec_number.h
+++ b/components/heltec_balancer_ble/number/heltec_number.h
@@ -4,8 +4,7 @@
 #include "esphome/core/component.h"
 #include "esphome/components/number/number.h"
 
-namespace esphome {
-namespace heltec_balancer_ble {
+namespace esphome::heltec_balancer_ble {
 
 class HeltecBalancerBle;
 
@@ -29,5 +28,4 @@ class HeltecNumber : public number::Number, public Component {
   }
 };
 
-}  // namespace heltec_balancer_ble
-}  // namespace esphome
+}  // namespace esphome::heltec_balancer_ble

--- a/components/heltec_balancer_ble/select/heltec_select.cpp
+++ b/components/heltec_balancer_ble/select/heltec_select.cpp
@@ -1,8 +1,7 @@
 #include "heltec_select.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace heltec_balancer_ble {
+namespace esphome::heltec_balancer_ble {
 
 static const char *const TAG = "heltec_balancer_ble.select";
 
@@ -25,5 +24,4 @@ void HeltecSelect::control(const std::string &value) {
   }
 }
 
-}  // namespace heltec_balancer_ble
-}  // namespace esphome
+}  // namespace esphome::heltec_balancer_ble

--- a/components/heltec_balancer_ble/select/heltec_select.h
+++ b/components/heltec_balancer_ble/select/heltec_select.h
@@ -4,8 +4,7 @@
 #include "esphome/core/component.h"
 #include "esphome/components/select/select.h"
 
-namespace esphome {
-namespace heltec_balancer_ble {
+namespace esphome::heltec_balancer_ble {
 
 class HeltecBalancerBle;
 
@@ -22,5 +21,4 @@ class HeltecSelect : public select::Select, public Component {
   uint8_t holding_register_;
 };
 
-}  // namespace heltec_balancer_ble
-}  // namespace esphome
+}  // namespace esphome::heltec_balancer_ble

--- a/components/heltec_balancer_ble/switch/heltec_switch.cpp
+++ b/components/heltec_balancer_ble/switch/heltec_switch.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/log.h"
 #include "esphome/core/application.h"
 
-namespace esphome {
-namespace heltec_balancer_ble {
+namespace esphome::heltec_balancer_ble {
 
 static const char *const TAG = "heltec_balancer_ble.switch";
 
@@ -17,5 +16,4 @@ void HeltecSwitch::write_state(bool state) {
   }
 }
 
-}  // namespace heltec_balancer_ble
-}  // namespace esphome
+}  // namespace esphome::heltec_balancer_ble

--- a/components/heltec_balancer_ble/switch/heltec_switch.h
+++ b/components/heltec_balancer_ble/switch/heltec_switch.h
@@ -4,8 +4,7 @@
 #include "esphome/core/component.h"
 #include "esphome/components/switch/switch.h"
 
-namespace esphome {
-namespace heltec_balancer_ble {
+namespace esphome::heltec_balancer_ble {
 
 class HeltecBalancerBle;
 class HeltecSwitch : public switch_::Switch, public Component {
@@ -22,5 +21,4 @@ class HeltecSwitch : public switch_::Switch, public Component {
   uint8_t holding_register_;
 };
 
-}  // namespace heltec_balancer_ble
-}  // namespace esphome
+}  // namespace esphome::heltec_balancer_ble

--- a/components/jk_balancer/jk_balancer.cpp
+++ b/components/jk_balancer/jk_balancer.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/log.h"
 #include "esphome/core/helpers.h"
 
-namespace esphome {
-namespace jk_balancer {
+namespace esphome::jk_balancer {
 
 static const char *const TAG = "jk_balancer";
 
@@ -300,5 +299,4 @@ void JkBalancer::dump_config() {  // NOLINT(google-readability-function-size,rea
   LOG_TEXT_SENSOR("", "Errors", this->errors_text_sensor_);
 }
 
-}  // namespace jk_balancer
-}  // namespace esphome
+}  // namespace esphome::jk_balancer

--- a/components/jk_balancer/jk_balancer.h
+++ b/components/jk_balancer/jk_balancer.h
@@ -8,8 +8,7 @@
 #include "esphome/components/switch/switch.h"
 #include "esphome/components/jk_balancer_modbus/jk_balancer_modbus.h"
 
-namespace esphome {
-namespace jk_balancer {
+namespace esphome::jk_balancer {
 
 class JkBalancer : public PollingComponent, public jk_balancer_modbus::JkBalancerModbusDevice {
  public:
@@ -122,5 +121,4 @@ class JkBalancer : public PollingComponent, public jk_balancer_modbus::JkBalance
   bool check_bit_(uint16_t mask, uint16_t flag) { return (mask & flag) == flag; }
 };
 
-}  // namespace jk_balancer
-}  // namespace esphome
+}  // namespace esphome::jk_balancer

--- a/components/jk_balancer/number/jk_number.cpp
+++ b/components/jk_balancer/number/jk_number.cpp
@@ -1,8 +1,7 @@
 #include "jk_number.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace jk_balancer {
+namespace esphome::jk_balancer {
 
 static const char *const TAG = "jk_balancer.number";
 
@@ -12,5 +11,4 @@ void JkNumber::control(float value) {
   this->publish_state(value);
 }
 
-}  // namespace jk_balancer
-}  // namespace esphome
+}  // namespace esphome::jk_balancer

--- a/components/jk_balancer/number/jk_number.h
+++ b/components/jk_balancer/number/jk_number.h
@@ -4,8 +4,7 @@
 #include "esphome/core/component.h"
 #include "esphome/components/number/number.h"
 
-namespace esphome {
-namespace jk_balancer {
+namespace esphome::jk_balancer {
 
 class JkBalancer;
 
@@ -22,5 +21,4 @@ class JkNumber : public number::Number, public Component {
   uint8_t holding_register_;
 };
 
-}  // namespace jk_balancer
-}  // namespace esphome
+}  // namespace esphome::jk_balancer

--- a/components/jk_balancer/switch/jk_switch.cpp
+++ b/components/jk_balancer/switch/jk_switch.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/log.h"
 #include "esphome/core/application.h"
 
-namespace esphome {
-namespace jk_balancer {
+namespace esphome::jk_balancer {
 
 static const char *const TAG = "jk_balancer.switch";
 
@@ -13,5 +12,4 @@ void JkSwitch::write_state(bool state) {
   this->publish_state(state);
 }
 
-}  // namespace jk_balancer
-}  // namespace esphome
+}  // namespace esphome::jk_balancer

--- a/components/jk_balancer/switch/jk_switch.h
+++ b/components/jk_balancer/switch/jk_switch.h
@@ -4,8 +4,7 @@
 #include "esphome/core/component.h"
 #include "esphome/components/switch/switch.h"
 
-namespace esphome {
-namespace jk_balancer {
+namespace esphome::jk_balancer {
 
 class JkBalancer;
 class JkSwitch : public switch_::Switch, public Component {
@@ -22,5 +21,4 @@ class JkSwitch : public switch_::Switch, public Component {
   uint8_t holding_register_;
 };
 
-}  // namespace jk_balancer
-}  // namespace esphome
+}  // namespace esphome::jk_balancer

--- a/components/jk_balancer_modbus/jk_balancer_modbus.cpp
+++ b/components/jk_balancer_modbus/jk_balancer_modbus.cpp
@@ -3,8 +3,7 @@
 #include "esphome/core/hal.h"
 #include "esphome/core/helpers.h"
 
-namespace esphome {
-namespace jk_balancer_modbus {
+namespace esphome::jk_balancer_modbus {
 
 static const char *const TAG = "jk_balancer_modbus";
 
@@ -127,5 +126,4 @@ void JkBalancerModbus::send(uint8_t address, uint8_t function, uint16_t value) {
   this->flush();
 }
 
-}  // namespace jk_balancer_modbus
-}  // namespace esphome
+}  // namespace esphome::jk_balancer_modbus

--- a/components/jk_balancer_modbus/jk_balancer_modbus.h
+++ b/components/jk_balancer_modbus/jk_balancer_modbus.h
@@ -3,8 +3,7 @@
 #include "esphome/core/component.h"
 #include "esphome/components/uart/uart.h"
 
-namespace esphome {
-namespace jk_balancer_modbus {
+namespace esphome::jk_balancer_modbus {
 
 class JkBalancerModbusDevice;
 
@@ -47,5 +46,4 @@ class JkBalancerModbusDevice {
   uint8_t address_;
 };
 
-}  // namespace jk_balancer_modbus
-}  // namespace esphome
+}  // namespace esphome::jk_balancer_modbus

--- a/components/jk_bms/jk_bms.cpp
+++ b/components/jk_bms/jk_bms.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/log.h"
 #include "esphome/core/helpers.h"
 
-namespace esphome {
-namespace jk_bms {
+namespace esphome::jk_bms {
 
 static const char *const TAG = "jk_bms";
 
@@ -664,5 +663,4 @@ void JkBms::dump_config() {  // NOLINT(google-readability-function-size,readabil
   LOG_TEXT_SENSOR("", "Errors", this->errors_text_sensor_);
 }
 
-}  // namespace jk_bms
-}  // namespace esphome
+}  // namespace esphome::jk_bms

--- a/components/jk_bms/jk_bms.h
+++ b/components/jk_bms/jk_bms.h
@@ -7,8 +7,7 @@
 #include "esphome/components/switch/switch.h"
 #include "esphome/components/jk_modbus/jk_modbus.h"
 
-namespace esphome {
-namespace jk_bms {
+namespace esphome::jk_bms {
 
 class JkBms : public PollingComponent, public jk_modbus::JkModbusDevice {
  public:
@@ -392,5 +391,4 @@ class JkBms : public PollingComponent, public jk_modbus::JkModbusDevice {
   bool check_bit_(uint16_t mask, uint16_t flag) { return (mask & flag) == flag; }
 };
 
-}  // namespace jk_bms
-}  // namespace esphome
+}  // namespace esphome::jk_bms

--- a/components/jk_bms/switch/jk_switch.cpp
+++ b/components/jk_bms/switch/jk_switch.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/log.h"
 #include "esphome/core/application.h"
 
-namespace esphome {
-namespace jk_bms {
+namespace esphome::jk_bms {
 
 static const char *const TAG = "jk_bms.switch";
 
@@ -13,5 +12,4 @@ void JkSwitch::write_state(bool state) {
   this->publish_state(state);
 }
 
-}  // namespace jk_bms
-}  // namespace esphome
+}  // namespace esphome::jk_bms

--- a/components/jk_bms/switch/jk_switch.h
+++ b/components/jk_bms/switch/jk_switch.h
@@ -4,8 +4,7 @@
 #include "esphome/core/component.h"
 #include "esphome/components/switch/switch.h"
 
-namespace esphome {
-namespace jk_bms {
+namespace esphome::jk_bms {
 
 class JkBms;
 class JkSwitch : public switch_::Switch, public Component {
@@ -22,5 +21,4 @@ class JkSwitch : public switch_::Switch, public Component {
   uint8_t holding_register_;
 };
 
-}  // namespace jk_bms
-}  // namespace esphome
+}  // namespace esphome::jk_bms

--- a/components/jk_bms_ble/button/jk_button.cpp
+++ b/components/jk_bms_ble/button/jk_button.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/log.h"
 #include "esphome/core/application.h"
 
-namespace esphome {
-namespace jk_bms_ble {
+namespace esphome::jk_bms_ble {
 
 static const char *const TAG = "jk_bms_ble.button";
 
@@ -13,5 +12,4 @@ void JkButton::press_action() {
   this->parent_->write_register(this->holding_register_, 0x00000000, 0x00);
 }
 
-}  // namespace jk_bms_ble
-}  // namespace esphome
+}  // namespace esphome::jk_bms_ble

--- a/components/jk_bms_ble/button/jk_button.h
+++ b/components/jk_bms_ble/button/jk_button.h
@@ -4,8 +4,7 @@
 #include "esphome/core/component.h"
 #include "esphome/components/button/button.h"
 
-namespace esphome {
-namespace jk_bms_ble {
+namespace esphome::jk_bms_ble {
 
 class JkBmsBle;
 class JkButton : public button::Button, public Component {
@@ -22,5 +21,4 @@ class JkButton : public button::Button, public Component {
   uint8_t holding_register_;
 };
 
-}  // namespace jk_bms_ble
-}  // namespace esphome
+}  // namespace esphome::jk_bms_ble

--- a/components/jk_bms_ble/jk_bms_ble.cpp
+++ b/components/jk_bms_ble/jk_bms_ble.cpp
@@ -8,8 +8,7 @@
 #define ADDR_STR(x) (x).c_str()
 #endif
 
-namespace esphome {
-namespace jk_bms_ble {
+namespace esphome::jk_bms_ble {
 
 static const char *const TAG = "jk_bms_ble";
 
@@ -1699,5 +1698,4 @@ std::string JkBmsBle::charge_status_id_to_string_(const uint8_t status) {
   }
 }
 
-}  // namespace jk_bms_ble
-}  // namespace esphome
+}  // namespace esphome::jk_bms_ble

--- a/components/jk_bms_ble/jk_bms_ble.h
+++ b/components/jk_bms_ble/jk_bms_ble.h
@@ -15,8 +15,7 @@
 namespace espbt = esphome::esp32_ble_tracker;
 #endif
 
-namespace esphome {
-namespace jk_bms_ble {
+namespace esphome::jk_bms_ble {
 
 enum ProtocolVersion {
   PROTOCOL_VERSION_JK04,
@@ -482,5 +481,4 @@ class JkBmsBle :
   bool check_bit_(uint8_t mask, uint8_t flag) { return (mask & flag) == flag; }
 };
 
-}  // namespace jk_bms_ble
-}  // namespace esphome
+}  // namespace esphome::jk_bms_ble

--- a/components/jk_bms_ble/number/jk_number.cpp
+++ b/components/jk_bms_ble/number/jk_number.cpp
@@ -1,8 +1,7 @@
 #include "jk_number.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace jk_bms_ble {
+namespace esphome::jk_bms_ble {
 
 static const char *const TAG = "jk_bms_ble.number";
 
@@ -35,5 +34,4 @@ void JkNumber::control(float value) {
   ESP_LOGE(TAG, "This number entity isn't supported by the selected protocol version");
 }
 
-}  // namespace jk_bms_ble
-}  // namespace esphome
+}  // namespace esphome::jk_bms_ble

--- a/components/jk_bms_ble/number/jk_number.h
+++ b/components/jk_bms_ble/number/jk_number.h
@@ -4,8 +4,7 @@
 #include "esphome/core/component.h"
 #include "esphome/components/number/number.h"
 
-namespace esphome {
-namespace jk_bms_ble {
+namespace esphome::jk_bms_ble {
 
 class JkBmsBle;
 
@@ -36,5 +35,4 @@ class JkNumber : public number::Number, public Component {
   float factor_{1000.0f};
 };
 
-}  // namespace jk_bms_ble
-}  // namespace esphome
+}  // namespace esphome::jk_bms_ble

--- a/components/jk_bms_ble/switch/jk_switch.cpp
+++ b/components/jk_bms_ble/switch/jk_switch.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/log.h"
 #include "esphome/core/application.h"
 
-namespace esphome {
-namespace jk_bms_ble {
+namespace esphome::jk_bms_ble {
 
 static const char *const TAG = "jk_bms_ble.switch";
 
@@ -33,5 +32,4 @@ void JkSwitch::write_state(bool state) {
   ESP_LOGE(TAG, "This switch isn't supported by the selected protocol version");
 }
 
-}  // namespace jk_bms_ble
-}  // namespace esphome
+}  // namespace esphome::jk_bms_ble

--- a/components/jk_bms_ble/switch/jk_switch.h
+++ b/components/jk_bms_ble/switch/jk_switch.h
@@ -4,8 +4,7 @@
 #include "esphome/core/component.h"
 #include "esphome/components/switch/switch.h"
 
-namespace esphome {
-namespace jk_bms_ble {
+namespace esphome::jk_bms_ble {
 
 class JkBmsBle;
 class JkSwitch : public switch_::Switch, public Component {
@@ -32,5 +31,4 @@ class JkSwitch : public switch_::Switch, public Component {
   uint8_t jk02_32s_holding_register_;
 };
 
-}  // namespace jk_bms_ble
-}  // namespace esphome
+}  // namespace esphome::jk_bms_ble

--- a/components/jk_bms_display/jk_bms_display.cpp
+++ b/components/jk_bms_display/jk_bms_display.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/log.h"
 #include "esphome/core/helpers.h"
 
-namespace esphome {
-namespace jk_bms_display {
+namespace esphome::jk_bms_display {
 
 static const char *const TAG = "jk_bms_display";
 
@@ -310,5 +309,4 @@ void JkBmsDisplay::publish_state_(sensor::Sensor *sensor, float value) {
   sensor->publish_state(value);
 }
 
-}  // namespace jk_bms_display
-}  // namespace esphome
+}  // namespace esphome::jk_bms_display

--- a/components/jk_bms_display/jk_bms_display.h
+++ b/components/jk_bms_display/jk_bms_display.h
@@ -5,8 +5,7 @@
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/uart/uart.h"
 
-namespace esphome {
-namespace jk_bms_display {
+namespace esphome::jk_bms_display {
 
 class JkBmsDisplay : public uart::UARTDevice, public Component {
  public:
@@ -149,5 +148,4 @@ class JkBmsDisplay : public uart::UARTDevice, public Component {
   std::string error_bits_to_string_(const uint8_t &mask);
 };
 
-}  // namespace jk_bms_display
-}  // namespace esphome
+}  // namespace esphome::jk_bms_display

--- a/components/jk_modbus/jk_modbus.cpp
+++ b/components/jk_modbus/jk_modbus.cpp
@@ -3,8 +3,7 @@
 #include "esphome/core/hal.h"
 #include "esphome/core/helpers.h"
 
-namespace esphome {
-namespace jk_modbus {
+namespace esphome::jk_modbus {
 
 static const char *const TAG = "jk_modbus";
 
@@ -207,5 +206,4 @@ void JkModbus::read_registers() {
     this->flow_control_pin_->digital_write(false);
 }
 
-}  // namespace jk_modbus
-}  // namespace esphome
+}  // namespace esphome::jk_modbus

--- a/components/jk_modbus/jk_modbus.h
+++ b/components/jk_modbus/jk_modbus.h
@@ -3,8 +3,7 @@
 #include "esphome/core/component.h"
 #include "esphome/components/uart/uart.h"
 
-namespace esphome {
-namespace jk_modbus {
+namespace esphome::jk_modbus {
 
 class JkModbusDevice;
 
@@ -58,5 +57,4 @@ class JkModbusDevice {
   uint8_t address_;
 };
 
-}  // namespace jk_modbus
-}  // namespace esphome
+}  // namespace esphome::jk_modbus


### PR DESCRIPTION
The `modernize-concat-nested-namespaces` check is active in ESPHome's CI. All nested namespace blocks are replaced with `namespace esphome::X` syntax. The `.clang-tidy` is synced to the current ESPHome dev version.