### PR TITLE
BREAKING: Rename alarm_low_volume sensor to low_soc_alarm

### DIFF
--- a/components/jk_bms/jk_bms.cpp
+++ b/components/jk_bms/jk_bms.cpp
@@ -354,7 +354,7 @@ void JkBms::on_status_data_(const std::vector<uint8_t> &data) {
   this->publish_state_(this->sleep_wait_time_sensor_, (float) jk_get_16bit(offset + 23 + 3 * 37));
 
   // 0xB1 0x14: Low volume alarm                                             20%            1.0 %      0-80%
-  this->publish_state_(this->alarm_low_volume_sensor_, (float) data[offset + 23 + 3 * 38]);
+  this->publish_state_(this->low_soc_alarm_sensor_, (float) data[offset + 23 + 3 * 38]);
 
   // 0xB2 0x31 0x32 0x33 0x34 0x35 0x36 0x00 0x00 0x00 0x00: Modify parameter password
   auto password_begin = data.begin() + offset + 25 + 3 * 38;
@@ -478,7 +478,7 @@ void JkBms::publish_device_unavailable_() {
   this->publish_state_(current_calibration_sensor_, NAN);
   this->publish_state_(device_address_sensor_, NAN);
   this->publish_state_(sleep_wait_time_sensor_, NAN);
-  this->publish_state_(alarm_low_volume_sensor_, NAN);
+  this->publish_state_(low_soc_alarm_sensor_, NAN);
   this->publish_state_(password_sensor_, NAN);
   this->publish_state_(manufacturing_date_sensor_, NAN);
   this->publish_state_(total_runtime_sensor_, NAN);
@@ -648,7 +648,7 @@ void JkBms::dump_config() {  // NOLINT(google-readability-function-size,readabil
   LOG_SENSOR("", "Device Address", this->device_address_sensor_);
   LOG_TEXT_SENSOR("", "Battery Type", this->battery_type_text_sensor_);
   LOG_SENSOR("", "Sleep Wait Time", this->sleep_wait_time_sensor_);
-  LOG_SENSOR("", "Alarm Low Volume", this->alarm_low_volume_sensor_);
+  LOG_SENSOR("", "Low SOC Alarm", this->low_soc_alarm_sensor_);
   LOG_TEXT_SENSOR("", "Password", this->password_text_sensor_);
   LOG_TEXT_SENSOR("", "Device Type", this->device_type_text_sensor_);
   LOG_SENSOR("", "Manufacturing Date", this->manufacturing_date_sensor_);

--- a/components/jk_bms/jk_bms.h
+++ b/components/jk_bms/jk_bms.h
@@ -195,8 +195,8 @@ class JkBms : public PollingComponent, public jk_modbus::JkModbusDevice {
   void set_sleep_wait_time_sensor(sensor::Sensor *sleep_wait_time_sensor) {
     sleep_wait_time_sensor_ = sleep_wait_time_sensor;
   }
-  void set_alarm_low_volume_sensor(sensor::Sensor *alarm_low_volume_sensor) {
-    alarm_low_volume_sensor_ = alarm_low_volume_sensor;
+  void set_low_soc_alarm_sensor(sensor::Sensor *low_soc_alarm_sensor) {
+    low_soc_alarm_sensor_ = low_soc_alarm_sensor;
   }
   void set_manufacturing_date_sensor(sensor::Sensor *manufacturing_date_sensor) {
     manufacturing_date_sensor_ = manufacturing_date_sensor;
@@ -309,7 +309,7 @@ class JkBms : public PollingComponent, public jk_modbus::JkModbusDevice {
   sensor::Sensor *current_calibration_sensor_{nullptr};
   sensor::Sensor *device_address_sensor_{nullptr};
   sensor::Sensor *sleep_wait_time_sensor_{nullptr};
-  sensor::Sensor *alarm_low_volume_sensor_{nullptr};
+  sensor::Sensor *low_soc_alarm_sensor_{nullptr};
   sensor::Sensor *password_sensor_{nullptr};
   sensor::Sensor *manufacturing_date_sensor_{nullptr};
   sensor::Sensor *total_runtime_sensor_{nullptr};

--- a/components/jk_bms/jk_bms.h
+++ b/components/jk_bms/jk_bms.h
@@ -195,9 +195,7 @@ class JkBms : public PollingComponent, public jk_modbus::JkModbusDevice {
   void set_sleep_wait_time_sensor(sensor::Sensor *sleep_wait_time_sensor) {
     sleep_wait_time_sensor_ = sleep_wait_time_sensor;
   }
-  void set_low_soc_alarm_sensor(sensor::Sensor *low_soc_alarm_sensor) {
-    low_soc_alarm_sensor_ = low_soc_alarm_sensor;
-  }
+  void set_low_soc_alarm_sensor(sensor::Sensor *low_soc_alarm_sensor) { low_soc_alarm_sensor_ = low_soc_alarm_sensor; }
   void set_manufacturing_date_sensor(sensor::Sensor *manufacturing_date_sensor) {
     manufacturing_date_sensor_ = manufacturing_date_sensor;
   }

--- a/components/jk_bms/sensor.py
+++ b/components/jk_bms/sensor.py
@@ -101,7 +101,7 @@ CONF_FULL_CHARGE_CAPACITY = "full_charge_capacity"
 CONF_CURRENT_CALIBRATION = "current_calibration"
 CONF_DEVICE_ADDRESS = "device_address"
 CONF_SLEEP_WAIT_TIME = "sleep_wait_time"
-CONF_ALARM_LOW_VOLUME = "alarm_low_volume"
+CONF_LOW_SOC_ALARM = "low_soc_alarm"
 CONF_MANUFACTURING_DATE = "manufacturing_date"
 CONF_TOTAL_RUNTIME = "total_runtime"
 CONF_START_CURRENT_CALIBRATION = "start_current_calibration"
@@ -121,7 +121,7 @@ ICON_DEVICE_ADDRESS = "mdi:identifier"
 ICON_ERRORS_BITMASK = "mdi:alert-circle-outline"
 ICON_OPERATION_MODE_BITMASK = "mdi:heart-pulse"
 ICON_CHARGING_CYCLES = "mdi:battery-sync"
-ICON_ALARM_LOW_VOLUME = "mdi:volume-high"
+ICON_LOW_SOC_ALARM = "mdi:battery-alert"
 
 UNIT_SECONDS = "s"
 UNIT_HOURS = "h"
@@ -501,9 +501,9 @@ SENSOR_DEFS = {
         "device_class": DEVICE_CLASS_EMPTY,
         "state_class": STATE_CLASS_MEASUREMENT,
     },
-    CONF_ALARM_LOW_VOLUME: {
+    CONF_LOW_SOC_ALARM: {
         "unit_of_measurement": UNIT_PERCENT,
-        "icon": ICON_ALARM_LOW_VOLUME,
+        "icon": ICON_LOW_SOC_ALARM,
         "accuracy_decimals": 0,
         "device_class": DEVICE_CLASS_EMPTY,
         "state_class": STATE_CLASS_MEASUREMENT,
@@ -560,6 +560,9 @@ CONFIG_SCHEMA = (
             ),
             cv.Optional("balance_opening_pressure_difference"): cv.invalid(
                 "sensor.balance_opening_pressure_difference has been renamed to sensor.balancing_delta_voltage"
+            ),
+            cv.Optional("alarm_low_volume"): cv.invalid(
+                "sensor.alarm_low_volume has been renamed to sensor.low_soc_alarm"
             ),
         }
     )

--- a/esp32-example.yaml
+++ b/esp32-example.yaml
@@ -229,7 +229,7 @@ sensor:
       name: "device address"
     sleep_wait_time:
       name: "sleep wait time"
-    alarm_low_volume:
+    low_soc_alarm:
       name: "alarm low volume"
     manufacturing_date:
       name: "manufacturing date"

--- a/esp8266-example.yaml
+++ b/esp8266-example.yaml
@@ -228,7 +228,7 @@ sensor:
       name: "device address"
     sleep_wait_time:
       name: "sleep wait time"
-    alarm_low_volume:
+    low_soc_alarm:
       name: "alarm low volume"
     manufacturing_date:
       name: "manufacturing date"

--- a/lovelace-entities-card.yaml
+++ b/lovelace-entities-card.yaml
@@ -40,7 +40,7 @@ entities:
     name: Capacity Remaining
   - entity: sensor.jk_bms_actual_battery_capacity
     name: Battery Capacity
-  - entity: sensor.jk_bms_alarm_low_volume
+  - entity: sensor.jk_bms_low_soc_alarm
     name: Alarm Low Volume
   - entity: sensor.jk_bms_balancing_delta_voltage
     name: Balance Opening Pressure Difference

--- a/tests/components/jk_bms/common.h
+++ b/tests/components/jk_bms/common.h
@@ -255,7 +255,7 @@ static const std::vector<uint8_t> STATUS_FRAME_14S = {
     0xB0,
     0x00,
     0x0A,
-    // bytes 181-182: alarm low volume = 20 %
+    // bytes 181-182: low_soc_alarm = 20 %
     0xB1,
     0x14,
     // bytes 183-193: password = "123456" (10 bytes, null-padded)

--- a/tests/components/jk_bms/jk_bms_test.cpp
+++ b/tests/components/jk_bms/jk_bms_test.cpp
@@ -189,6 +189,18 @@ TEST(JkBmsStatusDataTest, BatteryInfo) {
   EXPECT_EQ(battery_type.state, "Ternary Lithium");
 }
 
+// ── Alarm thresholds ─────────────────────────────────────────────────────────
+
+TEST(JkBmsStatusDataTest, LowSocAlarm) {
+  TestableJkBms bms;
+  sensor::Sensor low_soc_alarm;
+  bms.set_low_soc_alarm_sensor(&low_soc_alarm);
+
+  bms.on_jk_modbus_data(FUNCTION_READ_ALL, STATUS_FRAME_14S);
+
+  EXPECT_FLOAT_EQ(low_soc_alarm.state, 20.0f);  // 0x14 = 20 %
+}
+
 // ── Version and runtime ──────────────────────────────────────────────────────
 
 TEST(JkBmsStatusDataTest, SoftwareVersion) {


### PR DESCRIPTION
## Summary

- Renames `sensor.alarm_low_volume` to `sensor.low_soc_alarm`
- "volume" was a mistranslation from Chinese (容量 = capacity, not volume); the sensor reports a low SoC alarm threshold in percent
- Updates icon from `mdi:volume-high` to `mdi:battery-alert`
- Adds `cv.invalid` migration hint for the old name

## Migration

```yaml
# Before
sensor:
  - platform: jk_bms
    alarm_low_volume:
      name: "..."

# After
sensor:
  - platform: jk_bms
    low_soc_alarm:
      name: "..."
```