### PR TITLE
BREAKING: Rename battery_strings sensor to cell_count

### DIFF
--- a/components/jk_bms/jk_bms.cpp
+++ b/components/jk_bms/jk_bms.cpp
@@ -178,7 +178,7 @@ void JkBms::on_status_data_(const std::vector<uint8_t> &data) {
   this->publish_state_(this->total_charging_cycle_capacity_sensor_, (float) jk_get_32bit(offset + 4 + 3 * 6));
 
   // 0x8A 0x00 0x0E: Total number of battery strings             14                        1.0  count
-  this->publish_state_(this->battery_strings_sensor_, (float) jk_get_16bit(offset + 6 + 3 * 7));
+  this->publish_state_(this->cell_count_sensor_, (float) jk_get_16bit(offset + 6 + 3 * 7));
 
   // 0x8B 0x00 0x00: Battery warning message                     0000 0000 0000 0000
   //
@@ -442,7 +442,7 @@ void JkBms::publish_device_unavailable_() {
   this->publish_state_(temperature_sensors_sensor_, NAN);
   this->publish_state_(charging_cycles_sensor_, NAN);
   this->publish_state_(total_charging_cycle_capacity_sensor_, NAN);
-  this->publish_state_(battery_strings_sensor_, NAN);
+  this->publish_state_(cell_count_sensor_, NAN);
   this->publish_state_(errors_bitmask_sensor_, NAN);
   this->publish_state_(operation_mode_bitmask_sensor_, NAN);
   this->publish_state_(total_voltage_overvoltage_protection_sensor_, NAN);
@@ -612,7 +612,7 @@ void JkBms::dump_config() {  // NOLINT(google-readability-function-size,readabil
   LOG_SENSOR("", "Temperature Sensors", this->temperature_sensors_sensor_);
   LOG_SENSOR("", "Charging Cycles", this->charging_cycles_sensor_);
   LOG_SENSOR("", "Total Charging Cycle Capacity", this->total_charging_cycle_capacity_sensor_);
-  LOG_SENSOR("", "Battery Strings", this->battery_strings_sensor_);
+  LOG_SENSOR("", "Cell Count", this->cell_count_sensor_);
   LOG_SENSOR("", "Errors Bitmask", this->errors_bitmask_sensor_);
   LOG_SENSOR("", "Operation Mode Bitmask", this->operation_mode_bitmask_sensor_);
   LOG_SENSOR("", "Total Voltage Overvoltage Protection", this->total_voltage_overvoltage_protection_sensor_);

--- a/components/jk_bms/jk_bms.h
+++ b/components/jk_bms/jk_bms.h
@@ -90,8 +90,8 @@ class JkBms : public PollingComponent, public jk_modbus::JkModbusDevice {
   void set_total_charging_cycle_capacity_sensor(sensor::Sensor *total_charging_cycle_capacity_sensor) {
     total_charging_cycle_capacity_sensor_ = total_charging_cycle_capacity_sensor;
   }
-  void set_battery_strings_sensor(sensor::Sensor *battery_strings_sensor) {
-    battery_strings_sensor_ = battery_strings_sensor;
+  void set_cell_count_sensor(sensor::Sensor *cell_count_sensor) {
+    cell_count_sensor_ = cell_count_sensor;
   }
   void set_errors_bitmask_sensor(sensor::Sensor *errors_bitmask_sensor) {
     errors_bitmask_sensor_ = errors_bitmask_sensor;
@@ -272,7 +272,7 @@ class JkBms : public PollingComponent, public jk_modbus::JkModbusDevice {
   sensor::Sensor *temperature_sensors_sensor_{nullptr};
   sensor::Sensor *charging_cycles_sensor_{nullptr};
   sensor::Sensor *total_charging_cycle_capacity_sensor_{nullptr};
-  sensor::Sensor *battery_strings_sensor_{nullptr};
+  sensor::Sensor *cell_count_sensor_{nullptr};
   sensor::Sensor *errors_bitmask_sensor_{nullptr};
   sensor::Sensor *operation_mode_bitmask_sensor_{nullptr};
   sensor::Sensor *total_voltage_overvoltage_protection_sensor_{nullptr};

--- a/components/jk_bms/jk_bms.h
+++ b/components/jk_bms/jk_bms.h
@@ -90,9 +90,7 @@ class JkBms : public PollingComponent, public jk_modbus::JkModbusDevice {
   void set_total_charging_cycle_capacity_sensor(sensor::Sensor *total_charging_cycle_capacity_sensor) {
     total_charging_cycle_capacity_sensor_ = total_charging_cycle_capacity_sensor;
   }
-  void set_cell_count_sensor(sensor::Sensor *cell_count_sensor) {
-    cell_count_sensor_ = cell_count_sensor;
-  }
+  void set_cell_count_sensor(sensor::Sensor *cell_count_sensor) { cell_count_sensor_ = cell_count_sensor; }
   void set_errors_bitmask_sensor(sensor::Sensor *errors_bitmask_sensor) {
     errors_bitmask_sensor_ = errors_bitmask_sensor;
   }

--- a/components/jk_bms/sensor.py
+++ b/components/jk_bms/sensor.py
@@ -48,7 +48,7 @@ CONF_CAPACITY_REMAINING = "capacity_remaining"
 CONF_TEMPERATURE_SENSORS = "temperature_sensors"
 CONF_CHARGING_CYCLES = "charging_cycles"
 CONF_TOTAL_CHARGING_CYCLE_CAPACITY = "total_charging_cycle_capacity"
-CONF_BATTERY_STRINGS = "battery_strings"
+CONF_CELL_COUNT = "cell_count"
 
 CONF_ERRORS_BITMASK = "errors_bitmask"
 CONF_OPERATION_MODE_BITMASK = "operation_mode_bitmask"
@@ -95,7 +95,7 @@ CONF_DISCHARGING_LOW_TEMPERATURE_PROTECTION = "discharging_low_temperature_prote
 CONF_DISCHARGING_LOW_TEMPERATURE_RECOVERY = "discharging_low_temperature_recovery"
 
 # r/w
-# CONF_BATTERY_STRINGS = "battery_strings"
+# CONF_CELL_COUNT = "cell_count"
 CONF_FULL_CHARGE_CAPACITY = "full_charge_capacity"
 
 CONF_CURRENT_CALIBRATION = "current_calibration"
@@ -112,7 +112,7 @@ ICON_CURRENT_DC = "mdi:current-dc"
 ICON_MIN_VOLTAGE_CELL = "mdi:battery-minus-outline"
 ICON_MAX_VOLTAGE_CELL = "mdi:battery-plus-outline"
 
-ICON_BATTERY_STRINGS = "mdi:car-battery"
+ICON_CELL_COUNT = "mdi:car-battery"
 ICON_CAPACITY_REMAINING = "mdi:battery-50"
 ICON_ACTUAL_BATTERY_CAPACITY = "mdi:battery-50"
 ICON_TOTAL_BATTERY_CAPACITY_SETTING = "mdi:battery-sync"
@@ -270,9 +270,9 @@ SENSOR_DEFS = {
         "device_class": DEVICE_CLASS_EMPTY,
         "state_class": STATE_CLASS_TOTAL_INCREASING,
     },
-    CONF_BATTERY_STRINGS: {
+    CONF_CELL_COUNT: {
         "unit_of_measurement": UNIT_EMPTY,
-        "icon": ICON_BATTERY_STRINGS,
+        "icon": ICON_CELL_COUNT,
         "accuracy_decimals": 0,
         "device_class": DEVICE_CLASS_EMPTY,
         "state_class": STATE_CLASS_MEASUREMENT,
@@ -566,6 +566,9 @@ CONFIG_SCHEMA = (
             ),
             cv.Optional("capacity_remaining_derived"): cv.invalid(
                 "sensor.capacity_remaining_derived has been renamed to sensor.capacity_remaining"
+            ),
+            cv.Optional("battery_strings"): cv.invalid(
+                "sensor.battery_strings has been renamed to sensor.cell_count"
             ),
         }
     )

--- a/esp32-example.yaml
+++ b/esp32-example.yaml
@@ -163,7 +163,7 @@ sensor:
       name: "charging cycles"
     total_charging_cycle_capacity:
       name: "total charging cycle capacity"
-    battery_strings:
+    cell_count:
       name: "battery strings"
     errors_bitmask:
       name: "errors bitmask"

--- a/esp8266-example.yaml
+++ b/esp8266-example.yaml
@@ -162,7 +162,7 @@ sensor:
       name: "charging cycles"
     total_charging_cycle_capacity:
       name: "total charging cycle capacity"
-    battery_strings:
+    cell_count:
       name: "battery strings"
     errors_bitmask:
       name: "errors bitmask"

--- a/lovelace-entities-card.yaml
+++ b/lovelace-entities-card.yaml
@@ -26,7 +26,7 @@ entities:
     name: Cell Voltage 12
   - entity: sensor.jk_bms_cell_voltage_13
     name: Cell Voltage 13
-  - entity: sensor.jk_bms_battery_strings
+  - entity: sensor.jk_bms_cell_count
     name: Battery Strings
   - entity: switch.jk_bms_charging
     name: Charging

--- a/tests/components/jk_bms/common.h
+++ b/tests/components/jk_bms/common.h
@@ -20,7 +20,7 @@ class TestableJkBms : public JkBms {
 //   power_tube_temperature: 29°C         temperature_sensor_1: 30°C  temperature_sensor_2: 28°C
 //   state_of_charge: 15 %                total_battery_capacity: 14 Ah
 //   errors_bitmask: 0                    operation_modes: charging+discharging+balancer (0x07)
-//   battery_strings: 14                  charging_cycles: 4
+//   cell_count: 14                        charging_cycles: 4
 //   software_version: "H6.X__S6.1.3S__" total_runtime: 57856 min ("40d 4h")
 //   balancing_switch: on                 charging_switch: on  discharging_switch: on
 static const std::vector<uint8_t> STATUS_FRAME_14S = {

--- a/tests/components/jk_bms/common.h
+++ b/tests/components/jk_bms/common.h
@@ -107,7 +107,7 @@ static const std::vector<uint8_t> STATUS_FRAME_14S = {
     0x00,
     0x00,
     0x00,
-    // bytes 71-73: battery strings = 14
+    // bytes 71-73: cell count = 14
     0x8A,
     0x00,
     0x0E,

--- a/tests/components/jk_bms/jk_bms_test.cpp
+++ b/tests/components/jk_bms/jk_bms_test.cpp
@@ -178,7 +178,7 @@ TEST(JkBmsStatusDataTest, BatteryInfo) {
   TestableJkBms bms;
   sensor::Sensor strings, cycles;
   text_sensor::TextSensor battery_type;
-  bms.set_battery_strings_sensor(&strings);
+  bms.set_cell_count_sensor(&strings);
   bms.set_charging_cycles_sensor(&cycles);
   bms.set_battery_type_text_sensor(&battery_type);
 

--- a/tests/components/jk_bms/jk_bms_test.cpp
+++ b/tests/components/jk_bms/jk_bms_test.cpp
@@ -176,15 +176,15 @@ TEST(JkBmsStatusDataTest, SwitchStates) {
 
 TEST(JkBmsStatusDataTest, BatteryInfo) {
   TestableJkBms bms;
-  sensor::Sensor strings, cycles;
+  sensor::Sensor cell_count, cycles;
   text_sensor::TextSensor battery_type;
-  bms.set_cell_count_sensor(&strings);
+  bms.set_cell_count_sensor(&cell_count);
   bms.set_charging_cycles_sensor(&cycles);
   bms.set_battery_type_text_sensor(&battery_type);
 
   bms.on_jk_modbus_data(FUNCTION_READ_ALL, STATUS_FRAME_14S);
 
-  EXPECT_FLOAT_EQ(strings.state, 14.0f);
+  EXPECT_FLOAT_EQ(cell_count.state, 14.0f);
   EXPECT_FLOAT_EQ(cycles.state, 4.0f);
   EXPECT_EQ(battery_type.state, "Ternary Lithium");
 }


### PR DESCRIPTION
## Summary

- Renames `sensor.battery_strings` to `sensor.cell_count`
- "battery strings" is a Chinese BMS term (节数) meaning number of cells in series; `cell_count` is the standard English term used by Daly, JBD, and others
- Adds `cv.invalid` migration hint for the old name

## Migration

```yaml
# Before
sensor:
  - platform: jk_bms
    battery_strings:
      name: "..."

# After
sensor:
  - platform: jk_bms
    cell_count:
      name: "..."
```