### PR TITLE
Add device_class: problem to error and protection binary sensors

### DIFF
--- a/components/heltec_balancer_ble/binary_sensor.py
+++ b/components/heltec_balancer_ble/binary_sensor.py
@@ -1,7 +1,7 @@
 import esphome.codegen as cg
 from esphome.components import binary_sensor
 import esphome.config_validation as cv
-from esphome.const import DEVICE_CLASS_CONNECTIVITY, ENTITY_CATEGORY_DIAGNOSTIC
+from esphome.const import DEVICE_CLASS_CONNECTIVITY, DEVICE_CLASS_PROBLEM, ENTITY_CATEGORY_DIAGNOSTIC
 
 from . import CONF_HELTEC_BALANCER_BLE_ID, HELTEC_BALANCER_BLE_COMPONENT_SCHEMA
 
@@ -17,9 +17,21 @@ CONF_ONLINE_STATUS = "online_status"
 
 BINARY_SENSOR_DEFS = {
     CONF_BALANCING: {"icon": "mdi:battery-heart-variant"},
-    CONF_ERROR_CHARGING: {"icon": "mdi:alert-circle-outline"},
-    CONF_ERROR_DISCHARGING: {"icon": "mdi:alert-circle-outline"},
-    CONF_ERROR_SYSTEM_OVERHEATING: {"icon": "mdi:alert-circle-outline"},
+    CONF_ERROR_CHARGING: {
+        "icon": "mdi:alert-circle-outline",
+        "device_class": DEVICE_CLASS_PROBLEM,
+        "entity_category": ENTITY_CATEGORY_DIAGNOSTIC,
+    },
+    CONF_ERROR_DISCHARGING: {
+        "icon": "mdi:alert-circle-outline",
+        "device_class": DEVICE_CLASS_PROBLEM,
+        "entity_category": ENTITY_CATEGORY_DIAGNOSTIC,
+    },
+    CONF_ERROR_SYSTEM_OVERHEATING: {
+        "icon": "mdi:alert-circle-outline",
+        "device_class": DEVICE_CLASS_PROBLEM,
+        "entity_category": ENTITY_CATEGORY_DIAGNOSTIC,
+    },
     CONF_ONLINE_STATUS: {
         "device_class": DEVICE_CLASS_CONNECTIVITY,
         "entity_category": ENTITY_CATEGORY_DIAGNOSTIC,

--- a/components/heltec_balancer_ble/binary_sensor.py
+++ b/components/heltec_balancer_ble/binary_sensor.py
@@ -1,7 +1,11 @@
 import esphome.codegen as cg
 from esphome.components import binary_sensor
 import esphome.config_validation as cv
-from esphome.const import DEVICE_CLASS_CONNECTIVITY, DEVICE_CLASS_PROBLEM, ENTITY_CATEGORY_DIAGNOSTIC
+from esphome.const import (
+    DEVICE_CLASS_CONNECTIVITY,
+    DEVICE_CLASS_PROBLEM,
+    ENTITY_CATEGORY_DIAGNOSTIC,
+)
 
 from . import CONF_HELTEC_BALANCER_BLE_ID, HELTEC_BALANCER_BLE_COMPONENT_SCHEMA
 

--- a/components/jk_bms_display/binary_sensor.py
+++ b/components/jk_bms_display/binary_sensor.py
@@ -1,7 +1,7 @@
 import esphome.codegen as cg
 from esphome.components import binary_sensor
 import esphome.config_validation as cv
-from esphome.const import ENTITY_CATEGORY_DIAGNOSTIC
+from esphome.const import DEVICE_CLASS_PROBLEM, ENTITY_CATEGORY_DIAGNOSTIC
 
 from . import CONF_JK_BMS_DISPLAY_ID, JK_BMS_DISPLAY_COMPONENT_SCHEMA
 
@@ -28,31 +28,49 @@ ICON_DISCHARGING = "mdi:power-plug"
 ICON_BALANCING = "mdi:battery-heart-variant"
 
 BINARY_SENSOR_DEFS = {
-    CONF_SYSTEM_WARNING: {"entity_category": ENTITY_CATEGORY_DIAGNOSTIC},
+    CONF_SYSTEM_WARNING: {
+        "device_class": DEVICE_CLASS_PROBLEM,
+        "entity_category": ENTITY_CATEGORY_DIAGNOSTIC,
+    },
     CONF_BALANCING_SWITCH: {"icon": ICON_BALANCING},
     CONF_CHARGING: {"icon": ICON_CHARGING},
     CONF_DISCHARGING: {"icon": ICON_DISCHARGING},
     CONF_CELL_VOLTAGE_UNDERVOLTAGE_PROTECTION: {
-        "entity_category": ENTITY_CATEGORY_DIAGNOSTIC
+        "device_class": DEVICE_CLASS_PROBLEM,
+        "entity_category": ENTITY_CATEGORY_DIAGNOSTIC,
     },
     CONF_CELL_VOLTAGE_OVERVOLTAGE_PROTECTION: {
-        "entity_category": ENTITY_CATEGORY_DIAGNOSTIC
+        "device_class": DEVICE_CLASS_PROBLEM,
+        "entity_category": ENTITY_CATEGORY_DIAGNOSTIC,
     },
-    CONF_OVERCURRENT_PROTECTION: {"entity_category": ENTITY_CATEGORY_DIAGNOSTIC},
+    CONF_OVERCURRENT_PROTECTION: {
+        "device_class": DEVICE_CLASS_PROBLEM,
+        "entity_category": ENTITY_CATEGORY_DIAGNOSTIC,
+    },
     CONF_MOSFET_OVERTEMPERATURE_PROTECTION: {
-        "entity_category": ENTITY_CATEGORY_DIAGNOSTIC
+        "device_class": DEVICE_CLASS_PROBLEM,
+        "entity_category": ENTITY_CATEGORY_DIAGNOSTIC,
     },
     CONF_BATTERY_TEMPERATURE_PROTECTION: {
-        "entity_category": ENTITY_CATEGORY_DIAGNOSTIC
+        "device_class": DEVICE_CLASS_PROBLEM,
+        "entity_category": ENTITY_CATEGORY_DIAGNOSTIC,
     },
-    CONF_SHORT_CIRCUIT_PROTECTION: {"entity_category": ENTITY_CATEGORY_DIAGNOSTIC},
+    CONF_SHORT_CIRCUIT_PROTECTION: {
+        "device_class": DEVICE_CLASS_PROBLEM,
+        "entity_category": ENTITY_CATEGORY_DIAGNOSTIC,
+    },
     CONF_COPROCESSOR_COMMUNICATION_ERROR: {
-        "entity_category": ENTITY_CATEGORY_DIAGNOSTIC
+        "device_class": DEVICE_CLASS_PROBLEM,
+        "entity_category": ENTITY_CATEGORY_DIAGNOSTIC,
     },
     CONF_BALANCER_WIRE_RESISTANCE_TOO_HIGH: {
-        "entity_category": ENTITY_CATEGORY_DIAGNOSTIC
+        "device_class": DEVICE_CLASS_PROBLEM,
+        "entity_category": ENTITY_CATEGORY_DIAGNOSTIC,
     },
-    CONF_CELL_COUNT_MISMATCH: {"entity_category": ENTITY_CATEGORY_DIAGNOSTIC},
+    CONF_CELL_COUNT_MISMATCH: {
+        "device_class": DEVICE_CLASS_PROBLEM,
+        "entity_category": ENTITY_CATEGORY_DIAGNOSTIC,
+    },
 }
 
 CONFIG_SCHEMA = JK_BMS_DISPLAY_COMPONENT_SCHEMA.extend(


### PR DESCRIPTION
The `DEVICE_CLASS_PROBLEM` device class is now assigned to binary sensors that represent error conditions or active protections.

**heltec_balancer_ble:**
- `error_charging`
- `error_discharging`
- `error_system_overheating`

**jk_bms_display:**
- `system_warning`
- `cell_voltage_undervoltage_protection`
- `cell_voltage_overvoltage_protection`
- `overcurrent_protection`
- `mosfet_overtemperature_protection`
- `battery_temperature_protection`
- `short_circuit_protection`
- `coprocessor_communication_error`
- `balancer_wire_resistance_too_high`
- `cell_count_mismatch`