### PR TITLE
BREAKING: Rename total_battery_capacity_setting sensor to full_charge_capacity

### DIFF
--- a/components/jk_bms/jk_bms.cpp
+++ b/components/jk_bms/jk_bms.cpp
@@ -323,10 +323,10 @@ void JkBms::on_status_data_(const std::vector<uint8_t> &data) {
   // 0xA9 0x0E: Battery string setting                                      14              1.0 count
   // this->publish_state_(this->battery_string_setting_sensor_, (float) data[offset + 8 + 3 * 36]);
   // 0xAA 0x00 0x00 0x02 0x30: Total battery capacity setting              560 Ah           1.0 Ah
-  uint32_t raw_total_battery_capacity_setting = jk_get_32bit(offset + 10 + 3 * 36);
-  this->publish_state_(this->total_battery_capacity_setting_sensor_, (float) raw_total_battery_capacity_setting);
+  uint32_t raw_full_charge_capacity = jk_get_32bit(offset + 10 + 3 * 36);
+  this->publish_state_(this->full_charge_capacity_sensor_, (float) raw_full_charge_capacity);
   this->publish_state_(this->capacity_remaining_derived_sensor_,
-                       (float) (raw_total_battery_capacity_setting * (raw_battery_remaining_capacity * 0.01f)));
+                       (float) (raw_full_charge_capacity * (raw_battery_remaining_capacity * 0.01f)));
 
   // 0xAB 0x01: Charging MOS tube switch                                     1 (on)         Bool       0 (off), 1 (on)
   this->publish_state_(this->charging_switch_binary_sensor_, (bool) data[offset + 15 + 3 * 36]);
@@ -473,7 +473,7 @@ void JkBms::publish_device_unavailable_() {
   this->publish_state_(charging_low_temperature_recovery_sensor_, NAN);
   this->publish_state_(discharging_low_temperature_protection_sensor_, NAN);
   this->publish_state_(discharging_low_temperature_recovery_sensor_, NAN);
-  this->publish_state_(total_battery_capacity_setting_sensor_, NAN);
+  this->publish_state_(full_charge_capacity_sensor_, NAN);
   this->publish_state_(charging_sensor_, NAN);
   this->publish_state_(discharging_sensor_, NAN);
   this->publish_state_(current_calibration_sensor_, NAN);
@@ -644,7 +644,7 @@ void JkBms::dump_config() {  // NOLINT(google-readability-function-size,readabil
   LOG_SENSOR("", "Charging Low Temperature Recovery", this->charging_low_temperature_recovery_sensor_);
   LOG_SENSOR("", "Discharging Low Temperature Protection", this->discharging_low_temperature_protection_sensor_);
   LOG_SENSOR("", "Discharging Low Temperature Recovery", this->discharging_low_temperature_recovery_sensor_);
-  LOG_SENSOR("", "Total Battery Capacity Setting", this->total_battery_capacity_setting_sensor_);
+  LOG_SENSOR("", "Full Charge Capacity", this->full_charge_capacity_sensor_);
   LOG_SENSOR("", "Current Calibration", this->current_calibration_sensor_);
   LOG_SENSOR("", "Device Address", this->device_address_sensor_);
   LOG_TEXT_SENSOR("", "Battery Type", this->battery_type_text_sensor_);

--- a/components/jk_bms/jk_bms.h
+++ b/components/jk_bms/jk_bms.h
@@ -183,8 +183,8 @@ class JkBms : public PollingComponent, public jk_modbus::JkModbusDevice {
   void set_discharging_low_temperature_recovery_sensor(sensor::Sensor *discharging_low_temperature_recovery_sensor) {
     discharging_low_temperature_recovery_sensor_ = discharging_low_temperature_recovery_sensor;
   }
-  void set_total_battery_capacity_setting_sensor(sensor::Sensor *total_battery_capacity_setting_sensor) {
-    total_battery_capacity_setting_sensor_ = total_battery_capacity_setting_sensor;
+  void set_full_charge_capacity_sensor(sensor::Sensor *full_charge_capacity_sensor) {
+    full_charge_capacity_sensor_ = full_charge_capacity_sensor;
   }
   void set_current_calibration_sensor(sensor::Sensor *current_calibration_sensor) {
     current_calibration_sensor_ = current_calibration_sensor;
@@ -303,7 +303,7 @@ class JkBms : public PollingComponent, public jk_modbus::JkModbusDevice {
   sensor::Sensor *charging_low_temperature_recovery_sensor_{nullptr};
   sensor::Sensor *discharging_low_temperature_protection_sensor_{nullptr};
   sensor::Sensor *discharging_low_temperature_recovery_sensor_{nullptr};
-  sensor::Sensor *total_battery_capacity_setting_sensor_{nullptr};
+  sensor::Sensor *full_charge_capacity_sensor_{nullptr};
   sensor::Sensor *charging_sensor_{nullptr};
   sensor::Sensor *discharging_sensor_{nullptr};
   sensor::Sensor *current_calibration_sensor_{nullptr};

--- a/components/jk_bms/sensor.py
+++ b/components/jk_bms/sensor.py
@@ -96,7 +96,7 @@ CONF_DISCHARGING_LOW_TEMPERATURE_RECOVERY = "discharging_low_temperature_recover
 
 # r/w
 # CONF_BATTERY_STRINGS = "battery_strings"
-CONF_TOTAL_BATTERY_CAPACITY_SETTING = "total_battery_capacity_setting"
+CONF_FULL_CHARGE_CAPACITY = "full_charge_capacity"
 
 CONF_CURRENT_CALIBRATION = "current_calibration"
 CONF_DEVICE_ADDRESS = "device_address"
@@ -473,7 +473,7 @@ SENSOR_DEFS = {
         "device_class": DEVICE_CLASS_TEMPERATURE,
         "state_class": STATE_CLASS_MEASUREMENT,
     },
-    CONF_TOTAL_BATTERY_CAPACITY_SETTING: {
+    CONF_FULL_CHARGE_CAPACITY: {
         "unit_of_measurement": UNIT_AMPERE_HOURS,
         "icon": ICON_TOTAL_BATTERY_CAPACITY_SETTING,
         "accuracy_decimals": 0,

--- a/components/jk_bms_ble/jk_bms_ble.cpp
+++ b/components/jk_bms_ble/jk_bms_ble.cpp
@@ -168,7 +168,7 @@ void JkBmsBle::dump_config() {  // NOLINT(google-readability-function-size,reada
   LOG_SENSOR("", "State Of Charge", this->state_of_charge_sensor_);
   LOG_SENSOR("", "State Of Health", this->state_of_health_sensor_);
   LOG_SENSOR("", "Capacity Remaining", this->capacity_remaining_sensor_);
-  LOG_SENSOR("", "Total Battery Capacity Setting", this->total_battery_capacity_setting_sensor_);
+  LOG_SENSOR("", "Full Charge Capacity", this->full_charge_capacity_sensor_);
   LOG_SENSOR("", "Charging Cycles", this->charging_cycles_sensor_);
   LOG_SENSOR("", "Total Charging Cycle Capacity", this->total_charging_cycle_capacity_sensor_);
   LOG_SENSOR("", "Total Runtime", this->total_runtime_sensor_);
@@ -610,7 +610,7 @@ void JkBmsBle::decode_jk02_cell_info_(const std::vector<uint8_t> &data) {
   this->publish_state_(this->capacity_remaining_sensor_, (float) jk_get_32bit(142 + offset) * 0.001f);
 
   // 146   4   0x68 0x3C 0x01 0x00    Nominal_Capacity     0.001         Ah
-  this->publish_state_(this->total_battery_capacity_setting_sensor_, (float) jk_get_32bit(146 + offset) * 0.001f);
+  this->publish_state_(this->full_charge_capacity_sensor_, (float) jk_get_32bit(146 + offset) * 0.001f);
 
   // 150   4   0x00 0x00 0x00 0x00    Cycle_Count          1.0
   this->publish_state_(this->charging_cycles_sensor_, (float) jk_get_32bit(150 + offset));
@@ -1613,7 +1613,7 @@ void JkBmsBle::publish_device_unavailable_() {
   this->publish_state_(state_of_charge_sensor_, NAN);
   this->publish_state_(state_of_health_sensor_, NAN);
   this->publish_state_(capacity_remaining_sensor_, NAN);
-  this->publish_state_(total_battery_capacity_setting_sensor_, NAN);
+  this->publish_state_(full_charge_capacity_sensor_, NAN);
   this->publish_state_(charging_cycles_sensor_, NAN);
   this->publish_state_(total_charging_cycle_capacity_sensor_, NAN);
   this->publish_state_(total_runtime_sensor_, NAN);

--- a/components/jk_bms_ble/jk_bms_ble.h
+++ b/components/jk_bms_ble/jk_bms_ble.h
@@ -241,8 +241,8 @@ class JkBmsBle :
   void set_capacity_remaining_sensor(sensor::Sensor *capacity_remaining_sensor) {
     capacity_remaining_sensor_ = capacity_remaining_sensor;
   }
-  void set_total_battery_capacity_setting_sensor(sensor::Sensor *total_battery_capacity_setting_sensor) {
-    total_battery_capacity_setting_sensor_ = total_battery_capacity_setting_sensor;
+  void set_full_charge_capacity_sensor(sensor::Sensor *full_charge_capacity_sensor) {
+    full_charge_capacity_sensor_ = full_charge_capacity_sensor;
   }
   void set_charging_cycles_sensor(sensor::Sensor *charging_cycles_sensor) {
     charging_cycles_sensor_ = charging_cycles_sensor;
@@ -403,7 +403,7 @@ class JkBmsBle :
   sensor::Sensor *state_of_charge_sensor_{nullptr};
   sensor::Sensor *state_of_health_sensor_{nullptr};
   sensor::Sensor *capacity_remaining_sensor_{nullptr};
-  sensor::Sensor *total_battery_capacity_setting_sensor_{nullptr};
+  sensor::Sensor *full_charge_capacity_sensor_{nullptr};
   sensor::Sensor *charging_cycles_sensor_{nullptr};
   sensor::Sensor *total_charging_cycle_capacity_sensor_{nullptr};
   sensor::Sensor *total_runtime_sensor_{nullptr};

--- a/components/jk_bms_ble/sensor.py
+++ b/components/jk_bms_ble/sensor.py
@@ -48,7 +48,7 @@ CONF_POWER_TUBE_TEMPERATURE = "power_tube_temperature"
 CONF_STATE_OF_CHARGE = "state_of_charge"
 CONF_STATE_OF_HEALTH = "state_of_health"
 CONF_CAPACITY_REMAINING = "capacity_remaining"
-CONF_TOTAL_BATTERY_CAPACITY_SETTING = "total_battery_capacity_setting"
+CONF_FULL_CHARGE_CAPACITY = "full_charge_capacity"
 CONF_CHARGING_CYCLES = "charging_cycles"
 CONF_TOTAL_CHARGING_CYCLE_CAPACITY = "total_charging_cycle_capacity"
 CONF_TOTAL_RUNTIME = "total_runtime"
@@ -214,7 +214,7 @@ SENSOR_DEFS = {
         "device_class": DEVICE_CLASS_EMPTY,
         "state_class": STATE_CLASS_MEASUREMENT,
     },
-    CONF_TOTAL_BATTERY_CAPACITY_SETTING: {
+    CONF_FULL_CHARGE_CAPACITY: {
         "unit_of_measurement": UNIT_AMPERE_HOURS,
         "icon": ICON_EMPTY,
         "accuracy_decimals": 0,

--- a/esp32-ble-example.yaml
+++ b/esp32-ble-example.yaml
@@ -284,8 +284,8 @@ sensor:
       name: "state of charge"
     capacity_remaining:
       name: "capacity remaining"
-    total_battery_capacity_setting:
-      name: "total battery capacity setting"
+    full_charge_capacity:
+      name: "full charge capacity"
     charging_cycles:
       name: "charging cycles"
     total_charging_cycle_capacity:

--- a/esp32-ble-v11-example.yaml
+++ b/esp32-ble-v11-example.yaml
@@ -300,8 +300,8 @@ sensor:
       name: "state of charge"
     capacity_remaining:
       name: "capacity remaining"
-    total_battery_capacity_setting:
-      name: "total battery capacity setting"
+    full_charge_capacity:
+      name: "full charge capacity"
     charging_cycles:
       name: "charging cycles"
     total_charging_cycle_capacity:

--- a/esp32-ble-v14-example-multiple-devices.yaml
+++ b/esp32-ble-v14-example-multiple-devices.yaml
@@ -577,8 +577,8 @@ sensor:
     capacity_remaining:
       name: "capacity remaining"
       device_id: device0
-    total_battery_capacity_setting:
-      name: "total battery capacity setting"
+    full_charge_capacity:
+      name: "full charge capacity"
       device_id: device0
     charging_cycles:
       name: "charging cycles"
@@ -809,8 +809,8 @@ sensor:
     capacity_remaining:
       name: "capacity remaining"
       device_id: device1
-    total_battery_capacity_setting:
-      name: "total battery capacity setting"
+    full_charge_capacity:
+      name: "full charge capacity"
       device_id: device1
     charging_cycles:
       name: "charging cycles"

--- a/esp32-ble-v14-example.yaml
+++ b/esp32-ble-v14-example.yaml
@@ -312,8 +312,8 @@ sensor:
       name: "state of health"
     capacity_remaining:
       name: "capacity remaining"
-    total_battery_capacity_setting:
-      name: "total battery capacity setting"
+    full_charge_capacity:
+      name: "full charge capacity"
     charging_cycles:
       name: "charging cycles"
     total_charging_cycle_capacity:

--- a/esp32-ble-v15-example.yaml
+++ b/esp32-ble-v15-example.yaml
@@ -316,8 +316,8 @@ sensor:
       name: "state of health"
     capacity_remaining:
       name: "capacity remaining"
-    total_battery_capacity_setting:
-      name: "total battery capacity setting"
+    full_charge_capacity:
+      name: "full charge capacity"
     charging_cycles:
       name: "charging cycles"
     total_charging_cycle_capacity:

--- a/esp32-ble-v19-example.yaml
+++ b/esp32-ble-v19-example.yaml
@@ -318,8 +318,8 @@ sensor:
       name: "state of health"
     capacity_remaining:
       name: "capacity remaining"
-    total_battery_capacity_setting:
-      name: "total battery capacity setting"
+    full_charge_capacity:
+      name: "full charge capacity"
     charging_cycles:
       name: "charging cycles"
     total_charging_cycle_capacity:

--- a/esp32-example.yaml
+++ b/esp32-example.yaml
@@ -221,8 +221,8 @@ sensor:
       name: "discharging low temperature protection"
     discharging_low_temperature_recovery:
       name: "discharging low temperature recovery"
-    total_battery_capacity_setting:
-      name: "total battery capacity setting"
+    full_charge_capacity:
+      name: "full charge capacity"
     current_calibration:
       name: "current calibration"
     device_address:

--- a/esp8266-example.yaml
+++ b/esp8266-example.yaml
@@ -220,8 +220,8 @@ sensor:
       name: "discharging low temperature protection"
     discharging_low_temperature_recovery:
       name: "discharging low temperature recovery"
-    total_battery_capacity_setting:
-      name: "total battery capacity setting"
+    full_charge_capacity:
+      name: "full charge capacity"
     current_calibration:
       name: "current calibration"
     device_address:

--- a/tests/components/jk_bms/jk_bms_test.cpp
+++ b/tests/components/jk_bms/jk_bms_test.cpp
@@ -99,7 +99,7 @@ TEST(JkBmsStatusDataTest, Capacity) {
   sensor::Sensor remaining, remaining_derived, nominal;
   bms.set_capacity_remaining_sensor(&remaining);
   bms.set_capacity_remaining_derived_sensor(&remaining_derived);
-  bms.set_total_battery_capacity_setting_sensor(&nominal);
+  bms.set_full_charge_capacity_sensor(&nominal);
 
   bms.on_jk_modbus_data(FUNCTION_READ_ALL, STATUS_FRAME_14S);
 

--- a/tests/components/jk_bms_ble/jk_bms_ble_jk02_24s_v10_test.cpp
+++ b/tests/components/jk_bms_ble/jk_bms_ble_jk02_24s_v10_test.cpp
@@ -72,7 +72,7 @@ TEST(JkBmsV10CellInfoTest, Capacity) {
   TestableJkBmsBle bms;
   sensor::Sensor remaining, nominal;
   bms.set_capacity_remaining_sensor(&remaining);
-  bms.set_total_battery_capacity_setting_sensor(&nominal);
+  bms.set_full_charge_capacity_sensor(&nominal);
   bms.decode_jk02_cell_info_(CELL_INFO_JK02_24S_V10);
   EXPECT_NEAR(remaining.state, 42.804f, 0.001f);
   EXPECT_NEAR(nominal.state, 50.0f, 0.001f);

--- a/tests/components/jk_bms_ble/jk_bms_ble_jk02_32s_v15_test.cpp
+++ b/tests/components/jk_bms_ble/jk_bms_ble_jk02_32s_v15_test.cpp
@@ -94,7 +94,7 @@ TEST(JkBmsV15CellInfoTest, Capacity) {
   bms.set_protocol_version(PROTOCOL_VERSION_JK02_32S);
   sensor::Sensor remaining, nominal;
   bms.set_capacity_remaining_sensor(&remaining);
-  bms.set_total_battery_capacity_setting_sensor(&nominal);
+  bms.set_full_charge_capacity_sensor(&nominal);
   bms.decode_jk02_cell_info_(CELL_INFO_JK02_32S_V15);
   EXPECT_NEAR(remaining.state, 49.286f, 0.001f);
   EXPECT_NEAR(nominal.state, 200.000f, 0.001f);

--- a/tests/components/jk_bms_ble/jk_bms_ble_jk02_32s_v19_test.cpp
+++ b/tests/components/jk_bms_ble/jk_bms_ble_jk02_32s_v19_test.cpp
@@ -76,7 +76,7 @@ TEST(JkBmsV19CellInfoTest, Capacity) {
   bms.set_protocol_version(PROTOCOL_VERSION_JK02_32S);
   sensor::Sensor remaining, nominal;
   bms.set_capacity_remaining_sensor(&remaining);
-  bms.set_total_battery_capacity_setting_sensor(&nominal);
+  bms.set_full_charge_capacity_sensor(&nominal);
   bms.decode_jk02_cell_info_(CELL_INFO_JK02_32S_V19);
   EXPECT_NEAR(remaining.state, 312.898f, 0.001f);
   EXPECT_NEAR(nominal.state, 314.000f, 0.001f);

--- a/tests/components/jk_bms_ble/jk_bms_ble_test.cpp
+++ b/tests/components/jk_bms_ble/jk_bms_ble_test.cpp
@@ -187,7 +187,7 @@ TEST(JkBmsBleJk02CellInfoTest, Capacity) {
   TestableJkBmsBle bms;
   sensor::Sensor remaining, nominal, cycles;
   bms.set_capacity_remaining_sensor(&remaining);
-  bms.set_total_battery_capacity_setting_sensor(&nominal);
+  bms.set_full_charge_capacity_sensor(&nominal);
   bms.set_charging_cycles_sensor(&cycles);
 
   bms.decode_jk02_cell_info_(CELL_INFO_JK02_24S_V10);

--- a/tests/esp32-ble-b2a25s-example.yaml
+++ b/tests/esp32-ble-b2a25s-example.yaml
@@ -304,8 +304,8 @@ sensor:
       name: "state of charge"
     capacity_remaining:
       name: "capacity remaining"
-    total_battery_capacity_setting:
-      name: "total battery capacity setting"
+    full_charge_capacity:
+      name: "full charge capacity"
     charging_cycles:
       name: "charging cycles"
     total_charging_cycle_capacity:

--- a/tests/test_component_schemas.py
+++ b/tests/test_component_schemas.py
@@ -114,6 +114,7 @@ class TestJkBmsBleSensorLists:
 
     def test_sensor_defs_completeness(self):
         assert "total_voltage" in ble_sensor.SENSOR_DEFS
+        assert "full_charge_capacity" in ble_sensor.SENSOR_DEFS
         assert "detail_log_count" in ble_sensor.SENSOR_DEFS
         assert "battery_type_id" in ble_sensor.SENSOR_DEFS
         assert len(ble_sensor.SENSOR_DEFS) == 27


### PR DESCRIPTION
## Root cause

The `total_battery_capacity_setting` sensor was misnamed. The field it decodes (cell info frame, `Nominal_Capacity`) is **not** the user-configured capacity — it is the BMS's internally computed **Full Charge Capacity (FCC)**: how many Ah the BMS measured the battery delivering during its last observed full charge/discharge cycle.

The actual user-configured capacity is exposed by the writable `total_battery_capacity` **number** entity, which reads from the settings frame.

### Why the values diverge

When cells drop below their 0%-SoC threshold and recharge to 100%, the BMS measures the Ah transferred and stores that as the new FCC. If the pack is unbalanced or partially degraded, this measured value can be significantly lower than the configured setting — causing the sensor to report e.g. 161 Ah on a 250 Ah battery, or 316.8 Ah on a 320 Ah battery.

The correct term for this field in battery management standards (SBS specification) is **Full Charge Capacity**.

## Breaking change

| Before | After |
|--------|-------|
| `total_battery_capacity_setting` | `full_charge_capacity` |

Users who reference `total_battery_capacity_setting` in Home Assistant, automations, or dashboards must rename the entity.

## Closes

- #535 — capacity reporting 161 Ah instead of 250 Ah
- #889 — `total battery capacity setting` changes unexpectedly
- #941 — remaining capacity stuck at 316.801 Ah