### PR TITLE
Add deprecation compat layer for renamed sensors

### DIFF
--- a/components/jk_bms/__init__.py
+++ b/components/jk_bms/__init__.py
@@ -1,11 +1,32 @@
+import logging
+
 import esphome.codegen as cg
 from esphome.components import jk_modbus
 import esphome.config_validation as cv
 from esphome.const import CONF_ID
 
+_LOGGER = logging.getLogger(__name__)
+
 AUTO_LOAD = ["jk_modbus", "binary_sensor", "sensor", "switch", "text_sensor"]
 CODEOWNERS = ["@syssi"]
 MULTI_CONF = True
+
+
+def deprecated_renames(renames: dict[str, str]):
+    def validator(config):
+        config = config.copy()
+        for old, new in renames.items():
+            if old in config:
+                _LOGGER.warning(
+                    "'%s' is deprecated, use '%s' instead. Will be removed in a future release.",
+                    old,
+                    new,
+                )
+                config[new] = config.pop(old)
+        return config
+
+    return validator
+
 
 CONF_JK_BMS_ID = "jk_bms_id"
 

--- a/components/jk_bms/sensor.py
+++ b/components/jk_bms/sensor.py
@@ -24,7 +24,7 @@ from esphome.const import (
     UNIT_WATT,
 )
 
-from . import CONF_JK_BMS_ID, JK_BMS_COMPONENT_SCHEMA
+from . import CONF_JK_BMS_ID, JK_BMS_COMPONENT_SCHEMA, deprecated_renames
 
 DEPENDENCIES = ["jk_bms"]
 
@@ -545,36 +545,23 @@ SENSOR_DEFS = {
     },
 }
 
-CONFIG_SCHEMA = (
+_RENAMED_SENSORS = {
+    "cell_pressure_difference_protection": "cell_voltage_difference_protection",
+    "balance_opening_pressure_difference": "balancing_delta_voltage",
+    "alarm_low_volume": "low_soc_alarm",
+    "capacity_remaining_derived": "capacity_remaining",
+    "battery_strings": "cell_count",
+    "temperature_sensors": "temperature_sensor_count",
+}
+
+CONFIG_SCHEMA = cv.All(
+    deprecated_renames(_RENAMED_SENSORS),
     JK_BMS_COMPONENT_SCHEMA.extend(
         {
             cv.Optional(key): sensor.sensor_schema(**kwargs)
             for key, kwargs in SENSOR_DEFS.items()
         }
-    )
-    .extend({cv.Optional(key): _CELL_VOLTAGE_SCHEMA for key in CELLS})
-    .extend(
-        {
-            cv.Optional("cell_pressure_difference_protection"): cv.invalid(
-                "sensor.cell_pressure_difference_protection has been renamed to sensor.cell_voltage_difference_protection"
-            ),
-            cv.Optional("balance_opening_pressure_difference"): cv.invalid(
-                "sensor.balance_opening_pressure_difference has been renamed to sensor.balancing_delta_voltage"
-            ),
-            cv.Optional("alarm_low_volume"): cv.invalid(
-                "sensor.alarm_low_volume has been renamed to sensor.low_soc_alarm"
-            ),
-            cv.Optional("capacity_remaining_derived"): cv.invalid(
-                "sensor.capacity_remaining_derived has been renamed to sensor.capacity_remaining"
-            ),
-            cv.Optional("battery_strings"): cv.invalid(
-                "sensor.battery_strings has been renamed to sensor.cell_count"
-            ),
-            cv.Optional("temperature_sensors"): cv.invalid(
-                "sensor.temperature_sensors has been renamed to sensor.temperature_sensor_count"
-            ),
-        }
-    )
+    ).extend({cv.Optional(key): _CELL_VOLTAGE_SCHEMA for key in CELLS}),
 )
 
 

--- a/components/jk_bms/sensor.py
+++ b/components/jk_bms/sensor.py
@@ -549,9 +549,11 @@ _RENAMED_SENSORS = {
     "cell_pressure_difference_protection": "cell_voltage_difference_protection",
     "balance_opening_pressure_difference": "balancing_delta_voltage",
     "alarm_low_volume": "low_soc_alarm",
+    "capacity_remaining": "state_of_charge",
     "capacity_remaining_derived": "capacity_remaining",
     "battery_strings": "cell_count",
     "temperature_sensors": "temperature_sensor_count",
+    "total_battery_capacity_setting": "full_charge_capacity",
 }
 
 CONFIG_SCHEMA = cv.All(

--- a/components/jk_bms_ble/__init__.py
+++ b/components/jk_bms_ble/__init__.py
@@ -1,12 +1,33 @@
+import logging
+
 import esphome.codegen as cg
 from esphome.components import ble_client
 import esphome.config_validation as cv
 from esphome.const import CONF_ID, CONF_THROTTLE
 
+_LOGGER = logging.getLogger(__name__)
+
 CODEOWNERS = ["@syssi", "@txubelaxu"]
 DEPENDENCIES = ["ble_client"]
 AUTO_LOAD = ["binary_sensor", "button", "number", "sensor", "switch", "text_sensor"]
 MULTI_CONF = True
+
+
+def deprecated_renames(renames: dict[str, str]):
+    def validator(config):
+        config = config.copy()
+        for old, new in renames.items():
+            if old in config:
+                _LOGGER.warning(
+                    "'%s' is deprecated, use '%s' instead. Will be removed in a future release.",
+                    old,
+                    new,
+                )
+                config[new] = config.pop(old)
+        return config
+
+    return validator
+
 
 CONF_JK_BMS_BLE_ID = "jk_bms_ble_id"
 CONF_PROTOCOL_VERSION = "protocol_version"

--- a/components/jk_bms_ble/sensor.py
+++ b/components/jk_bms_ble/sensor.py
@@ -24,7 +24,7 @@ from esphome.const import (
     UNIT_WATT,
 )
 
-from . import CONF_JK_BMS_BLE_ID, JK_BMS_BLE_COMPONENT_SCHEMA
+from . import CONF_JK_BMS_BLE_ID, JK_BMS_BLE_COMPONENT_SCHEMA, deprecated_renames
 
 CODEOWNERS = ["@syssi", "@txubelaxu"]
 
@@ -290,7 +290,13 @@ SENSOR_DEFS = {
     },
 }
 
-CONFIG_SCHEMA = (
+_RENAMED_SENSORS = {
+    "balancing": "balancer_status",
+    "total_battery_capacity_setting": "full_charge_capacity",
+}
+
+CONFIG_SCHEMA = cv.All(
+    deprecated_renames(_RENAMED_SENSORS),
     JK_BMS_BLE_COMPONENT_SCHEMA.extend(
         {
             cv.Optional(key): sensor.sensor_schema(**kwargs)
@@ -305,14 +311,8 @@ CONFIG_SCHEMA = (
             cv.Optional("errors_bitmask"): cv.invalid(
                 "sensor.errors_bitmask has been removed; use text_sensor.errors_bitmask_hex instead"
             ),
-            cv.Optional("balancing"): cv.invalid(
-                "sensor.balancing has been renamed to sensor.balancer_status"
-            ),
-            cv.Optional("total_battery_capacity_setting"): cv.invalid(
-                "sensor.total_battery_capacity_setting has been renamed to sensor.full_charge_capacity"
-            ),
         }
-    )
+    ),
 )
 
 


### PR DESCRIPTION
## Summary

Replace the recent `cv.invalid` hard errors for renamed sensor keys with a small **deprecation + routing** layer: the old key still works, the user gets a clear warning at validation time, and the value is silently forwarded to the new key.

## Background

Several v3 PRs renamed sensor keys (e.g. `battery_strings` → `cell_count`, `temperature_sensors` → `temperature_sensor_count`, …). The current implementation rejects the old key outright via `cv.invalid(...)`, which breaks every user config the moment they pull v3. A typical large JK-BMS config touches several of these at once, so the upgrade path becomes a chain of failed compiles.

This PR keeps the new key as canonical but routes the legacy keys to it with a deprecation warning, giving users a non-breaking migration window.

## How

Both `jk_bms/__init__.py` and `jk_bms_ble/__init__.py` get a tiny helper:

```python
def deprecated_renames(renames: dict[str, str]):
    def validator(config):
        config = config.copy()
        for old, new in renames.items():
            if old in config:
                _LOGGER.warning(
                    "'%s' is deprecated, use '%s' instead. Will be removed in a future release.",
                    old, new,
                )
                config[new] = config.pop(old)
        return config
    return validator
```

…and each `sensor.py` declares a `_RENAMED_SENSORS` dict, wired in via `cv.All(deprecated_renames(_RENAMED_SENSORS), <existing schema>)`.

The pattern matches the canonical one used in ESPHome core ([combination/sensor.py](https://github.com/esphome/esphome/blob/dev/esphome/components/combination/sensor.py)) — core only exposes `cv.rename_key` (silent), no warn+rename helper, so a small local helper is the simplest fit.

## Covered renames

**jk_bms** (6):
- `cell_pressure_difference_protection` → `cell_voltage_difference_protection`
- `balance_opening_pressure_difference` → `balancing_delta_voltage`
- `alarm_low_volume` → `low_soc_alarm`
- `capacity_remaining_derived` → `capacity_remaining`
- `battery_strings` → `cell_count`
- `temperature_sensors` → `temperature_sensor_count`

**jk_bms_ble** (2):
- `balancing` → `balancer_status`
- `total_battery_capacity_setting` → `full_charge_capacity`

The `errors_bitmask` removal in `jk_bms_ble` stays as a hard `cv.invalid` because there is no rename target on the sensor platform (replacement lives on `text_sensor.errors_bitmask_hex`).

## Test plan

- [ ] `pre-commit run --all-files` passes locally
- [ ] Existing CI (`script/cpp_unit_test.py`, `esphome-config`) stays green
- [ ] Hand-validate an example YAML using a legacy key (e.g. `battery_strings:`) — should log a deprecation warning and compile
- [ ] Hand-validate that supplying both old and new key behaves as expected (new key takes precedence after rename)
- [ ] `errors_bitmask` on jk_bms_ble still produces the hard error pointing at `text_sensor.errors_bitmask_hex`