### PR TITLE
BREAKING: Rename balance_opening_pressure_difference sensor to balancing_delta_voltage

### DIFF
--- a/components/jk_bms/jk_bms.cpp
+++ b/components/jk_bms/jk_bms.cpp
@@ -272,8 +272,7 @@ void JkBms::on_status_data_(const std::vector<uint8_t> &data) {
   this->publish_state_(this->balance_starting_voltage_sensor_, (float) jk_get_16bit(offset + 6 + 3 * 23) * 0.001f);
 
   // 0x9C 0x00 0x08: Balanced opening pressure difference           8 * 0.001 = 0.008V     0.001 V     0.01-1V
-  this->publish_state_(this->balancing_delta_voltage_sensor_,
-                       (float) jk_get_16bit(offset + 6 + 3 * 24) * 0.001f);
+  this->publish_state_(this->balancing_delta_voltage_sensor_, (float) jk_get_16bit(offset + 6 + 3 * 24) * 0.001f);
 
   // 0x9D 0x01: Active balance switch                              1 (on)                     Bool     0 (off), 1 (on)
   this->publish_state_(this->balancing_switch_binary_sensor_, (bool) data[offset + 6 + 3 * 25]);

--- a/components/jk_bms/jk_bms.cpp
+++ b/components/jk_bms/jk_bms.cpp
@@ -272,7 +272,7 @@ void JkBms::on_status_data_(const std::vector<uint8_t> &data) {
   this->publish_state_(this->balance_starting_voltage_sensor_, (float) jk_get_16bit(offset + 6 + 3 * 23) * 0.001f);
 
   // 0x9C 0x00 0x08: Balanced opening pressure difference           8 * 0.001 = 0.008V     0.001 V     0.01-1V
-  this->publish_state_(this->balance_opening_pressure_difference_sensor_,
+  this->publish_state_(this->balancing_delta_voltage_sensor_,
                        (float) jk_get_16bit(offset + 6 + 3 * 24) * 0.001f);
 
   // 0x9D 0x01: Active balance switch                              1 (on)                     Bool     0 (off), 1 (on)
@@ -461,7 +461,7 @@ void JkBms::publish_device_unavailable_() {
   this->publish_state_(charging_overcurrent_protection_sensor_, NAN);
   this->publish_state_(charging_overcurrent_delay_sensor_, NAN);
   this->publish_state_(balance_starting_voltage_sensor_, NAN);
-  this->publish_state_(balance_opening_pressure_difference_sensor_, NAN);
+  this->publish_state_(balancing_delta_voltage_sensor_, NAN);
   this->publish_state_(power_tube_temperature_protection_sensor_, NAN);
   this->publish_state_(power_tube_temperature_recovery_sensor_, NAN);
   this->publish_state_(temperature_sensor_temperature_protection_sensor_, NAN);
@@ -631,7 +631,7 @@ void JkBms::dump_config() {  // NOLINT(google-readability-function-size,readabil
   LOG_SENSOR("", "Charging Overcurrent Protection", this->charging_overcurrent_protection_sensor_);
   LOG_SENSOR("", "Charging Overcurrent Delay", this->charging_overcurrent_delay_sensor_);
   LOG_SENSOR("", "Balance Starting Voltage", this->balance_starting_voltage_sensor_);
-  LOG_SENSOR("", "Balance Opening Pressure Difference", this->balance_opening_pressure_difference_sensor_);
+  LOG_SENSOR("", "Balancing Delta Voltage", this->balancing_delta_voltage_sensor_);
   LOG_SENSOR("", "Power Tube Temperature Protection", this->power_tube_temperature_protection_sensor_);
   LOG_SENSOR("", "Power Tube Temperature Recovery", this->power_tube_temperature_recovery_sensor_);
   LOG_SENSOR("", "Temperature Sensor Temperature Protection", this->temperature_sensor_temperature_protection_sensor_);

--- a/components/jk_bms/jk_bms.h
+++ b/components/jk_bms/jk_bms.h
@@ -141,8 +141,8 @@ class JkBms : public PollingComponent, public jk_modbus::JkModbusDevice {
   void set_balance_starting_voltage_sensor(sensor::Sensor *balance_starting_voltage_sensor) {
     balance_starting_voltage_sensor_ = balance_starting_voltage_sensor;
   }
-  void set_balance_opening_pressure_difference_sensor(sensor::Sensor *balance_opening_pressure_difference_sensor) {
-    balance_opening_pressure_difference_sensor_ = balance_opening_pressure_difference_sensor;
+  void set_balancing_delta_voltage_sensor(sensor::Sensor *balancing_delta_voltage_sensor) {
+    balancing_delta_voltage_sensor_ = balancing_delta_voltage_sensor;
   }
   void set_power_tube_temperature_protection_sensor(sensor::Sensor *power_tube_temperature_protection_sensor) {
     power_tube_temperature_protection_sensor_ = power_tube_temperature_protection_sensor;
@@ -291,7 +291,7 @@ class JkBms : public PollingComponent, public jk_modbus::JkModbusDevice {
   sensor::Sensor *charging_overcurrent_protection_sensor_{nullptr};
   sensor::Sensor *charging_overcurrent_delay_sensor_{nullptr};
   sensor::Sensor *balance_starting_voltage_sensor_{nullptr};
-  sensor::Sensor *balance_opening_pressure_difference_sensor_{nullptr};
+  sensor::Sensor *balancing_delta_voltage_sensor_{nullptr};
   sensor::Sensor *power_tube_temperature_protection_sensor_{nullptr};
   sensor::Sensor *power_tube_temperature_recovery_sensor_{nullptr};
   sensor::Sensor *temperature_sensor_temperature_protection_sensor_{nullptr};

--- a/components/jk_bms/sensor.py
+++ b/components/jk_bms/sensor.py
@@ -73,7 +73,7 @@ CONF_CHARGING_OVERCURRENT_PROTECTION = "charging_overcurrent_protection"
 CONF_CHARGING_OVERCURRENT_DELAY = "charging_overcurrent_delay"
 
 CONF_BALANCE_STARTING_VOLTAGE = "balance_starting_voltage"
-CONF_BALANCE_OPENING_PRESSURE_DIFFERENCE = "balance_opening_pressure_difference"
+CONF_BALANCING_DELTA_VOLTAGE = "balancing_delta_voltage"
 
 CONF_POWER_TUBE_TEMPERATURE_PROTECTION = "power_tube_temperature_protection"
 CONF_POWER_TUBE_TEMPERATURE_RECOVERY = "power_tube_temperature_recovery"
@@ -389,7 +389,7 @@ SENSOR_DEFS = {
         "device_class": DEVICE_CLASS_VOLTAGE,
         "state_class": STATE_CLASS_MEASUREMENT,
     },
-    CONF_BALANCE_OPENING_PRESSURE_DIFFERENCE: {
+    CONF_BALANCING_DELTA_VOLTAGE: {
         "unit_of_measurement": UNIT_VOLT,
         "icon": ICON_EMPTY,
         "accuracy_decimals": 3,
@@ -557,6 +557,9 @@ CONFIG_SCHEMA = (
         {
             cv.Optional("cell_pressure_difference_protection"): cv.invalid(
                 "sensor.cell_pressure_difference_protection has been renamed to sensor.cell_voltage_difference_protection"
+            ),
+            cv.Optional("balance_opening_pressure_difference"): cv.invalid(
+                "sensor.balance_opening_pressure_difference has been renamed to sensor.balancing_delta_voltage"
             ),
         }
     )

--- a/esp32-example.yaml
+++ b/esp32-example.yaml
@@ -197,7 +197,7 @@ sensor:
       name: "charging overcurrent delay"
     balance_starting_voltage:
       name: "balance starting voltage"
-    balance_opening_pressure_difference:
+    balancing_delta_voltage:
       name: "balance opening pressure difference"
     power_tube_temperature_protection:
       name: "power tube temperature protection"

--- a/esp8266-example.yaml
+++ b/esp8266-example.yaml
@@ -196,7 +196,7 @@ sensor:
       name: "charging overcurrent delay"
     balance_starting_voltage:
       name: "balance starting voltage"
-    balance_opening_pressure_difference:
+    balancing_delta_voltage:
       name: "balance opening pressure difference"
     power_tube_temperature_protection:
       name: "power tube temperature protection"

--- a/lovelace-entities-card.yaml
+++ b/lovelace-entities-card.yaml
@@ -42,7 +42,7 @@ entities:
     name: Battery Capacity
   - entity: sensor.jk_bms_alarm_low_volume
     name: Alarm Low Volume
-  - entity: sensor.jk_bms_balance_opening_pressure_difference
+  - entity: sensor.jk_bms_balancing_delta_voltage
     name: Balance Opening Pressure Difference
   - entity: sensor.jk_bms_balance_starting_voltage
     name: Balance Starting Voltage

--- a/tests/components/jk_bms/common.h
+++ b/tests/components/jk_bms/common.h
@@ -175,7 +175,7 @@ static const std::vector<uint8_t> STATUS_FRAME_14S = {
     0x9B,
     0x0C,
     0xE4,
-    // bytes 122-124: balance opening pressure difference = 8 × 0.001 = 0.008 V
+    // bytes 122-124: balancing delta voltage = 8 × 0.001 = 0.008 V
     0x9C,
     0x00,
     0x08,

--- a/tests/components/jk_bms/jk_bms_test.cpp
+++ b/tests/components/jk_bms/jk_bms_test.cpp
@@ -108,6 +108,20 @@ TEST(JkBmsStatusDataTest, Capacity) {
   EXPECT_FLOAT_EQ(nominal.state, 14.0f);               // 14 Ah
 }
 
+// ── Balancing configuration ──────────────────────────────────────────────────
+
+TEST(JkBmsStatusDataTest, BalancingConfig) {
+  TestableJkBms bms;
+  sensor::Sensor starting_voltage, delta_voltage;
+  bms.set_balance_starting_voltage_sensor(&starting_voltage);
+  bms.set_balancing_delta_voltage_sensor(&delta_voltage);
+
+  bms.on_jk_modbus_data(FUNCTION_READ_ALL, STATUS_FRAME_14S);
+
+  EXPECT_NEAR(starting_voltage.state, 3.300f, 0.001f);  // 3300 × 0.001
+  EXPECT_NEAR(delta_voltage.state, 0.008f, 0.001f);     // 8 × 0.001
+}
+
 // ── Errors ───────────────────────────────────────────────────────────────────
 
 TEST(JkBmsStatusDataTest, NoErrors) {


### PR DESCRIPTION
## Summary

- Renames `sensor.balance_opening_pressure_difference` to `sensor.balancing_delta_voltage`
- "pressure difference" was a mistranslation from Chinese (压差 = voltage difference); "opening" was a mistranslation of "activation threshold"
- Adds `cv.invalid` migration hint for the old name

## Migration

```yaml
# Before
sensor:
  - platform: jk_bms
    balance_opening_pressure_difference:
      name: "..."

# After
sensor:
  - platform: jk_bms
    balancing_delta_voltage:
      name: "..."
```