### PR TITLE
BREAKING: Rename balancing sensor to balancer_status

### DIFF
--- a/components/jk_bms_ble/jk_bms_ble.cpp
+++ b/components/jk_bms_ble/jk_bms_ble.cpp
@@ -164,7 +164,7 @@ void JkBmsBle::dump_config() {  // NOLINT(google-readability-function-size,reada
   LOG_SENSOR("", "Temperature Sensor 3", this->temperatures_[2].temperature_sensor_);
   LOG_SENSOR("", "Temperature Sensor 4", this->temperatures_[3].temperature_sensor_);
   LOG_SENSOR("", "Temperature Sensor 5", this->temperatures_[4].temperature_sensor_);
-  LOG_SENSOR("", "Balancing", this->balancing_sensor_);
+  LOG_SENSOR("", "Balancing", this->balancer_status_sensor_);
   LOG_SENSOR("", "State Of Charge", this->state_of_charge_sensor_);
   LOG_SENSOR("", "State Of Health", this->state_of_health_sensor_);
   LOG_SENSOR("", "Capacity Remaining", this->capacity_remaining_sensor_);
@@ -599,7 +599,7 @@ void JkBmsBle::decode_jk02_cell_info_(const std::vector<uint8_t> &data) {
   // 140   1   0x00                   Balancing action                   0x00: Off
   //                                                                     0x01: Charging balancer
   //                                                                     0x02: Discharging balancer
-  this->publish_state_(this->balancing_sensor_, (data[140 + offset]));
+  this->publish_state_(this->balancer_status_sensor_, (data[140 + offset]));
   this->publish_state_(this->balancing_binary_sensor_, (data[140 + offset] != 0x00));
   ESP_LOGD(TAG, "Balancing indicator (legacy): %s", YESNO(data[140 + offset] != 0x00));
 
@@ -1609,7 +1609,7 @@ void JkBmsBle::publish_device_unavailable_() {
   this->publish_state_(charging_power_sensor_, NAN);
   this->publish_state_(discharging_power_sensor_, NAN);
   this->publish_state_(power_tube_temperature_sensor_, NAN);
-  this->publish_state_(balancing_sensor_, NAN);
+  this->publish_state_(balancer_status_sensor_, NAN);
   this->publish_state_(state_of_charge_sensor_, NAN);
   this->publish_state_(state_of_health_sensor_, NAN);
   this->publish_state_(capacity_remaining_sensor_, NAN);

--- a/components/jk_bms_ble/jk_bms_ble.h
+++ b/components/jk_bms_ble/jk_bms_ble.h
@@ -169,7 +169,9 @@ class JkBmsBle :
   void set_balancing_binary_sensor(binary_sensor::BinarySensor *balancing_binary_sensor) {
     balancing_binary_sensor_ = balancing_binary_sensor;
   }
-  void set_balancing_sensor(sensor::Sensor *balancing_sensor) { balancing_sensor_ = balancing_sensor; }
+  void set_balancer_status_sensor(sensor::Sensor *balancer_status_sensor) {
+    balancer_status_sensor_ = balancer_status_sensor;
+  }
   void set_precharging_binary_sensor(binary_sensor::BinarySensor *precharging_binary_sensor) {
     precharging_binary_sensor_ = precharging_binary_sensor;
   }
@@ -387,7 +389,7 @@ class JkBmsBle :
   number::Number *heating_stop_temperature_number_{nullptr};
   number::Number *re_bulk_soc_number_{nullptr};
 
-  sensor::Sensor *balancing_sensor_{nullptr};
+  sensor::Sensor *balancer_status_sensor_{nullptr};
   sensor::Sensor *min_cell_voltage_sensor_{nullptr};
   sensor::Sensor *max_cell_voltage_sensor_{nullptr};
   sensor::Sensor *min_voltage_cell_sensor_{nullptr};

--- a/components/jk_bms_ble/sensor.py
+++ b/components/jk_bms_ble/sensor.py
@@ -26,8 +26,6 @@ from esphome.const import (
 
 from . import CONF_JK_BMS_BLE_ID, JK_BMS_BLE_COMPONENT_SCHEMA
 
-CONF_BALANCER_STATUS = "balancer_status"
-
 CODEOWNERS = ["@syssi", "@txubelaxu"]
 
 CONF_MIN_CELL_VOLTAGE = "min_cell_voltage"
@@ -60,6 +58,7 @@ CONF_CHARGE_STATUS_ID = "charge_status_id"
 CONF_CHARGE_STATUS_TIME_ELAPSED = "charge_status_time_elapsed"
 CONF_DETAIL_LOG_COUNT = "detail_log_count"
 CONF_BATTERY_TYPE_ID = "battery_type_id"
+CONF_BALANCER_STATUS = "balancer_status"
 
 UNIT_AMPERE_HOURS = "Ah"
 UNIT_OHM = "Ω"

--- a/components/jk_bms_ble/sensor.py
+++ b/components/jk_bms_ble/sensor.py
@@ -25,7 +25,8 @@ from esphome.const import (
 )
 
 from . import CONF_JK_BMS_BLE_ID, JK_BMS_BLE_COMPONENT_SCHEMA
-from .const import CONF_BALANCING
+
+CONF_BALANCER_STATUS = "balancer_status"
 
 CODEOWNERS = ["@syssi", "@txubelaxu"]
 
@@ -104,7 +105,7 @@ _TEMPERATURE_SCHEMA = sensor.sensor_schema(
 )
 
 SENSOR_DEFS = {
-    CONF_BALANCING: {
+    CONF_BALANCER_STATUS: {
         "unit_of_measurement": UNIT_EMPTY,
         "icon": ICON_BALANCER,
         "accuracy_decimals": 0,
@@ -304,6 +305,9 @@ CONFIG_SCHEMA = (
         {
             cv.Optional("errors_bitmask"): cv.invalid(
                 "sensor.errors_bitmask has been removed; use text_sensor.errors_bitmask_hex instead"
+            ),
+            cv.Optional("balancing"): cv.invalid(
+                "sensor.balancing has been renamed to sensor.balancer_status"
             ),
         }
     )

--- a/esp32-ble-example.yaml
+++ b/esp32-ble-example.yaml
@@ -278,8 +278,8 @@ sensor:
     #   name: "temperature sensor 4"
     power_tube_temperature:
       name: "power tube temperature"
-    balancing:
-      name: "balancing"
+    balancer_status:
+      name: "balancer status"
     state_of_charge:
       name: "state of charge"
     capacity_remaining:

--- a/esp32-ble-v11-example.yaml
+++ b/esp32-ble-v11-example.yaml
@@ -294,8 +294,8 @@ sensor:
       name: "temperature sensor 4"
     power_tube_temperature:
       name: "power tube temperature"
-    balancing:
-      name: "balancing"
+    balancer_status:
+      name: "balancer status"
     state_of_charge:
       name: "state of charge"
     capacity_remaining:

--- a/esp32-ble-v14-example-multiple-devices.yaml
+++ b/esp32-ble-v14-example-multiple-devices.yaml
@@ -568,8 +568,8 @@ sensor:
     power_tube_temperature:
       name: "power tube temperature"
       device_id: device0
-    balancing:
-      name: "balancing"
+    balancer_status:
+      name: "balancer status"
       device_id: device0
     state_of_charge:
       name: "state of charge"
@@ -800,8 +800,8 @@ sensor:
     power_tube_temperature:
       name: "power tube temperature"
       device_id: device1
-    balancing:
-      name: "balancing"
+    balancer_status:
+      name: "balancer status"
       device_id: device1
     state_of_charge:
       name: "state of charge"

--- a/esp32-ble-v14-example.yaml
+++ b/esp32-ble-v14-example.yaml
@@ -304,8 +304,8 @@ sensor:
       name: "temperature sensor 5"
     power_tube_temperature:
       name: "power tube temperature"
-    balancing:
-      name: "balancing"
+    balancer_status:
+      name: "balancer status"
     state_of_charge:
       name: "state of charge"
     state_of_health:

--- a/esp32-ble-v15-example.yaml
+++ b/esp32-ble-v15-example.yaml
@@ -308,8 +308,8 @@ sensor:
       name: "temperature sensor 5"
     power_tube_temperature:
       name: "power tube temperature"
-    balancing:
-      name: "balancing"
+    balancer_status:
+      name: "balancer status"
     state_of_charge:
       name: "state of charge"
     state_of_health:

--- a/esp32-ble-v19-example.yaml
+++ b/esp32-ble-v19-example.yaml
@@ -310,8 +310,8 @@ sensor:
       name: "temperature sensor 5"
     power_tube_temperature:
       name: "power tube temperature"
-    balancing:
-      name: "balancing"
+    balancer_status:
+      name: "balancer status"
     state_of_charge:
       name: "state of charge"
     state_of_health:

--- a/tests/components/jk_bms_ble/jk_bms_ble_test.cpp
+++ b/tests/components/jk_bms_ble/jk_bms_ble_test.cpp
@@ -152,14 +152,14 @@ TEST(JkBmsBleJk02CellInfoTest, NoErrors) {
 
 TEST(JkBmsBleJk02CellInfoTest, BalancingOff) {
   TestableJkBmsBle bms;
-  sensor::Sensor balancing;
+  sensor::Sensor balancer_status;
   binary_sensor::BinarySensor balancing_binary;
-  bms.set_balancing_sensor(&balancing);
+  bms.set_balancer_status_sensor(&balancer_status);
   bms.set_balancing_binary_sensor(&balancing_binary);
 
   bms.decode_jk02_cell_info_(CELL_INFO_JK02_24S_V10);
 
-  EXPECT_FLOAT_EQ(balancing.state, 0.0f);
+  EXPECT_FLOAT_EQ(balancer_status.state, 0.0f);
   EXPECT_FALSE(balancing_binary.state);
 }
 

--- a/tests/esp32-ble-b2a25s-example.yaml
+++ b/tests/esp32-ble-b2a25s-example.yaml
@@ -298,8 +298,8 @@ sensor:
       name: "charging power"
     discharging_power:
       name: "discharging power"
-    balancing:
-      name: "balancing"
+    balancer_status:
+      name: "balancer status"
     state_of_charge:
       name: "state of charge"
     capacity_remaining:

--- a/tests/test_component_schemas.py
+++ b/tests/test_component_schemas.py
@@ -115,6 +115,7 @@ class TestJkBmsBleSensorLists:
     def test_sensor_defs_completeness(self):
         assert "total_voltage" in ble_sensor.SENSOR_DEFS
         assert "full_charge_capacity" in ble_sensor.SENSOR_DEFS
+        assert "balancer_status" in ble_sensor.SENSOR_DEFS
         assert "detail_log_count" in ble_sensor.SENSOR_DEFS
         assert "battery_type_id" in ble_sensor.SENSOR_DEFS
         assert len(ble_sensor.SENSOR_DEFS) == 27


### PR DESCRIPTION
## Problem

The `balancing` **sensor** (numeric, values 0/1/2) and the `balancing` **binary sensor** (true/false) share the same name, which is confusing when both are configured simultaneously. Users cannot tell from the entity name alone which one they are using.

## Change

| Before | After |
|--------|-------|
| `balancing` (sensor, numeric) | `balancer_status` |

Values: `0` = off, `1` = charging balancer active, `2` = discharging balancer active.

The `balancing` **binary sensor** is unaffected.

## Breaking change

Users who reference the numeric `balancing` sensor in Home Assistant, automations, or dashboards must rename the entity to `balancer_status`.

Closes #579