### PR TITLE
BREAKING: Rename capacity_remaining sensor to state_of_charge

### DIFF
--- a/components/jk_bms/jk_bms.cpp
+++ b/components/jk_bms/jk_bms.cpp
@@ -166,7 +166,7 @@ void JkBms::on_status_data_(const std::vector<uint8_t> &data) {
 
   // 0x85 0x0F: Battery remaining capacity                       15 %
   uint8_t raw_battery_remaining_capacity = data[offset + 3 * 5];
-  this->publish_state_(this->capacity_remaining_sensor_, (float) raw_battery_remaining_capacity);
+  this->publish_state_(this->state_of_charge_sensor_, (float) raw_battery_remaining_capacity);
 
   // 0x86 0x02: Number of battery temperature sensors             2                        1.0  count
   this->publish_state_(this->temperature_sensors_sensor_, (float) data[offset + 2 + 3 * 5]);
@@ -438,7 +438,7 @@ void JkBms::publish_device_unavailable_() {
   this->publish_state_(power_sensor_, NAN);
   this->publish_state_(charging_power_sensor_, NAN);
   this->publish_state_(discharging_power_sensor_, NAN);
-  this->publish_state_(capacity_remaining_sensor_, NAN);
+  this->publish_state_(state_of_charge_sensor_, NAN);
   this->publish_state_(capacity_remaining_derived_sensor_, NAN);
   this->publish_state_(temperature_sensors_sensor_, NAN);
   this->publish_state_(charging_cycles_sensor_, NAN);
@@ -608,7 +608,7 @@ void JkBms::dump_config() {  // NOLINT(google-readability-function-size,readabil
   LOG_SENSOR("", "Power", this->power_sensor_);
   LOG_SENSOR("", "Charging Power", this->charging_power_sensor_);
   LOG_SENSOR("", "Discharging Power", this->discharging_power_sensor_);
-  LOG_SENSOR("", "Capacity Remaining", this->capacity_remaining_sensor_);
+  LOG_SENSOR("", "State of Charge", this->state_of_charge_sensor_);
   LOG_SENSOR("", "Capacity Remaining Derived", this->capacity_remaining_derived_sensor_);
   LOG_SENSOR("", "Temperature Sensors", this->temperature_sensors_sensor_);
   LOG_SENSOR("", "Charging Cycles", this->charging_cycles_sensor_);

--- a/components/jk_bms/jk_bms.cpp
+++ b/components/jk_bms/jk_bms.cpp
@@ -165,8 +165,8 @@ void JkBms::on_status_data_(const std::vector<uint8_t> &data) {
   this->publish_state_(this->discharging_power_sensor_, std::abs(std::min(0.0f, power)));  // -500W vs 0W -> 500W
 
   // 0x85 0x0F: Battery remaining capacity                       15 %
-  uint8_t raw_battery_remaining_capacity = data[offset + 3 * 5];
-  this->publish_state_(this->state_of_charge_sensor_, (float) raw_battery_remaining_capacity);
+  uint8_t raw_soc = data[offset + 3 * 5];
+  this->publish_state_(this->state_of_charge_sensor_, (float) raw_soc);
 
   // 0x86 0x02: Number of battery temperature sensors             2                        1.0  count
   this->publish_state_(this->temperature_sensors_sensor_, (float) data[offset + 2 + 3 * 5]);
@@ -325,7 +325,7 @@ void JkBms::on_status_data_(const std::vector<uint8_t> &data) {
   uint32_t raw_full_charge_capacity = jk_get_32bit(offset + 10 + 3 * 36);
   this->publish_state_(this->full_charge_capacity_sensor_, (float) raw_full_charge_capacity);
   this->publish_state_(this->capacity_remaining_derived_sensor_,
-                       (float) (raw_full_charge_capacity * (raw_battery_remaining_capacity * 0.01f)));
+                       (float) (raw_full_charge_capacity * (raw_soc * 0.01f)));
 
   // 0xAB 0x01: Charging MOS tube switch                                     1 (on)         Bool       0 (off), 1 (on)
   this->publish_state_(this->charging_switch_binary_sensor_, (bool) data[offset + 15 + 3 * 36]);

--- a/components/jk_bms/jk_bms.h
+++ b/components/jk_bms/jk_bms.h
@@ -75,8 +75,8 @@ class JkBms : public PollingComponent, public jk_modbus::JkModbusDevice {
   void set_discharging_power_sensor(sensor::Sensor *discharging_power_sensor) {
     discharging_power_sensor_ = discharging_power_sensor;
   }
-  void set_capacity_remaining_sensor(sensor::Sensor *capacity_remaining_sensor) {
-    capacity_remaining_sensor_ = capacity_remaining_sensor;
+  void set_state_of_charge_sensor(sensor::Sensor *state_of_charge_sensor) {
+    state_of_charge_sensor_ = state_of_charge_sensor;
   }
   void set_capacity_remaining_derived_sensor(sensor::Sensor *capacity_remaining_derived_sensor) {
     capacity_remaining_derived_sensor_ = capacity_remaining_derived_sensor;
@@ -267,7 +267,7 @@ class JkBms : public PollingComponent, public jk_modbus::JkModbusDevice {
   sensor::Sensor *power_sensor_{nullptr};
   sensor::Sensor *charging_power_sensor_{nullptr};
   sensor::Sensor *discharging_power_sensor_{nullptr};
-  sensor::Sensor *capacity_remaining_sensor_{nullptr};
+  sensor::Sensor *state_of_charge_sensor_{nullptr};
   sensor::Sensor *capacity_remaining_derived_sensor_{nullptr};
   sensor::Sensor *temperature_sensors_sensor_{nullptr};
   sensor::Sensor *charging_cycles_sensor_{nullptr};

--- a/components/jk_bms/sensor.py
+++ b/components/jk_bms/sensor.py
@@ -43,7 +43,7 @@ CONF_TEMPERATURE_SENSOR_2 = "temperature_sensor_2"
 CONF_TOTAL_VOLTAGE = "total_voltage"
 CONF_CHARGING_POWER = "charging_power"
 CONF_DISCHARGING_POWER = "discharging_power"
-CONF_CAPACITY_REMAINING = "capacity_remaining"
+CONF_STATE_OF_CHARGE = "state_of_charge"
 CONF_CAPACITY_REMAINING_DERIVED = "capacity_remaining_derived"
 CONF_TEMPERATURE_SENSORS = "temperature_sensors"
 CONF_CHARGING_CYCLES = "charging_cycles"
@@ -236,7 +236,7 @@ SENSOR_DEFS = {
         "device_class": DEVICE_CLASS_POWER,
         "state_class": STATE_CLASS_MEASUREMENT,
     },
-    CONF_CAPACITY_REMAINING: {
+    CONF_STATE_OF_CHARGE: {
         "unit_of_measurement": UNIT_PERCENT,
         "accuracy_decimals": 0,
         "device_class": DEVICE_CLASS_BATTERY,
@@ -563,6 +563,9 @@ CONFIG_SCHEMA = (
             ),
             cv.Optional("alarm_low_volume"): cv.invalid(
                 "sensor.alarm_low_volume has been renamed to sensor.low_soc_alarm"
+            ),
+            cv.Optional("capacity_remaining"): cv.invalid(
+                "sensor.capacity_remaining has been renamed to sensor.state_of_charge"
             ),
         }
     )

--- a/esp32-ble-uart-hybrid-example.yaml
+++ b/esp32-ble-uart-hybrid-example.yaml
@@ -186,7 +186,7 @@ sensor:
       name: "charging power"
     discharging_power:
       name: "discharging power"
-    capacity_remaining:
+    state_of_charge:
       name: "capacity remaining"
     capacity_remaining_derived:
       name: "capacity remaining derived"

--- a/esp32-example.yaml
+++ b/esp32-example.yaml
@@ -153,7 +153,7 @@ sensor:
       name: "charging power"
     discharging_power:
       name: "discharging power"
-    capacity_remaining:
+    state_of_charge:
       name: "capacity remaining"
     capacity_remaining_derived:
       name: "capacity remaining derived"

--- a/esp8266-example.yaml
+++ b/esp8266-example.yaml
@@ -152,7 +152,7 @@ sensor:
       name: "charging power"
     discharging_power:
       name: "discharging power"
-    capacity_remaining:
+    state_of_charge:
       name: "capacity remaining"
     capacity_remaining_derived:
       name: "capacity remaining derived"

--- a/lovelace-entities-card.yaml
+++ b/lovelace-entities-card.yaml
@@ -36,7 +36,7 @@ entities:
     name: Balancing
   - entity: switch.jk_bms_dedicated_charger
     name: Dedicated Charger
-  - entity: sensor.jk_bms_capacity_remaining
+  - entity: sensor.jk_bms_state_of_charge
     name: Capacity Remaining
   - entity: sensor.jk_bms_actual_battery_capacity
     name: Battery Capacity

--- a/tests/components/jk_bms/common.h
+++ b/tests/components/jk_bms/common.h
@@ -18,7 +18,7 @@ class TestableJkBms : public JkBms {
 //   delta_cell_voltage: 0.024 V          average_cell_voltage: 3.82821 V
 //   total_voltage: 53.59 V               current: 2.08 A (charging, protocol version 1)
 //   power_tube_temperature: 29°C         temperature_sensor_1: 30°C  temperature_sensor_2: 28°C
-//   capacity_remaining: 15 %             total_battery_capacity: 14 Ah
+//   state_of_charge: 15 %                total_battery_capacity: 14 Ah
 //   errors_bitmask: 0                    operation_modes: charging+discharging+balancer (0x07)
 //   battery_strings: 14                  charging_cycles: 4
 //   software_version: "H6.X__S6.1.3S__" total_runtime: 57856 min ("40d 4h")

--- a/tests/components/jk_bms/jk_bms_test.cpp
+++ b/tests/components/jk_bms/jk_bms_test.cpp
@@ -97,7 +97,7 @@ TEST(JkBmsStatusDataTest, Temperatures) {
 TEST(JkBmsStatusDataTest, Capacity) {
   TestableJkBms bms;
   sensor::Sensor remaining, remaining_derived, nominal;
-  bms.set_capacity_remaining_sensor(&remaining);
+  bms.set_state_of_charge_sensor(&remaining);
   bms.set_capacity_remaining_derived_sensor(&remaining_derived);
   bms.set_full_charge_capacity_sensor(&nominal);
 

--- a/tests/components/jk_bms/jk_bms_test.cpp
+++ b/tests/components/jk_bms/jk_bms_test.cpp
@@ -96,16 +96,16 @@ TEST(JkBmsStatusDataTest, Temperatures) {
 
 TEST(JkBmsStatusDataTest, Capacity) {
   TestableJkBms bms;
-  sensor::Sensor remaining, remaining_derived, nominal;
-  bms.set_state_of_charge_sensor(&remaining);
-  bms.set_capacity_remaining_derived_sensor(&remaining_derived);
-  bms.set_full_charge_capacity_sensor(&nominal);
+  sensor::Sensor soc, soc_derived, full_charge_capacity;
+  bms.set_state_of_charge_sensor(&soc);
+  bms.set_capacity_remaining_derived_sensor(&soc_derived);
+  bms.set_full_charge_capacity_sensor(&full_charge_capacity);
 
   bms.on_jk_modbus_data(FUNCTION_READ_ALL, STATUS_FRAME_14S);
 
-  EXPECT_FLOAT_EQ(remaining.state, 15.0f);             // 15 %
-  EXPECT_NEAR(remaining_derived.state, 2.1f, 0.001f);  // 14 Ah × 15 %
-  EXPECT_FLOAT_EQ(nominal.state, 14.0f);               // 14 Ah
+  EXPECT_FLOAT_EQ(soc.state, 15.0f);                   // 15 %
+  EXPECT_NEAR(soc_derived.state, 2.1f, 0.001f);        // 14 Ah × 15 %
+  EXPECT_FLOAT_EQ(full_charge_capacity.state, 14.0f);  // 14 Ah
 }
 
 // ── Balancing configuration ──────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Renames `sensor.capacity_remaining` (unit: %) in the `jk_bms` platform to `sensor.state_of_charge`
- The old name was ambiguous: `capacity_remaining` in `jk_bms_ble` is in Ah, while in `jk_bms` it was in % — same name, different meaning
- `state_of_charge` is the industry-standard term (IEC 62619, USABC) and consistent with `jk_bms_ble`, Daly, JBD, Seplos, and all other platforms
- Adds `cv.invalid` migration hint for the old name

## Migration

```yaml
# Before
sensor:
  - platform: jk_bms
    capacity_remaining:
      name: "..."

# After
sensor:
  - platform: jk_bms
    state_of_charge:
      name: "..."
```