### PR TITLE
Add migration hint for renamed total_battery_capacity_setting sensor

### DIFF
--- a/components/jk_bms_ble/sensor.py
+++ b/components/jk_bms_ble/sensor.py
@@ -308,6 +308,9 @@ CONFIG_SCHEMA = (
             cv.Optional("balancing"): cv.invalid(
                 "sensor.balancing has been renamed to sensor.balancer_status"
             ),
+            cv.Optional("total_battery_capacity_setting"): cv.invalid(
+                "sensor.total_battery_capacity_setting has been renamed to sensor.full_charge_capacity"
+            ),
         }
     )
 )


### PR DESCRIPTION
## Summary

- Adds `cv.invalid()` hint for the old `sensor.total_battery_capacity_setting` key
- Users who haven't migrated yet get a clear error message pointing to the new name `sensor.full_charge_capacity`

Follows the pattern established for `sensor.errors_bitmask`.

Related: #965