### PR TITLE
Fix redundant string initialization

### DIFF
--- a/components/jk_balancer/jk_balancer.cpp
+++ b/components/jk_balancer/jk_balancer.cpp
@@ -237,7 +237,7 @@ void JkBalancer::publish_state_(text_sensor::TextSensor *text_sensor, const std:
 
 std::string JkBalancer::error_bits_to_string_(const uint8_t mask) {
   bool first = true;
-  std::string errors_list = "";
+  std::string errors_list;
 
   if (mask) {
     for (int i = 0; i < ERRORS_SIZE; i++) {

--- a/components/jk_bms/jk_bms.cpp
+++ b/components/jk_bms/jk_bms.cpp
@@ -522,7 +522,7 @@ void JkBms::publish_state_(text_sensor::TextSensor *text_sensor, const std::stri
 
 std::string JkBms::error_bits_to_string_(const uint16_t mask) {
   bool first = true;
-  std::string errors_list = "";
+  std::string errors_list;
 
   if (mask) {
     for (int i = 0; i < ERRORS_SIZE; i++) {
@@ -542,7 +542,7 @@ std::string JkBms::error_bits_to_string_(const uint16_t mask) {
 
 std::string JkBms::mode_bits_to_string_(const uint16_t mask) {
   bool first = true;
-  std::string modes_list = "";
+  std::string modes_list;
 
   if (mask) {
     for (int i = 0; i < OPERATION_MODES_SIZE; i++) {

--- a/components/jk_bms_ble/jk_bms_ble.cpp
+++ b/components/jk_bms_ble/jk_bms_ble.cpp
@@ -1661,7 +1661,7 @@ void JkBmsBle::publish_state_(text_sensor::TextSensor *text_sensor, const std::s
 
 std::string JkBmsBle::error_bits_to_string_(const uint16_t mask) {
   bool first = true;
-  std::string errors_list = "";
+  std::string errors_list;
 
   if (mask) {
     for (int i = 0; i < ERRORS_SIZE; i++) {


### PR DESCRIPTION
Remove redundant empty string initialization (`= ""`) flagged by `readability-redundant-string-init`. `std::string` default-constructs to an empty string.

Affected files: `jk_balancer.cpp`, `jk_bms.cpp`, `jk_bms_ble.cpp`.