### PR TITLE
BREAKING: Rename cell_pressure_difference_protection sensor to cell_voltage_difference_protection

### DIFF
--- a/components/jk_bms/jk_bms.cpp
+++ b/components/jk_bms/jk_bms.cpp
@@ -253,7 +253,7 @@ void JkBms::on_status_data_(const std::vector<uint8_t> &data) {
   this->publish_state_(this->cell_voltage_undervoltage_delay_sensor_, (float) jk_get_16bit(offset + 6 + 3 * 17));
 
   // 0x96 0x01 0x2C: Cell pressure difference protection value    300 * 0.001 = 0.300V     0.001 V     0.000-1.000V
-  this->publish_state_(this->cell_pressure_difference_protection_sensor_,
+  this->publish_state_(this->cell_voltage_difference_protection_sensor_,
                        (float) jk_get_16bit(offset + 6 + 3 * 18) * 0.001f);
 
   // 0x97 0x00 0x07: Discharge overcurrent protection value       7A                         1.0 A
@@ -455,7 +455,7 @@ void JkBms::publish_device_unavailable_() {
   this->publish_state_(cell_voltage_undervoltage_protection_sensor_, NAN);
   this->publish_state_(cell_voltage_undervoltage_recovery_sensor_, NAN);
   this->publish_state_(cell_voltage_undervoltage_delay_sensor_, NAN);
-  this->publish_state_(cell_pressure_difference_protection_sensor_, NAN);
+  this->publish_state_(cell_voltage_difference_protection_sensor_, NAN);
   this->publish_state_(discharging_overcurrent_protection_sensor_, NAN);
   this->publish_state_(discharging_overcurrent_delay_sensor_, NAN);
   this->publish_state_(charging_overcurrent_protection_sensor_, NAN);
@@ -625,7 +625,7 @@ void JkBms::dump_config() {  // NOLINT(google-readability-function-size,readabil
   LOG_SENSOR("", "Cell Voltage Undervoltage Protection", this->cell_voltage_undervoltage_protection_sensor_);
   LOG_SENSOR("", "Cell Voltage Undervoltage Recovery", this->cell_voltage_undervoltage_recovery_sensor_);
   LOG_SENSOR("", "Cell Voltage Undervoltage Delay", this->cell_voltage_undervoltage_delay_sensor_);
-  LOG_SENSOR("", "Cell Pressure Difference Protection", this->cell_pressure_difference_protection_sensor_);
+  LOG_SENSOR("", "Cell Voltage Difference Protection", this->cell_voltage_difference_protection_sensor_);
   LOG_SENSOR("", "Discharging Overcurrent Protection", this->discharging_overcurrent_protection_sensor_);
   LOG_SENSOR("", "Discharging Overcurrent Delay", this->discharging_overcurrent_delay_sensor_);
   LOG_SENSOR("", "Charging Overcurrent Protection", this->charging_overcurrent_protection_sensor_);

--- a/components/jk_bms/jk_bms.h
+++ b/components/jk_bms/jk_bms.h
@@ -123,8 +123,8 @@ class JkBms : public PollingComponent, public jk_modbus::JkModbusDevice {
   void set_cell_voltage_undervoltage_delay_sensor(sensor::Sensor *cell_voltage_undervoltage_delay_sensor) {
     cell_voltage_undervoltage_delay_sensor_ = cell_voltage_undervoltage_delay_sensor;
   }
-  void set_cell_pressure_difference_protection_sensor(sensor::Sensor *cell_pressure_difference_protection_sensor) {
-    cell_pressure_difference_protection_sensor_ = cell_pressure_difference_protection_sensor;
+  void set_cell_voltage_difference_protection_sensor(sensor::Sensor *cell_voltage_difference_protection_sensor) {
+    cell_voltage_difference_protection_sensor_ = cell_voltage_difference_protection_sensor;
   }
   void set_discharging_overcurrent_protection_sensor(sensor::Sensor *discharging_overcurrent_protection_sensor) {
     discharging_overcurrent_protection_sensor_ = discharging_overcurrent_protection_sensor;
@@ -285,7 +285,7 @@ class JkBms : public PollingComponent, public jk_modbus::JkModbusDevice {
   sensor::Sensor *cell_voltage_undervoltage_protection_sensor_{nullptr};
   sensor::Sensor *cell_voltage_undervoltage_recovery_sensor_{nullptr};
   sensor::Sensor *cell_voltage_undervoltage_delay_sensor_{nullptr};
-  sensor::Sensor *cell_pressure_difference_protection_sensor_{nullptr};
+  sensor::Sensor *cell_voltage_difference_protection_sensor_{nullptr};
   sensor::Sensor *discharging_overcurrent_protection_sensor_{nullptr};
   sensor::Sensor *discharging_overcurrent_delay_sensor_{nullptr};
   sensor::Sensor *charging_overcurrent_protection_sensor_{nullptr};

--- a/components/jk_bms/sensor.py
+++ b/components/jk_bms/sensor.py
@@ -64,7 +64,7 @@ CONF_CELL_VOLTAGE_UNDERVOLTAGE_PROTECTION = "cell_voltage_undervoltage_protectio
 CONF_CELL_VOLTAGE_UNDERVOLTAGE_RECOVERY = "cell_voltage_undervoltage_recovery"
 CONF_CELL_VOLTAGE_UNDERVOLTAGE_DELAY = "cell_voltage_undervoltage_delay"
 
-CONF_CELL_PRESSURE_DIFFERENCE_PROTECTION = "cell_pressure_difference_protection"
+CONF_CELL_VOLTAGE_DIFFERENCE_PROTECTION = "cell_voltage_difference_protection"
 
 CONF_DISCHARGING_OVERCURRENT_PROTECTION = "discharging_overcurrent_protection"
 CONF_DISCHARGING_OVERCURRENT_DELAY = "discharging_overcurrent_delay"
@@ -347,7 +347,7 @@ SENSOR_DEFS = {
         "device_class": DEVICE_CLASS_EMPTY,
         "state_class": STATE_CLASS_MEASUREMENT,
     },
-    CONF_CELL_PRESSURE_DIFFERENCE_PROTECTION: {
+    CONF_CELL_VOLTAGE_DIFFERENCE_PROTECTION: {
         "unit_of_measurement": UNIT_VOLT,
         "icon": ICON_EMPTY,
         "accuracy_decimals": 3,
@@ -545,12 +545,22 @@ SENSOR_DEFS = {
     },
 }
 
-CONFIG_SCHEMA = JK_BMS_COMPONENT_SCHEMA.extend(
-    {
-        cv.Optional(key): sensor.sensor_schema(**kwargs)
-        for key, kwargs in SENSOR_DEFS.items()
-    }
-).extend({cv.Optional(key): _CELL_VOLTAGE_SCHEMA for key in CELLS})
+CONFIG_SCHEMA = (
+    JK_BMS_COMPONENT_SCHEMA.extend(
+        {
+            cv.Optional(key): sensor.sensor_schema(**kwargs)
+            for key, kwargs in SENSOR_DEFS.items()
+        }
+    )
+    .extend({cv.Optional(key): _CELL_VOLTAGE_SCHEMA for key in CELLS})
+    .extend(
+        {
+            cv.Optional("cell_pressure_difference_protection"): cv.invalid(
+                "sensor.cell_pressure_difference_protection has been renamed to sensor.cell_voltage_difference_protection"
+            ),
+        }
+    )
+)
 
 
 async def to_code(config):

--- a/esp32-example.yaml
+++ b/esp32-example.yaml
@@ -185,7 +185,7 @@ sensor:
       name: "cell voltage undervoltage recovery"
     cell_voltage_undervoltage_delay:
       name: "cell voltage undervoltage delay"
-    cell_pressure_difference_protection:
+    cell_voltage_difference_protection:
       name: "cell pressure difference protection"
     discharging_overcurrent_protection:
       name: "discharging overcurrent protection"

--- a/esp8266-example.yaml
+++ b/esp8266-example.yaml
@@ -184,7 +184,7 @@ sensor:
       name: "cell voltage undervoltage recovery"
     cell_voltage_undervoltage_delay:
       name: "cell voltage undervoltage delay"
-    cell_pressure_difference_protection:
+    cell_voltage_difference_protection:
       name: "cell pressure difference protection"
     discharging_overcurrent_protection:
       name: "discharging overcurrent protection"

--- a/lovelace-entities-card.yaml
+++ b/lovelace-entities-card.yaml
@@ -48,7 +48,7 @@ entities:
     name: Balance Starting Voltage
   - entity: sensor.jk_bms_battery_type
     name: Battery Type
-  - entity: sensor.jk_bms_cell_pressure_difference_protection
+  - entity: sensor.jk_bms_cell_voltage_difference_protection
     name: Cell Pressure Difference Protection
   - entity: sensor.jk_bms_cell_voltage_overvoltage_delay
     name: Cell Voltage Overvoltage Delay


### PR DESCRIPTION
## Summary

- Renames `sensor.cell_pressure_difference_protection` to `sensor.cell_voltage_difference_protection`
- "pressure difference" was a mistranslation from Chinese (压差 = voltage difference, not pressure difference)
- Adds `cv.invalid` migration hint for the old name

## Migration

```yaml
# Before
sensor:
  - platform: jk_bms
    cell_pressure_difference_protection:
      name: "..."

# After
sensor:
  - platform: jk_bms
    cell_voltage_difference_protection:
      name: "..."
```