### PR TITLE
BREAKING: Rename capacity_remaining_derived sensor to capacity_remaining

### DIFF
--- a/components/jk_bms/jk_bms.cpp
+++ b/components/jk_bms/jk_bms.cpp
@@ -324,7 +324,7 @@ void JkBms::on_status_data_(const std::vector<uint8_t> &data) {
   // 0xAA 0x00 0x00 0x02 0x30: Total battery capacity setting              560 Ah           1.0 Ah
   uint32_t raw_full_charge_capacity = jk_get_32bit(offset + 10 + 3 * 36);
   this->publish_state_(this->full_charge_capacity_sensor_, (float) raw_full_charge_capacity);
-  this->publish_state_(this->capacity_remaining_derived_sensor_,
+  this->publish_state_(this->capacity_remaining_sensor_,
                        (float) (raw_full_charge_capacity * (raw_soc * 0.01f)));
 
   // 0xAB 0x01: Charging MOS tube switch                                     1 (on)         Bool       0 (off), 1 (on)
@@ -439,7 +439,7 @@ void JkBms::publish_device_unavailable_() {
   this->publish_state_(charging_power_sensor_, NAN);
   this->publish_state_(discharging_power_sensor_, NAN);
   this->publish_state_(state_of_charge_sensor_, NAN);
-  this->publish_state_(capacity_remaining_derived_sensor_, NAN);
+  this->publish_state_(capacity_remaining_sensor_, NAN);
   this->publish_state_(temperature_sensors_sensor_, NAN);
   this->publish_state_(charging_cycles_sensor_, NAN);
   this->publish_state_(total_charging_cycle_capacity_sensor_, NAN);
@@ -609,7 +609,7 @@ void JkBms::dump_config() {  // NOLINT(google-readability-function-size,readabil
   LOG_SENSOR("", "Charging Power", this->charging_power_sensor_);
   LOG_SENSOR("", "Discharging Power", this->discharging_power_sensor_);
   LOG_SENSOR("", "State of Charge", this->state_of_charge_sensor_);
-  LOG_SENSOR("", "Capacity Remaining Derived", this->capacity_remaining_derived_sensor_);
+  LOG_SENSOR("", "Capacity Remaining", this->capacity_remaining_sensor_);
   LOG_SENSOR("", "Temperature Sensors", this->temperature_sensors_sensor_);
   LOG_SENSOR("", "Charging Cycles", this->charging_cycles_sensor_);
   LOG_SENSOR("", "Total Charging Cycle Capacity", this->total_charging_cycle_capacity_sensor_);

--- a/components/jk_bms/jk_bms.cpp
+++ b/components/jk_bms/jk_bms.cpp
@@ -324,8 +324,7 @@ void JkBms::on_status_data_(const std::vector<uint8_t> &data) {
   // 0xAA 0x00 0x00 0x02 0x30: Total battery capacity setting              560 Ah           1.0 Ah
   uint32_t raw_full_charge_capacity = jk_get_32bit(offset + 10 + 3 * 36);
   this->publish_state_(this->full_charge_capacity_sensor_, (float) raw_full_charge_capacity);
-  this->publish_state_(this->capacity_remaining_sensor_,
-                       (float) (raw_full_charge_capacity * (raw_soc * 0.01f)));
+  this->publish_state_(this->capacity_remaining_sensor_, (float) (raw_full_charge_capacity * (raw_soc * 0.01f)));
 
   // 0xAB 0x01: Charging MOS tube switch                                     1 (on)         Bool       0 (off), 1 (on)
   this->publish_state_(this->charging_switch_binary_sensor_, (bool) data[offset + 15 + 3 * 36]);

--- a/components/jk_bms/jk_bms.h
+++ b/components/jk_bms/jk_bms.h
@@ -78,8 +78,8 @@ class JkBms : public PollingComponent, public jk_modbus::JkModbusDevice {
   void set_state_of_charge_sensor(sensor::Sensor *state_of_charge_sensor) {
     state_of_charge_sensor_ = state_of_charge_sensor;
   }
-  void set_capacity_remaining_derived_sensor(sensor::Sensor *capacity_remaining_derived_sensor) {
-    capacity_remaining_derived_sensor_ = capacity_remaining_derived_sensor;
+  void set_capacity_remaining_sensor(sensor::Sensor *capacity_remaining_sensor) {
+    capacity_remaining_sensor_ = capacity_remaining_sensor;
   }
   void set_temperature_sensors_sensor(sensor::Sensor *temperature_sensors_sensor) {
     temperature_sensors_sensor_ = temperature_sensors_sensor;
@@ -268,7 +268,7 @@ class JkBms : public PollingComponent, public jk_modbus::JkModbusDevice {
   sensor::Sensor *charging_power_sensor_{nullptr};
   sensor::Sensor *discharging_power_sensor_{nullptr};
   sensor::Sensor *state_of_charge_sensor_{nullptr};
-  sensor::Sensor *capacity_remaining_derived_sensor_{nullptr};
+  sensor::Sensor *capacity_remaining_sensor_{nullptr};
   sensor::Sensor *temperature_sensors_sensor_{nullptr};
   sensor::Sensor *charging_cycles_sensor_{nullptr};
   sensor::Sensor *total_charging_cycle_capacity_sensor_{nullptr};

--- a/components/jk_bms/sensor.py
+++ b/components/jk_bms/sensor.py
@@ -44,7 +44,7 @@ CONF_TOTAL_VOLTAGE = "total_voltage"
 CONF_CHARGING_POWER = "charging_power"
 CONF_DISCHARGING_POWER = "discharging_power"
 CONF_STATE_OF_CHARGE = "state_of_charge"
-CONF_CAPACITY_REMAINING_DERIVED = "capacity_remaining_derived"
+CONF_CAPACITY_REMAINING = "capacity_remaining"
 CONF_TEMPERATURE_SENSORS = "temperature_sensors"
 CONF_CHARGING_CYCLES = "charging_cycles"
 CONF_TOTAL_CHARGING_CYCLE_CAPACITY = "total_charging_cycle_capacity"
@@ -113,7 +113,7 @@ ICON_MIN_VOLTAGE_CELL = "mdi:battery-minus-outline"
 ICON_MAX_VOLTAGE_CELL = "mdi:battery-plus-outline"
 
 ICON_BATTERY_STRINGS = "mdi:car-battery"
-ICON_CAPACITY_REMAINING_DERIVED = "mdi:battery-50"
+ICON_CAPACITY_REMAINING = "mdi:battery-50"
 ICON_ACTUAL_BATTERY_CAPACITY = "mdi:battery-50"
 ICON_TOTAL_BATTERY_CAPACITY_SETTING = "mdi:battery-sync"
 
@@ -242,9 +242,9 @@ SENSOR_DEFS = {
         "device_class": DEVICE_CLASS_BATTERY,
         "state_class": STATE_CLASS_MEASUREMENT,
     },
-    CONF_CAPACITY_REMAINING_DERIVED: {
+    CONF_CAPACITY_REMAINING: {
         "unit_of_measurement": UNIT_AMPERE_HOURS,
-        "icon": ICON_CAPACITY_REMAINING_DERIVED,
+        "icon": ICON_CAPACITY_REMAINING,
         "accuracy_decimals": 1,
         "device_class": DEVICE_CLASS_EMPTY,
         "state_class": STATE_CLASS_MEASUREMENT,
@@ -566,6 +566,9 @@ CONFIG_SCHEMA = (
             ),
             cv.Optional("capacity_remaining"): cv.invalid(
                 "sensor.capacity_remaining has been renamed to sensor.state_of_charge"
+            ),
+            cv.Optional("capacity_remaining_derived"): cv.invalid(
+                "sensor.capacity_remaining_derived has been renamed to sensor.capacity_remaining"
             ),
         }
     )

--- a/components/jk_bms/sensor.py
+++ b/components/jk_bms/sensor.py
@@ -564,9 +564,6 @@ CONFIG_SCHEMA = (
             cv.Optional("alarm_low_volume"): cv.invalid(
                 "sensor.alarm_low_volume has been renamed to sensor.low_soc_alarm"
             ),
-            cv.Optional("capacity_remaining"): cv.invalid(
-                "sensor.capacity_remaining has been renamed to sensor.state_of_charge"
-            ),
             cv.Optional("capacity_remaining_derived"): cv.invalid(
                 "sensor.capacity_remaining_derived has been renamed to sensor.capacity_remaining"
             ),

--- a/esp32-ble-uart-hybrid-example.yaml
+++ b/esp32-ble-uart-hybrid-example.yaml
@@ -188,7 +188,7 @@ sensor:
       name: "discharging power"
     state_of_charge:
       name: "capacity remaining"
-    capacity_remaining_derived:
+    capacity_remaining:
       name: "capacity remaining derived"
     errors_bitmask:
       name: "errors bitmask"

--- a/esp32-example.yaml
+++ b/esp32-example.yaml
@@ -155,7 +155,7 @@ sensor:
       name: "discharging power"
     state_of_charge:
       name: "capacity remaining"
-    capacity_remaining_derived:
+    capacity_remaining:
       name: "capacity remaining derived"
     temperature_sensors:
       name: "temperature sensors"

--- a/esp32-example.yaml
+++ b/esp32-example.yaml
@@ -154,9 +154,9 @@ sensor:
     discharging_power:
       name: "discharging power"
     state_of_charge:
-      name: "capacity remaining"
+      name: "state of charge"
     capacity_remaining:
-      name: "capacity remaining derived"
+      name: "capacity remaining"
     temperature_sensors:
       name: "temperature sensors"
     charging_cycles:

--- a/esp8266-example.yaml
+++ b/esp8266-example.yaml
@@ -154,7 +154,7 @@ sensor:
       name: "discharging power"
     state_of_charge:
       name: "capacity remaining"
-    capacity_remaining_derived:
+    capacity_remaining:
       name: "capacity remaining derived"
     temperature_sensors:
       name: "temperature sensors"

--- a/esp8266-example.yaml
+++ b/esp8266-example.yaml
@@ -153,9 +153,9 @@ sensor:
     discharging_power:
       name: "discharging power"
     state_of_charge:
-      name: "capacity remaining"
+      name: "state of charge"
     capacity_remaining:
-      name: "capacity remaining derived"
+      name: "capacity remaining"
     temperature_sensors:
       name: "temperature sensors"
     charging_cycles:

--- a/tests/components/jk_bms/jk_bms_test.cpp
+++ b/tests/components/jk_bms/jk_bms_test.cpp
@@ -98,7 +98,7 @@ TEST(JkBmsStatusDataTest, Capacity) {
   TestableJkBms bms;
   sensor::Sensor soc, soc_derived, full_charge_capacity;
   bms.set_state_of_charge_sensor(&soc);
-  bms.set_capacity_remaining_derived_sensor(&soc_derived);
+  bms.set_capacity_remaining_sensor(&soc_derived);
   bms.set_full_charge_capacity_sensor(&full_charge_capacity);
 
   bms.on_jk_modbus_data(FUNCTION_READ_ALL, STATUS_FRAME_14S);

--- a/tests/components/jk_bms/jk_bms_test.cpp
+++ b/tests/components/jk_bms/jk_bms_test.cpp
@@ -96,16 +96,16 @@ TEST(JkBmsStatusDataTest, Temperatures) {
 
 TEST(JkBmsStatusDataTest, Capacity) {
   TestableJkBms bms;
-  sensor::Sensor soc, soc_derived, full_charge_capacity;
+  sensor::Sensor soc, capacity_remaining, full_charge_capacity;
   bms.set_state_of_charge_sensor(&soc);
-  bms.set_capacity_remaining_sensor(&soc_derived);
+  bms.set_capacity_remaining_sensor(&capacity_remaining);
   bms.set_full_charge_capacity_sensor(&full_charge_capacity);
 
   bms.on_jk_modbus_data(FUNCTION_READ_ALL, STATUS_FRAME_14S);
 
-  EXPECT_FLOAT_EQ(soc.state, 15.0f);                   // 15 %
-  EXPECT_NEAR(soc_derived.state, 2.1f, 0.001f);        // 14 Ah × 15 %
-  EXPECT_FLOAT_EQ(full_charge_capacity.state, 14.0f);  // 14 Ah
+  EXPECT_FLOAT_EQ(soc.state, 15.0f);                    // 15 %
+  EXPECT_NEAR(capacity_remaining.state, 2.1f, 0.001f);  // 14 Ah × 15 %
+  EXPECT_FLOAT_EQ(full_charge_capacity.state, 14.0f);   // 14 Ah
 }
 
 // ── Balancing configuration ──────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Renames `sensor.capacity_remaining_derived` (unit: Ah) to `sensor.capacity_remaining`
- Now that `capacity_remaining` (%) has been renamed to `state_of_charge`, the `_derived` suffix is no longer needed and the name aligns with `jk_bms_ble`, Daly, JBD, Seplos, and all other platforms
- Adds `cv.invalid` migration hint for the old name

## Migration

```yaml
# Before
sensor:
  - platform: jk_bms
    capacity_remaining_derived:
      name: "..."

# After
sensor:
  - platform: jk_bms
    capacity_remaining:
      name: "..."
```