### PR TITLE
Add battery_type_id sensor and battery_type text sensor (JK02_32S)

### DIFF
--- a/components/jk_bms_ble/jk_bms_ble.cpp
+++ b/components/jk_bms_ble/jk_bms_ble.cpp
@@ -162,6 +162,7 @@ void JkBmsBle::dump_config() {  // NOLINT(google-readability-function-size,reada
   LOG_SENSOR("", "Emergency Time Countdown", this->emergency_time_countdown_sensor_);
   LOG_SENSOR("", "Charge Status ID", this->charge_status_id_sensor_);
   LOG_SENSOR("", "Charge Status Time Elapsed", this->charge_status_time_elapsed_sensor_);
+  LOG_SENSOR("", "Battery Type ID", this->battery_type_id_sensor_);
 
   LOG_TEXT_SENSOR("", "Operation Status", this->operation_status_text_sensor_);
   LOG_TEXT_SENSOR("", "Total Runtime Formatted", this->total_runtime_formatted_text_sensor_);
@@ -169,6 +170,7 @@ void JkBmsBle::dump_config() {  // NOLINT(google-readability-function-size,reada
   LOG_TEXT_SENSOR("", "Charge Status", this->charge_status_text_sensor_);
   LOG_TEXT_SENSOR("", "Software Version", this->software_version_text_sensor_);
   LOG_TEXT_SENSOR("", "Hardware Version", this->hardware_version_text_sensor_);
+  LOG_TEXT_SENSOR("", "Battery Type", this->battery_type_text_sensor_);
 }
 
 #ifdef USE_ESP32
@@ -701,6 +703,10 @@ void JkBmsBle::decode_jk02_cell_info_(const std::vector<uint8_t> &data) {
 
     // 234+32  4   0x3E 0x00 0x00 0x00    Detail log count     1
     this->publish_state_(this->detail_log_count_sensor_, (float) jk_get_32bit(234 + offset));
+
+    // 243+32  1   0x00                   Battery type code    0=LFP, 1=Li-ion, 2=LTO
+    this->publish_state_(this->battery_type_id_sensor_, (float) data[243 + offset]);
+    this->publish_state_(this->battery_type_text_sensor_, this->battery_type_id_to_string_(data[243 + offset]));
 
     // 246+32  2   0x00 0x00              Charge status time
     this->publish_state_(this->charge_status_time_elapsed_sensor_, (float) jk_get_16bit(246 + offset));
@@ -1686,6 +1692,19 @@ static std::string unknown_to_string(const uint8_t value) {
   char buf[15];
   snprintf(buf, sizeof(buf), "Unknown (0x%02X)", value);
   return buf;
+}
+
+std::string JkBmsBle::battery_type_id_to_string_(const uint8_t code) {
+  switch (code) {
+    case 0x00:
+      return "LFP";
+    case 0x01:
+      return "Li-ion";
+    case 0x02:
+      return "LTO";
+    default:
+      return unknown_to_string(code);
+  }
 }
 
 std::string JkBmsBle::charge_status_id_to_string_(const uint8_t status) {

--- a/components/jk_bms_ble/jk_bms_ble.h
+++ b/components/jk_bms_ble/jk_bms_ble.h
@@ -272,6 +272,9 @@ class JkBmsBle :
   void set_detail_log_count_sensor(sensor::Sensor *detail_log_count_sensor) {
     detail_log_count_sensor_ = detail_log_count_sensor;
   }
+  void set_battery_type_id_sensor(sensor::Sensor *battery_type_id_sensor) {
+    battery_type_id_sensor_ = battery_type_id_sensor;
+  }
 
   void set_errors_text_sensor(text_sensor::TextSensor *errors_text_sensor) { errors_text_sensor_ = errors_text_sensor; }
   void set_operation_status_text_sensor(text_sensor::TextSensor *operation_status_text_sensor) {
@@ -288,6 +291,9 @@ class JkBmsBle :
   }
   void set_hardware_version_text_sensor(text_sensor::TextSensor *hardware_version_text_sensor) {
     hardware_version_text_sensor_ = hardware_version_text_sensor;
+  }
+  void set_battery_type_text_sensor(text_sensor::TextSensor *battery_type_text_sensor) {
+    battery_type_text_sensor_ = battery_type_text_sensor;
   }
 
   void set_charging_switch(switch_::Switch *charging_switch) { charging_switch_ = charging_switch; }
@@ -408,6 +414,7 @@ class JkBmsBle :
   sensor::Sensor *charge_status_id_sensor_{nullptr};
   sensor::Sensor *charge_status_time_elapsed_sensor_{nullptr};
   sensor::Sensor *detail_log_count_sensor_{nullptr};
+  sensor::Sensor *battery_type_id_sensor_{nullptr};
 
   switch_::Switch *charging_switch_{nullptr};
   switch_::Switch *discharging_switch_{nullptr};
@@ -427,6 +434,7 @@ class JkBmsBle :
   text_sensor::TextSensor *charge_status_text_sensor_{nullptr};
   text_sensor::TextSensor *software_version_text_sensor_{nullptr};
   text_sensor::TextSensor *hardware_version_text_sensor_{nullptr};
+  text_sensor::TextSensor *battery_type_text_sensor_{nullptr};
 
   std::vector<uint8_t> frame_buffer_;
   bool status_notification_received_ = false;
@@ -454,6 +462,7 @@ class JkBmsBle :
   void track_online_status_();
   std::string error_bits_to_string_(uint16_t bitmask);
   std::string charge_status_id_to_string_(uint8_t status);
+  std::string battery_type_id_to_string_(uint8_t code);
 
   std::string format_total_runtime_(const uint32_t value) {
     int seconds = (int) value;

--- a/components/jk_bms_ble/sensor.py
+++ b/components/jk_bms_ble/sensor.py
@@ -59,6 +59,7 @@ CONF_HEATING_CURRENT = "heating_current"
 CONF_CHARGE_STATUS_ID = "charge_status_id"
 CONF_CHARGE_STATUS_TIME_ELAPSED = "charge_status_time_elapsed"
 CONF_DETAIL_LOG_COUNT = "detail_log_count"
+CONF_BATTERY_TYPE_ID = "battery_type_id"
 
 UNIT_AMPERE_HOURS = "Ah"
 UNIT_OHM = "Ω"
@@ -285,6 +286,13 @@ SENSOR_DEFS = {
     CONF_DETAIL_LOG_COUNT: {
         "unit_of_measurement": UNIT_EMPTY,
         "icon": ICON_COUNTER,
+        "accuracy_decimals": 0,
+        "device_class": DEVICE_CLASS_EMPTY,
+        "entity_category": ENTITY_CATEGORY_DIAGNOSTIC,
+    },
+    CONF_BATTERY_TYPE_ID: {
+        "unit_of_measurement": UNIT_EMPTY,
+        "icon": ICON_EMPTY,
         "accuracy_decimals": 0,
         "device_class": DEVICE_CLASS_EMPTY,
         "entity_category": ENTITY_CATEGORY_DIAGNOSTIC,

--- a/components/jk_bms_ble/text_sensor.py
+++ b/components/jk_bms_ble/text_sensor.py
@@ -15,10 +15,12 @@ CONF_TOTAL_RUNTIME_FORMATTED = "total_runtime_formatted"
 CONF_CHARGE_STATUS = "charge_status"
 CONF_SOFTWARE_VERSION = "software_version"
 CONF_HARDWARE_VERSION = "hardware_version"
+CONF_BATTERY_TYPE = "battery_type"
 
 ICON_ERRORS = "mdi:alert-circle-outline"
 ICON_OPERATION_STATUS = "mdi:heart-pulse"
 ICON_CHARGE_STATUS = "mdi:battery-clock"
+ICON_BATTERY_TYPE = "mdi:battery-heart-variant"
 
 TEXT_SENSORS = [
     CONF_ERRORS,
@@ -27,6 +29,7 @@ TEXT_SENSORS = [
     CONF_CHARGE_STATUS,
     CONF_SOFTWARE_VERSION,
     CONF_HARDWARE_VERSION,
+    CONF_BATTERY_TYPE,
 ]
 
 CONFIG_SCHEMA = JK_BMS_BLE_COMPONENT_SCHEMA.extend(
@@ -50,6 +53,10 @@ CONFIG_SCHEMA = JK_BMS_BLE_COMPONENT_SCHEMA.extend(
         ),
         cv.Optional(CONF_HARDWARE_VERSION): text_sensor.text_sensor_schema(
             icon=ICON_EMPTY,
+            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+        ),
+        cv.Optional(CONF_BATTERY_TYPE): text_sensor.text_sensor_schema(
+            icon=ICON_BATTERY_TYPE,
             entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
         ),
     }

--- a/esp32-ble-v14-example.yaml
+++ b/esp32-ble-v14-example.yaml
@@ -332,7 +332,8 @@ sensor:
       name: "charge status time elapsed"
     detail_log_count:
       name: "detail log count"
-
+    battery_type_id:
+      name: "battery type id"
 switch:
   - platform: jk_bms_ble
     charging:
@@ -375,3 +376,5 @@ text_sensor:
       name: "software version"
     hardware_version:
       name: "hardware version"
+    battery_type:
+      name: "battery type"

--- a/esp32-ble-v15-example.yaml
+++ b/esp32-ble-v15-example.yaml
@@ -336,7 +336,8 @@ sensor:
       name: "charge status time elapsed"
     detail_log_count:
       name: "detail log count"
-
+    battery_type_id:
+      name: "battery type id"
 switch:
   - platform: jk_bms_ble
     charging:
@@ -379,3 +380,5 @@ text_sensor:
       name: "software version"
     hardware_version:
       name: "hardware version"
+    battery_type:
+      name: "battery type"

--- a/esp32-ble-v19-example.yaml
+++ b/esp32-ble-v19-example.yaml
@@ -338,7 +338,8 @@ sensor:
       name: "charge status time elapsed"
     detail_log_count:
       name: "detail log count"
-
+    battery_type_id:
+      name: "battery type id"
 switch:
   - platform: jk_bms_ble
     charging:
@@ -381,3 +382,5 @@ text_sensor:
       name: "software version"
     hardware_version:
       name: "hardware version"
+    battery_type:
+      name: "battery type"

--- a/tests/components/jk_bms_ble/jk_bms_ble_jk02_32s_v19_test.cpp
+++ b/tests/components/jk_bms_ble/jk_bms_ble_jk02_32s_v19_test.cpp
@@ -120,4 +120,22 @@ TEST(JkBmsV19CellInfoTest, DetailLogCount) {
   EXPECT_FLOAT_EQ(detail_log_count.state, 62.0f);
 }
 
+TEST(JkBmsV19CellInfoTest, BatteryTypeCode) {
+  TestableJkBmsBle bms;
+  bms.set_protocol_version(PROTOCOL_VERSION_JK02_32S);
+  sensor::Sensor battery_type_id;
+  bms.set_battery_type_id_sensor(&battery_type_id);
+  bms.decode_jk02_cell_info_(CELL_INFO_JK02_32S_V19);
+  EXPECT_FLOAT_EQ(battery_type_id.state, 0.0f);  // LFP
+}
+
+TEST(JkBmsV19CellInfoTest, BatteryType) {
+  TestableJkBmsBle bms;
+  bms.set_protocol_version(PROTOCOL_VERSION_JK02_32S);
+  text_sensor::TextSensor battery_type;
+  bms.set_battery_type_text_sensor(&battery_type);
+  bms.decode_jk02_cell_info_(CELL_INFO_JK02_32S_V19);
+  EXPECT_EQ(battery_type.state, "LFP");
+}
+
 }  // namespace esphome::jk_bms_ble::testing

--- a/tests/test_component_schemas.py
+++ b/tests/test_component_schemas.py
@@ -115,7 +115,8 @@ class TestJkBmsBleSensorLists:
     def test_sensor_defs_completeness(self):
         assert "total_voltage" in ble_sensor.SENSOR_DEFS
         assert "detail_log_count" in ble_sensor.SENSOR_DEFS
-        assert len(ble_sensor.SENSOR_DEFS) == 27
+        assert "battery_type_id" in ble_sensor.SENSOR_DEFS
+        assert len(ble_sensor.SENSOR_DEFS) == 28
 
 
 class TestJkBmsBleBinarySensorConstants:
@@ -158,7 +159,8 @@ class TestJkBleTextSensorConstants:
         assert ble_text_sensor.CONF_ERRORS in ble_text_sensor.TEXT_SENSORS
         assert ble_text_sensor.CONF_OPERATION_STATUS in ble_text_sensor.TEXT_SENSORS
         assert ble_text_sensor.CONF_CHARGE_STATUS in ble_text_sensor.TEXT_SENSORS
-        assert len(ble_text_sensor.TEXT_SENSORS) == 6
+        assert ble_text_sensor.CONF_BATTERY_TYPE in ble_text_sensor.TEXT_SENSORS
+        assert len(ble_text_sensor.TEXT_SENSORS) == 7
 
 
 class TestJkBmsDisplaySensorLists:


### PR DESCRIPTION
## Summary

- Adds `battery_type_id` sensor (numeric, JK02_32S only): raw value 0/1/2
- Adds `battery_type` text sensor (JK02_32S only): "LFP", "Li-ion", or "LTO"
- Byte position 275 (code position `data[243 + offset]`, offset=32 for JK02_32S) confirmed via BLE emulator: setting `0x01` causes the Android app to display "Lion"

## Test plan

- [ ] Pytest schema tests pass (`test_sensor_defs_completeness`, `test_text_sensors_list`)
- [ ] C++ GoogleTest: `BatteryTypeCode` and `BatteryType` in `jk_bms_ble_jk02_32s_v19_test.cpp`
- [ ] Flash v19 or v14/v15 firmware, confirm `battery_type` reports "LFP" for a standard device
- [ ] Emulator test with `battery_type_code=1` → app shows "Lion" ✓