### PR TITLE
BREAKING: Rename temperature_sensors sensor to temperature_sensor_count

### DIFF
--- a/components/jk_bms/jk_bms.cpp
+++ b/components/jk_bms/jk_bms.cpp
@@ -169,7 +169,7 @@ void JkBms::on_status_data_(const std::vector<uint8_t> &data) {
   this->publish_state_(this->state_of_charge_sensor_, (float) raw_soc);
 
   // 0x86 0x02: Number of battery temperature sensors             2                        1.0  count
-  this->publish_state_(this->temperature_sensors_sensor_, (float) data[offset + 2 + 3 * 5]);
+  this->publish_state_(this->temperature_sensor_count_sensor_, (float) data[offset + 2 + 3 * 5]);
 
   // 0x87 0x00 0x04: Number of battery cycles                     4                        1.0  count
   this->publish_state_(this->charging_cycles_sensor_, (float) jk_get_16bit(offset + 4 + 3 * 5));
@@ -439,7 +439,7 @@ void JkBms::publish_device_unavailable_() {
   this->publish_state_(discharging_power_sensor_, NAN);
   this->publish_state_(state_of_charge_sensor_, NAN);
   this->publish_state_(capacity_remaining_sensor_, NAN);
-  this->publish_state_(temperature_sensors_sensor_, NAN);
+  this->publish_state_(temperature_sensor_count_sensor_, NAN);
   this->publish_state_(charging_cycles_sensor_, NAN);
   this->publish_state_(total_charging_cycle_capacity_sensor_, NAN);
   this->publish_state_(cell_count_sensor_, NAN);
@@ -609,7 +609,7 @@ void JkBms::dump_config() {  // NOLINT(google-readability-function-size,readabil
   LOG_SENSOR("", "Discharging Power", this->discharging_power_sensor_);
   LOG_SENSOR("", "State of Charge", this->state_of_charge_sensor_);
   LOG_SENSOR("", "Capacity Remaining", this->capacity_remaining_sensor_);
-  LOG_SENSOR("", "Temperature Sensors", this->temperature_sensors_sensor_);
+  LOG_SENSOR("", "Temperature Sensor Count", this->temperature_sensor_count_sensor_);
   LOG_SENSOR("", "Charging Cycles", this->charging_cycles_sensor_);
   LOG_SENSOR("", "Total Charging Cycle Capacity", this->total_charging_cycle_capacity_sensor_);
   LOG_SENSOR("", "Cell Count", this->cell_count_sensor_);

--- a/components/jk_bms/jk_bms.h
+++ b/components/jk_bms/jk_bms.h
@@ -81,8 +81,8 @@ class JkBms : public PollingComponent, public jk_modbus::JkModbusDevice {
   void set_capacity_remaining_sensor(sensor::Sensor *capacity_remaining_sensor) {
     capacity_remaining_sensor_ = capacity_remaining_sensor;
   }
-  void set_temperature_sensors_sensor(sensor::Sensor *temperature_sensors_sensor) {
-    temperature_sensors_sensor_ = temperature_sensors_sensor;
+  void set_temperature_sensor_count_sensor(sensor::Sensor *temperature_sensor_count_sensor) {
+    temperature_sensor_count_sensor_ = temperature_sensor_count_sensor;
   }
   void set_charging_cycles_sensor(sensor::Sensor *charging_cycles_sensor) {
     charging_cycles_sensor_ = charging_cycles_sensor;
@@ -267,7 +267,7 @@ class JkBms : public PollingComponent, public jk_modbus::JkModbusDevice {
   sensor::Sensor *discharging_power_sensor_{nullptr};
   sensor::Sensor *state_of_charge_sensor_{nullptr};
   sensor::Sensor *capacity_remaining_sensor_{nullptr};
-  sensor::Sensor *temperature_sensors_sensor_{nullptr};
+  sensor::Sensor *temperature_sensor_count_sensor_{nullptr};
   sensor::Sensor *charging_cycles_sensor_{nullptr};
   sensor::Sensor *total_charging_cycle_capacity_sensor_{nullptr};
   sensor::Sensor *cell_count_sensor_{nullptr};

--- a/components/jk_bms/sensor.py
+++ b/components/jk_bms/sensor.py
@@ -45,7 +45,7 @@ CONF_CHARGING_POWER = "charging_power"
 CONF_DISCHARGING_POWER = "discharging_power"
 CONF_STATE_OF_CHARGE = "state_of_charge"
 CONF_CAPACITY_REMAINING = "capacity_remaining"
-CONF_TEMPERATURE_SENSORS = "temperature_sensors"
+CONF_TEMPERATURE_SENSOR_COUNT = "temperature_sensor_count"
 CONF_CHARGING_CYCLES = "charging_cycles"
 CONF_TOTAL_CHARGING_CYCLE_CAPACITY = "total_charging_cycle_capacity"
 CONF_CELL_COUNT = "cell_count"
@@ -249,7 +249,7 @@ SENSOR_DEFS = {
         "device_class": DEVICE_CLASS_EMPTY,
         "state_class": STATE_CLASS_MEASUREMENT,
     },
-    CONF_TEMPERATURE_SENSORS: {
+    CONF_TEMPERATURE_SENSOR_COUNT: {
         "unit_of_measurement": UNIT_EMPTY,
         "icon": ICON_EMPTY,
         "accuracy_decimals": 0,
@@ -569,6 +569,9 @@ CONFIG_SCHEMA = (
             ),
             cv.Optional("battery_strings"): cv.invalid(
                 "sensor.battery_strings has been renamed to sensor.cell_count"
+            ),
+            cv.Optional("temperature_sensors"): cv.invalid(
+                "sensor.temperature_sensors has been renamed to sensor.temperature_sensor_count"
             ),
         }
     )

--- a/esp32-example.yaml
+++ b/esp32-example.yaml
@@ -157,7 +157,7 @@ sensor:
       name: "state of charge"
     capacity_remaining:
       name: "capacity remaining"
-    temperature_sensors:
+    temperature_sensor_count:
       name: "temperature sensors"
     charging_cycles:
       name: "charging cycles"

--- a/esp8266-example.yaml
+++ b/esp8266-example.yaml
@@ -156,7 +156,7 @@ sensor:
       name: "state of charge"
     capacity_remaining:
       name: "capacity remaining"
-    temperature_sensors:
+    temperature_sensor_count:
       name: "temperature sensors"
     charging_cycles:
       name: "charging cycles"

--- a/lovelace-entities-card.yaml
+++ b/lovelace-entities-card.yaml
@@ -126,7 +126,7 @@ entities:
     name: Temperature Sensor Temperature Protection
   - entity: sensor.jk_bms_temperature_sensor_temperature_recovery
     name: Temperature Sensor Temperature Recovery
-  - entity: sensor.jk_bms_temperature_sensors
+  - entity: sensor.jk_bms_temperature_sensor_count
     name: Temperature Sensors
   - entity: sensor.jk_bms_total_charging_cycle_capacity
     name: Total Charging Cycle Capacity

--- a/tests/components/jk_bms/common.h
+++ b/tests/components/jk_bms/common.h
@@ -94,7 +94,7 @@ static const std::vector<uint8_t> STATUS_FRAME_14S = {
     // bytes 59-60: capacity remaining = 15 %
     0x85,
     0x0F,
-    // bytes 61-62: temperature sensors count = 2
+    // bytes 61-62: temperature sensor count = 2
     0x86,
     0x02,
     // bytes 63-65: charging cycles = 4

--- a/tests/components/jk_bms/jk_bms_test.cpp
+++ b/tests/components/jk_bms/jk_bms_test.cpp
@@ -80,16 +80,18 @@ TEST(JkBmsStatusDataTest, ChargingCurrentAndPower) {
 
 TEST(JkBmsStatusDataTest, Temperatures) {
   TestableJkBms bms;
-  sensor::Sensor tube, t1, t2;
+  sensor::Sensor tube, t1, t2, count;
   bms.set_power_tube_temperature_sensor(&tube);
   bms.set_temperature_sensor_1_sensor(&t1);
   bms.set_temperature_sensor_2_sensor(&t2);
+  bms.set_temperature_sensor_count_sensor(&count);
 
   bms.on_jk_modbus_data(FUNCTION_READ_ALL, STATUS_FRAME_14S);
 
   EXPECT_FLOAT_EQ(tube.state, 29.0f);
   EXPECT_FLOAT_EQ(t1.state, 30.0f);
   EXPECT_FLOAT_EQ(t2.state, 28.0f);
+  EXPECT_FLOAT_EQ(count.state, 2.0f);
 }
 
 // ── Capacity ─────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Renames `sensor.temperature_sensors` to `sensor.temperature_sensor_count`
- The old name reads as a list of sensors; the value is actually a count (integer)
- Adds `cv.invalid` migration hint for the old name

## Migration

```yaml
# Before
sensor:
  - platform: jk_bms
    temperature_sensors:
      name: "..."

# After
sensor:
  - platform: jk_bms
    temperature_sensor_count:
      name: "..."
```