### PR TITLE
Add detail_log_count sensor (JK02_32S only)

### DIFF
--- a/components/jk_bms_ble/jk_bms_ble.cpp
+++ b/components/jk_bms_ble/jk_bms_ble.cpp
@@ -699,6 +699,9 @@ void JkBmsBle::decode_jk02_cell_info_(const std::vector<uint8_t> &data) {
     this->publish_state_(this->temperatures_[2].temperature_sensor_,
                          (float) ((int16_t) jk_get_16bit(226 + offset)) * 0.1f);
 
+    // 234+32  4   0x3E 0x00 0x00 0x00    Detail log count     1
+    this->publish_state_(this->detail_log_count_sensor_, (float) jk_get_32bit(234 + offset));
+
     // 246+32  2   0x00 0x00              Charge status time
     this->publish_state_(this->charge_status_time_elapsed_sensor_, (float) jk_get_16bit(246 + offset));
 
@@ -707,9 +710,6 @@ void JkBmsBle::decode_jk02_cell_info_(const std::vector<uint8_t> &data) {
     //                                                                                 0x02: Float
     this->publish_state_(this->charge_status_id_sensor_, (float) data[248 + offset]);
     this->publish_state_(this->charge_status_text_sensor_, this->charge_status_id_to_string_(data[248 + offset]));
-
-    // 234+32  4   0x3E 0x00 0x00 0x00    Detail log count     1
-    this->publish_state_(this->detail_log_count_sensor_, (float) jk_get_32bit(234 + offset));
   }
 
   // 299   1   0xCD                   CRC

--- a/components/jk_bms_ble/jk_bms_ble.cpp
+++ b/components/jk_bms_ble/jk_bms_ble.cpp
@@ -707,6 +707,9 @@ void JkBmsBle::decode_jk02_cell_info_(const std::vector<uint8_t> &data) {
     //                                                                                 0x02: Float
     this->publish_state_(this->charge_status_id_sensor_, (float) data[248 + offset]);
     this->publish_state_(this->charge_status_text_sensor_, this->charge_status_id_to_string_(data[248 + offset]));
+
+    // 234+32  4   0x3E 0x00 0x00 0x00    Detail log count     1
+    this->publish_state_(this->detail_log_count_sensor_, (float) jk_get_32bit(234 + offset));
   }
 
   // 299   1   0xCD                   CRC

--- a/components/jk_bms_ble/jk_bms_ble.h
+++ b/components/jk_bms_ble/jk_bms_ble.h
@@ -269,6 +269,9 @@ class JkBmsBle :
   void set_charge_status_time_elapsed_sensor(sensor::Sensor *charge_status_time_elapsed_sensor) {
     charge_status_time_elapsed_sensor_ = charge_status_time_elapsed_sensor;
   }
+  void set_detail_log_count_sensor(sensor::Sensor *detail_log_count_sensor) {
+    detail_log_count_sensor_ = detail_log_count_sensor;
+  }
 
   void set_errors_text_sensor(text_sensor::TextSensor *errors_text_sensor) { errors_text_sensor_ = errors_text_sensor; }
   void set_operation_status_text_sensor(text_sensor::TextSensor *operation_status_text_sensor) {
@@ -404,6 +407,7 @@ class JkBmsBle :
   sensor::Sensor *heating_current_sensor_{nullptr};
   sensor::Sensor *charge_status_id_sensor_{nullptr};
   sensor::Sensor *charge_status_time_elapsed_sensor_{nullptr};
+  sensor::Sensor *detail_log_count_sensor_{nullptr};
 
   switch_::Switch *charging_switch_{nullptr};
   switch_::Switch *discharging_switch_{nullptr};

--- a/components/jk_bms_ble/sensor.py
+++ b/components/jk_bms_ble/sensor.py
@@ -58,6 +58,7 @@ CONF_EMERGENCY_TIME_COUNTDOWN = "emergency_time_countdown"
 CONF_HEATING_CURRENT = "heating_current"
 CONF_CHARGE_STATUS_ID = "charge_status_id"
 CONF_CHARGE_STATUS_TIME_ELAPSED = "charge_status_time_elapsed"
+CONF_DETAIL_LOG_COUNT = "detail_log_count"
 
 UNIT_AMPERE_HOURS = "Ah"
 UNIT_OHM = "Ω"
@@ -280,6 +281,13 @@ SENSOR_DEFS = {
         "icon": ICON_CHARGE_STATUS_TIME_ELAPSED,
         "accuracy_decimals": 0,
         "device_class": DEVICE_CLASS_EMPTY,
+    },
+    CONF_DETAIL_LOG_COUNT: {
+        "unit_of_measurement": UNIT_EMPTY,
+        "icon": ICON_COUNTER,
+        "accuracy_decimals": 0,
+        "device_class": DEVICE_CLASS_EMPTY,
+        "entity_category": ENTITY_CATEGORY_DIAGNOSTIC,
     },
 }
 

--- a/esp32-ble-v11-example.yaml
+++ b/esp32-ble-v11-example.yaml
@@ -314,6 +314,8 @@ sensor:
       name: "errors bitmask"
     emergency_time_countdown:
       name: "emergency time countdown"
+    detail_log_count:
+      name: "detail log count"
 
 switch:
   - platform: jk_bms_ble

--- a/esp32-ble-v14-example-multiple-devices.yaml
+++ b/esp32-ble-v14-example-multiple-devices.yaml
@@ -598,6 +598,9 @@ sensor:
     emergency_time_countdown:
       name: "emergency time countdown"
       device_id: device0
+    detail_log_count:
+      name: "detail log count"
+      device_id: device0
     # ...
 
   - platform: jk_bms_ble
@@ -829,6 +832,9 @@ sensor:
       device_id: device1
     emergency_time_countdown:
       name: "emergency time countdown"
+      device_id: device1
+    detail_log_count:
+      name: "detail log count"
       device_id: device1
     # ...
 

--- a/esp32-ble-v14-example.yaml
+++ b/esp32-ble-v14-example.yaml
@@ -330,6 +330,8 @@ sensor:
       name: "charge status id"
     charge_status_time_elapsed:
       name: "charge status time elapsed"
+    detail_log_count:
+      name: "detail log count"
 
 switch:
   - platform: jk_bms_ble

--- a/esp32-ble-v15-example.yaml
+++ b/esp32-ble-v15-example.yaml
@@ -334,6 +334,8 @@ sensor:
       name: "charge status id"
     charge_status_time_elapsed:
       name: "charge status time elapsed"
+    detail_log_count:
+      name: "detail log count"
 
 switch:
   - platform: jk_bms_ble

--- a/esp32-ble-v19-example.yaml
+++ b/esp32-ble-v19-example.yaml
@@ -336,6 +336,8 @@ sensor:
       name: "charge status id"
     charge_status_time_elapsed:
       name: "charge status time elapsed"
+    detail_log_count:
+      name: "detail log count"
 
 switch:
   - platform: jk_bms_ble

--- a/tests/components/jk_bms_ble/jk_bms_ble_jk02_32s_v19_test.cpp
+++ b/tests/components/jk_bms_ble/jk_bms_ble_jk02_32s_v19_test.cpp
@@ -111,4 +111,13 @@ TEST(JkBmsV19CellInfoTest, MosfetState) {
   EXPECT_TRUE(discharging.state);
 }
 
+TEST(JkBmsV19CellInfoTest, DetailLogCount) {
+  TestableJkBmsBle bms;
+  bms.set_protocol_version(PROTOCOL_VERSION_JK02_32S);
+  sensor::Sensor detail_log_count;
+  bms.set_detail_log_count_sensor(&detail_log_count);
+  bms.decode_jk02_cell_info_(CELL_INFO_JK02_32S_V19);
+  EXPECT_FLOAT_EQ(detail_log_count.state, 62.0f);
+}
+
 }  // namespace esphome::jk_bms_ble::testing

--- a/tests/test_component_schemas.py
+++ b/tests/test_component_schemas.py
@@ -114,7 +114,8 @@ class TestJkBmsBleSensorLists:
 
     def test_sensor_defs_completeness(self):
         assert "total_voltage" in ble_sensor.SENSOR_DEFS
-        assert len(ble_sensor.SENSOR_DEFS) == 26
+        assert "detail_log_count" in ble_sensor.SENSOR_DEFS
+        assert len(ble_sensor.SENSOR_DEFS) == 27
 
 
 class TestJkBmsBleBinarySensorConstants:


### PR DESCRIPTION
## Summary

- Adds a new `detail_log_count` sensor to the `jk_bms_ble` component
- Field is only available in JK02_32S frames (byte offset 266 = `234 + 32` after the doubled protocol offset)
- Identified by correlating the Android BMS app's "Detail Logs Count" display value against raw BLE frame captures from a JK-B2A8S20P (HW 19H, SW 19.25)

## Protocol details

Frame: cell_info (type 0x02), JK02_32S only
Position: bytes 266–269, uint32 little-endian (= offset `234 + 32` in `decode_jk02_cell_info_()`)
Confirmed values across real-device captures: v11=1560, v14=1585, v15=22, v19=62

## Changes

- `jk_bms_ble.h`: setter + member `detail_log_count_sensor_`
- `jk_bms_ble.cpp`: parse in `decode_jk02_cell_info_()` inside the `FRAME_VERSION_JK02_32S` block
- `sensor.py`: `CONF_DETAIL_LOG_COUNT` + `SENSOR_DEFS` entry (`ICON_COUNTER`, diagnostic category)
- `esp32-ble-v11/v14/v14-multiple/v15/v19-example.yaml`: sensor entries added
- `jk_bms_ble_jk02_32s_v19_test.cpp`: `DetailLogCount` GoogleTest case (expected: 62.0)
- `test_component_schemas.py`: count assertion updated 26 → 27, explicit key presence check added

## Test plan

- [x] `pytest tests/test_component_schemas.py` — 33/33 passed
- [ ] C++ GoogleTest (`jk_bms_ble_jk02_32s_v19_test.cpp`) — requires ESP32 toolchain / CI
- [ ] Hardware test via JK-BMS BLE emulator with Android app (contributor has test setup)