### PR TITLE
BREAKING: Rename power_tube_temperature sensors to mosfet_temperature

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ esphome run esp32-example.yaml
 [sensor:127]: 'jk-bms cell voltage 11': Sending state 4.12800 V with 3 decimals of accuracy
 [sensor:127]: 'jk-bms cell voltage 12': Sending state 4.13100 V with 3 decimals of accuracy
 [sensor:127]: 'jk-bms cell voltage 13': Sending state 4.12400 V with 3 decimals of accuracy
-[sensor:127]: 'jk-bms power tube temperature': Sending state 24.00000 °C with 0 decimals of accuracy
+[sensor:127]: 'jk-bms mosfet temperature': Sending state 24.00000 °C with 0 decimals of accuracy
 [sensor:127]: 'jk-bms temperature sensor 1': Sending state 22.00000 °C with 0 decimals of accuracy
 [sensor:127]: 'jk-bms temperature sensor 2': Sending state 22.00000 °C with 0 decimals of accuracy
 [sensor:127]: 'jk-bms total voltage': Sending state 53.64000 V with 2 decimals of accuracy
@@ -189,8 +189,8 @@ esphome run esp32-example.yaml
 [sensor:127]: 'jk-bms balance starting voltage': Sending state 3.30000 V with 3 decimals of accuracy
 [sensor:127]: 'jk-bms balance opening pressure difference': Sending state 0.01000 V with 3 decimals of accuracy
 [switch:045]: 'jk-bms balancing': Sending state ON
-[sensor:127]: 'jk-bms power tube temperature protection': Sending state 90.00000 °C with 0 decimals of accuracy
-[sensor:127]: 'jk-bms power tube temperature recovery': Sending state 70.00000 °C with 0 decimals of accuracy
+[sensor:127]: 'jk-bms mosfet temperature protection': Sending state 90.00000 °C with 0 decimals of accuracy
+[sensor:127]: 'jk-bms mosfet temperature recovery': Sending state 70.00000 °C with 0 decimals of accuracy
 [sensor:127]: 'jk-bms temperature sensor temperature protection': Sending state 100.00000 °C with 0 decimals of accuracy
 [sensor:127]: 'jk-bms temperature sensor temperature recovery': Sending state 100.00000 °C with 0 decimals of accuracy
 [sensor:127]: 'jk-bms temperature sensor temperature difference protection': Sending state 20.00000 °C with 0 decimals of accuracy

--- a/components/jk_bms/jk_bms.cpp
+++ b/components/jk_bms/jk_bms.cpp
@@ -142,7 +142,7 @@ void JkBms::on_status_data_(const std::vector<uint8_t> &data) {
 
   // 0x80 0x00 0x1D: Read power tube temperature                 29°C                      1.0 °C
   // --->  99 = 99°C, 100 = 100°C, 101 = -1°C, 140 = -40°C
-  this->publish_state_(this->power_tube_temperature_sensor_, get_temperature_(jk_get_16bit(offset + 3 * 0)));
+  this->publish_state_(this->mosfet_temperature_sensor_, get_temperature_(jk_get_16bit(offset + 3 * 0)));
 
   // 0x81 0x00 0x1E: Read the temperature in the battery box     30°C                      1.0 °C
   this->publish_state_(this->temperature_sensor_1_sensor_, get_temperature_(jk_get_16bit(offset + 3 * 1)));
@@ -279,10 +279,10 @@ void JkBms::on_status_data_(const std::vector<uint8_t> &data) {
   this->publish_state_(this->balancer_switch_, (bool) data[offset + 6 + 3 * 25]);
 
   // 0x9E 0x00 0x5A: Power tube temperature protection value                90°C            1.0 °C     0-100°C
-  this->publish_state_(this->power_tube_temperature_protection_sensor_, (float) jk_get_16bit(offset + 8 + 3 * 25));
+  this->publish_state_(this->mosfet_temperature_protection_sensor_, (float) jk_get_16bit(offset + 8 + 3 * 25));
 
   // 0x9F 0x00 0x46: Power tube temperature recovery value                  70°C            1.0 °C     0-100°C
-  this->publish_state_(this->power_tube_temperature_recovery_sensor_, (float) jk_get_16bit(offset + 8 + 3 * 26));
+  this->publish_state_(this->mosfet_temperature_recovery_sensor_, (float) jk_get_16bit(offset + 8 + 3 * 26));
 
   // 0xA0 0x00 0x64: Temperature protection value in the battery box       100°C            1.0 °C     40-100°C
   this->publish_state_(this->temperature_sensor_temperature_protection_sensor_,
@@ -429,7 +429,7 @@ void JkBms::publish_device_unavailable_() {
   this->publish_state_(max_voltage_cell_sensor_, NAN);
   this->publish_state_(delta_cell_voltage_sensor_, NAN);
   this->publish_state_(average_cell_voltage_sensor_, NAN);
-  this->publish_state_(power_tube_temperature_sensor_, NAN);
+  this->publish_state_(mosfet_temperature_sensor_, NAN);
   this->publish_state_(temperature_sensor_1_sensor_, NAN);
   this->publish_state_(temperature_sensor_2_sensor_, NAN);
   this->publish_state_(total_voltage_sensor_, NAN);
@@ -460,8 +460,8 @@ void JkBms::publish_device_unavailable_() {
   this->publish_state_(charging_overcurrent_delay_sensor_, NAN);
   this->publish_state_(balance_starting_voltage_sensor_, NAN);
   this->publish_state_(balancing_delta_voltage_sensor_, NAN);
-  this->publish_state_(power_tube_temperature_protection_sensor_, NAN);
-  this->publish_state_(power_tube_temperature_recovery_sensor_, NAN);
+  this->publish_state_(mosfet_temperature_protection_sensor_, NAN);
+  this->publish_state_(mosfet_temperature_recovery_sensor_, NAN);
   this->publish_state_(temperature_sensor_temperature_protection_sensor_, NAN);
   this->publish_state_(temperature_sensor_temperature_recovery_sensor_, NAN);
   this->publish_state_(temperature_sensor_temperature_difference_protection_sensor_, NAN);
@@ -599,7 +599,7 @@ void JkBms::dump_config() {  // NOLINT(google-readability-function-size,readabil
   LOG_SENSOR("", "Cell Voltage 22", this->cells_[21].cell_voltage_sensor_);
   LOG_SENSOR("", "Cell Voltage 23", this->cells_[22].cell_voltage_sensor_);
   LOG_SENSOR("", "Cell Voltage 24", this->cells_[23].cell_voltage_sensor_);
-  LOG_SENSOR("", "Power Tube Temperature", this->power_tube_temperature_sensor_);
+  LOG_SENSOR("", "Mosfet Temperature", this->mosfet_temperature_sensor_);
   LOG_SENSOR("", "Temperature Sensor 1", this->temperature_sensor_1_sensor_);
   LOG_SENSOR("", "Temperature Sensor 2", this->temperature_sensor_2_sensor_);
   LOG_SENSOR("", "Total Voltage", this->total_voltage_sensor_);
@@ -630,8 +630,8 @@ void JkBms::dump_config() {  // NOLINT(google-readability-function-size,readabil
   LOG_SENSOR("", "Charging Overcurrent Delay", this->charging_overcurrent_delay_sensor_);
   LOG_SENSOR("", "Balance Starting Voltage", this->balance_starting_voltage_sensor_);
   LOG_SENSOR("", "Balancing Delta Voltage", this->balancing_delta_voltage_sensor_);
-  LOG_SENSOR("", "Power Tube Temperature Protection", this->power_tube_temperature_protection_sensor_);
-  LOG_SENSOR("", "Power Tube Temperature Recovery", this->power_tube_temperature_recovery_sensor_);
+  LOG_SENSOR("", "Mosfet Temperature Protection", this->mosfet_temperature_protection_sensor_);
+  LOG_SENSOR("", "Mosfet Temperature Recovery", this->mosfet_temperature_recovery_sensor_);
   LOG_SENSOR("", "Temperature Sensor Temperature Protection", this->temperature_sensor_temperature_protection_sensor_);
   LOG_SENSOR("", "Temperature Sensor Temperature Recovery", this->temperature_sensor_temperature_recovery_sensor_);
   LOG_SENSOR("", "Temperature Sensor Temperature Difference Protection",

--- a/components/jk_bms/jk_bms.cpp
+++ b/components/jk_bms/jk_bms.cpp
@@ -140,7 +140,7 @@ void JkBms::on_status_data_(const std::vector<uint8_t> &data) {
 
   uint16_t offset = data[1] + 3;
 
-  // 0x80 0x00 0x1D: Read power tube temperature                 29°C                      1.0 °C
+  // 0x80 0x00 0x1D: Read mosfet temperature                    29°C                      1.0 °C
   // --->  99 = 99°C, 100 = 100°C, 101 = -1°C, 140 = -40°C
   this->publish_state_(this->mosfet_temperature_sensor_, get_temperature_(jk_get_16bit(offset + 3 * 0)));
 
@@ -201,8 +201,8 @@ void JkBms::on_status_data_(const std::vector<uint8_t> &data) {
   //
   // Examples:
   // 0x0001 = 00000000 00000001: Low capacity alarm
-  // 0x0002 = 00000000 00000010: MOS tube over-temperature alarm
-  // 0x0003 = 00000000 00000011: Low capacity alarm AND power tube over-temperature alarm
+  // 0x0002 = 00000000 00000010: Mosfet over-temperature alarm
+  // 0x0003 = 00000000 00000011: Low capacity alarm AND mosfet over-temperature alarm
   uint16_t raw_errors_bitmask = jk_get_16bit(offset + 6 + 3 * 8);
   this->publish_state_(this->errors_bitmask_sensor_, (float) raw_errors_bitmask);
   this->publish_state_(this->errors_text_sensor_, this->error_bits_to_string_(raw_errors_bitmask));

--- a/components/jk_bms/jk_bms.h
+++ b/components/jk_bms/jk_bms.h
@@ -57,8 +57,8 @@ class JkBms : public PollingComponent, public jk_modbus::JkModbusDevice {
   void set_cell_voltage_sensor(uint8_t cell, sensor::Sensor *cell_voltage_sensor) {
     this->cells_[cell].cell_voltage_sensor_ = cell_voltage_sensor;
   }
-  void set_power_tube_temperature_sensor(sensor::Sensor *power_tube_temperature_sensor) {
-    power_tube_temperature_sensor_ = power_tube_temperature_sensor;
+  void set_mosfet_temperature_sensor(sensor::Sensor *mosfet_temperature_sensor) {
+    mosfet_temperature_sensor_ = mosfet_temperature_sensor;
   }
   void set_temperature_sensor_1_sensor(sensor::Sensor *temperature_sensor_1_sensor) {
     temperature_sensor_1_sensor_ = temperature_sensor_1_sensor;
@@ -142,11 +142,11 @@ class JkBms : public PollingComponent, public jk_modbus::JkModbusDevice {
   void set_balancing_delta_voltage_sensor(sensor::Sensor *balancing_delta_voltage_sensor) {
     balancing_delta_voltage_sensor_ = balancing_delta_voltage_sensor;
   }
-  void set_power_tube_temperature_protection_sensor(sensor::Sensor *power_tube_temperature_protection_sensor) {
-    power_tube_temperature_protection_sensor_ = power_tube_temperature_protection_sensor;
+  void set_mosfet_temperature_protection_sensor(sensor::Sensor *mosfet_temperature_protection_sensor) {
+    mosfet_temperature_protection_sensor_ = mosfet_temperature_protection_sensor;
   }
-  void set_power_tube_temperature_recovery_sensor(sensor::Sensor *power_tube_temperature_recovery_sensor) {
-    power_tube_temperature_recovery_sensor_ = power_tube_temperature_recovery_sensor;
+  void set_mosfet_temperature_recovery_sensor(sensor::Sensor *mosfet_temperature_recovery_sensor) {
+    mosfet_temperature_recovery_sensor_ = mosfet_temperature_recovery_sensor;
   }
   void set_temperature_sensor_temperature_protection_sensor(
       sensor::Sensor *temperature_sensor_temperature_protection_sensor) {
@@ -257,7 +257,7 @@ class JkBms : public PollingComponent, public jk_modbus::JkModbusDevice {
   sensor::Sensor *max_voltage_cell_sensor_{nullptr};
   sensor::Sensor *delta_cell_voltage_sensor_{nullptr};
   sensor::Sensor *average_cell_voltage_sensor_{nullptr};
-  sensor::Sensor *power_tube_temperature_sensor_{nullptr};
+  sensor::Sensor *mosfet_temperature_sensor_{nullptr};
   sensor::Sensor *temperature_sensor_1_sensor_{nullptr};
   sensor::Sensor *temperature_sensor_2_sensor_{nullptr};
   sensor::Sensor *total_voltage_sensor_{nullptr};
@@ -288,8 +288,8 @@ class JkBms : public PollingComponent, public jk_modbus::JkModbusDevice {
   sensor::Sensor *charging_overcurrent_delay_sensor_{nullptr};
   sensor::Sensor *balance_starting_voltage_sensor_{nullptr};
   sensor::Sensor *balancing_delta_voltage_sensor_{nullptr};
-  sensor::Sensor *power_tube_temperature_protection_sensor_{nullptr};
-  sensor::Sensor *power_tube_temperature_recovery_sensor_{nullptr};
+  sensor::Sensor *mosfet_temperature_protection_sensor_{nullptr};
+  sensor::Sensor *mosfet_temperature_recovery_sensor_{nullptr};
   sensor::Sensor *temperature_sensor_temperature_protection_sensor_{nullptr};
   sensor::Sensor *temperature_sensor_temperature_recovery_sensor_{nullptr};
   sensor::Sensor *temperature_sensor_temperature_difference_protection_sensor_{nullptr};

--- a/components/jk_bms/sensor.py
+++ b/components/jk_bms/sensor.py
@@ -37,7 +37,7 @@ CONF_MAX_VOLTAGE_CELL = "max_voltage_cell"
 CONF_DELTA_CELL_VOLTAGE = "delta_cell_voltage"
 CONF_AVERAGE_CELL_VOLTAGE = "average_cell_voltage"
 
-CONF_POWER_TUBE_TEMPERATURE = "power_tube_temperature"
+CONF_MOSFET_TEMPERATURE = "mosfet_temperature"
 CONF_TEMPERATURE_SENSOR_1 = "temperature_sensor_1"
 CONF_TEMPERATURE_SENSOR_2 = "temperature_sensor_2"
 CONF_TOTAL_VOLTAGE = "total_voltage"
@@ -75,8 +75,8 @@ CONF_CHARGING_OVERCURRENT_DELAY = "charging_overcurrent_delay"
 CONF_BALANCE_STARTING_VOLTAGE = "balance_starting_voltage"
 CONF_BALANCING_DELTA_VOLTAGE = "balancing_delta_voltage"
 
-CONF_POWER_TUBE_TEMPERATURE_PROTECTION = "power_tube_temperature_protection"
-CONF_POWER_TUBE_TEMPERATURE_RECOVERY = "power_tube_temperature_recovery"
+CONF_MOSFET_TEMPERATURE_PROTECTION = "mosfet_temperature_protection"
+CONF_MOSFET_TEMPERATURE_RECOVERY = "mosfet_temperature_recovery"
 
 CONF_TEMPERATURE_SENSOR_TEMPERATURE_PROTECTION = (
     "temperature_sensor_temperature_protection"
@@ -180,7 +180,7 @@ SENSOR_DEFS = {
         "device_class": DEVICE_CLASS_VOLTAGE,
         "state_class": STATE_CLASS_MEASUREMENT,
     },
-    CONF_POWER_TUBE_TEMPERATURE: {
+    CONF_MOSFET_TEMPERATURE: {
         "unit_of_measurement": UNIT_CELSIUS,
         "icon": ICON_EMPTY,
         "accuracy_decimals": 0,
@@ -396,14 +396,14 @@ SENSOR_DEFS = {
         "device_class": DEVICE_CLASS_VOLTAGE,
         "state_class": STATE_CLASS_MEASUREMENT,
     },
-    CONF_POWER_TUBE_TEMPERATURE_PROTECTION: {
+    CONF_MOSFET_TEMPERATURE_PROTECTION: {
         "unit_of_measurement": UNIT_CELSIUS,
         "icon": ICON_EMPTY,
         "accuracy_decimals": 0,
         "device_class": DEVICE_CLASS_TEMPERATURE,
         "state_class": STATE_CLASS_MEASUREMENT,
     },
-    CONF_POWER_TUBE_TEMPERATURE_RECOVERY: {
+    CONF_MOSFET_TEMPERATURE_RECOVERY: {
         "unit_of_measurement": UNIT_CELSIUS,
         "icon": ICON_EMPTY,
         "accuracy_decimals": 0,
@@ -554,6 +554,9 @@ _RENAMED_SENSORS = {
     "battery_strings": "cell_count",
     "temperature_sensors": "temperature_sensor_count",
     "total_battery_capacity_setting": "full_charge_capacity",
+    "power_tube_temperature": "mosfet_temperature",
+    "power_tube_temperature_protection": "mosfet_temperature_protection",
+    "power_tube_temperature_recovery": "mosfet_temperature_recovery",
 }
 
 CONFIG_SCHEMA = cv.All(

--- a/components/jk_bms_ble/jk_bms_ble.cpp
+++ b/components/jk_bms_ble/jk_bms_ble.cpp
@@ -158,7 +158,7 @@ void JkBmsBle::dump_config() {  // NOLINT(google-readability-function-size,reada
   LOG_SENSOR("", "Power", this->power_sensor_);
   LOG_SENSOR("", "Charging Power", this->charging_power_sensor_);
   LOG_SENSOR("", "Discharging Power", this->discharging_power_sensor_);
-  LOG_SENSOR("", "Power Tube Temperature", this->power_tube_temperature_sensor_);
+  LOG_SENSOR("", "Mosfet Temperature", this->mosfet_temperature_sensor_);
   LOG_SENSOR("", "Temperature Sensor 1", this->temperatures_[0].temperature_sensor_);
   LOG_SENSOR("", "Temperature Sensor 2", this->temperatures_[1].temperature_sensor_);
   LOG_SENSOR("", "Temperature Sensor 3", this->temperatures_[2].temperature_sensor_);
@@ -542,7 +542,7 @@ void JkBmsBle::decode_jk02_cell_info_(const std::vector<uint8_t> &data) {
 
   // 112   2   0x00 0x00              Unknown112
   if (frame_version == FRAME_VERSION_JK02_32S) {
-    this->publish_state_(this->power_tube_temperature_sensor_, (float) ((int16_t) jk_get_16bit(112 + offset)) * 0.1f);
+    this->publish_state_(this->mosfet_temperature_sensor_, (float) ((int16_t) jk_get_16bit(112 + offset)) * 0.1f);
   } else {
     ESP_LOGD(TAG, "Unknown112: 0x%02X 0x%02X", data[112 + offset], data[113 + offset]);
   }
@@ -582,7 +582,7 @@ void JkBmsBle::decode_jk02_cell_info_(const std::vector<uint8_t> &data) {
     this->publish_state_(this->errors_bitmask_hex_text_sensor_, this->to_hex_string_(raw_errors_bitmask));
     this->publish_state_(this->errors_text_sensor_, this->error_bits_to_string_(raw_errors_bitmask, ERRORS_JK02, 32));
   } else {
-    this->publish_state_(this->power_tube_temperature_sensor_, (float) ((int16_t) jk_get_16bit(134 + offset)) * 0.1f);
+    this->publish_state_(this->mosfet_temperature_sensor_, (float) ((int16_t) jk_get_16bit(134 + offset)) * 0.1f);
   }
 
   // 136-137: errors bitmask (JK02_24S only), little-endian 16-bit
@@ -1045,12 +1045,11 @@ void JkBmsBle::decode_jk02_settings_(const std::vector<uint8_t> &data) {
 
   // 106   4   0x84 0x03 0x00 0x00    MOS OTP
   ESP_LOGV(TAG, "  Mosfet OTP: %f °C", (float) ((int32_t) jk_get_32bit(106)) * 0.1f);
-  this->publish_state_(this->power_tube_overtemperature_protection_number_,
-                       (float) ((int32_t) jk_get_32bit(106)) * 0.1f);
+  this->publish_state_(this->mosfet_overtemperature_protection_number_, (float) ((int32_t) jk_get_32bit(106)) * 0.1f);
 
   // 110   4   0xBC 0x02 0x00 0x00    MOS OTP Recovery
   ESP_LOGV(TAG, "  Mosfet OTP recovery: %f °C", (float) ((int32_t) jk_get_32bit(110)) * 0.1f);
-  this->publish_state_(this->power_tube_overtemperature_protection_recovery_number_,
+  this->publish_state_(this->mosfet_overtemperature_protection_recovery_number_,
                        (float) ((int32_t) jk_get_32bit(110)) * 0.1f);
 
   // 114   4   0x0D 0x00 0x00 0x00    Cell count
@@ -1608,7 +1607,7 @@ void JkBmsBle::publish_device_unavailable_() {
   this->publish_state_(power_sensor_, NAN);
   this->publish_state_(charging_power_sensor_, NAN);
   this->publish_state_(discharging_power_sensor_, NAN);
-  this->publish_state_(power_tube_temperature_sensor_, NAN);
+  this->publish_state_(mosfet_temperature_sensor_, NAN);
   this->publish_state_(balancer_status_sensor_, NAN);
   this->publish_state_(state_of_charge_sensor_, NAN);
   this->publish_state_(state_of_health_sensor_, NAN);

--- a/components/jk_bms_ble/jk_bms_ble.h
+++ b/components/jk_bms_ble/jk_bms_ble.h
@@ -148,12 +148,12 @@ class JkBmsBle :
       number::Number *discharge_undertemperature_protection_recovery_number) {
     discharge_undertemperature_protection_recovery_number_ = discharge_undertemperature_protection_recovery_number;
   }
-  void set_power_tube_overtemperature_protection_number(number::Number *power_tube_overtemperature_protection_number) {
-    power_tube_overtemperature_protection_number_ = power_tube_overtemperature_protection_number;
+  void set_mosfet_overtemperature_protection_number(number::Number *mosfet_overtemperature_protection_number) {
+    mosfet_overtemperature_protection_number_ = mosfet_overtemperature_protection_number;
   }
-  void set_power_tube_overtemperature_protection_recovery_number(
-      number::Number *power_tube_overtemperature_protection_recovery_number) {
-    power_tube_overtemperature_protection_recovery_number_ = power_tube_overtemperature_protection_recovery_number;
+  void set_mosfet_overtemperature_protection_recovery_number(
+      number::Number *mosfet_overtemperature_protection_recovery_number) {
+    mosfet_overtemperature_protection_recovery_number_ = mosfet_overtemperature_protection_recovery_number;
   }
   void set_discharge_precharge_time_number(number::Number *discharge_precharge_time_number) {
     discharge_precharge_time_number_ = discharge_precharge_time_number;
@@ -231,8 +231,8 @@ class JkBmsBle :
   void set_temperature_sensor(uint8_t temperature, sensor::Sensor *temperature_sensor) {
     this->temperatures_[temperature].temperature_sensor_ = temperature_sensor;
   }
-  void set_power_tube_temperature_sensor(sensor::Sensor *power_tube_temperature_sensor) {
-    power_tube_temperature_sensor_ = power_tube_temperature_sensor;
+  void set_mosfet_temperature_sensor(sensor::Sensor *mosfet_temperature_sensor) {
+    mosfet_temperature_sensor_ = mosfet_temperature_sensor;
   }
   void set_state_of_charge_sensor(sensor::Sensor *state_of_charge_sensor) {
     state_of_charge_sensor_ = state_of_charge_sensor;
@@ -382,8 +382,8 @@ class JkBmsBle :
   number::Number *charge_undertemperature_protection_recovery_number_{nullptr};
   number::Number *discharge_undertemperature_protection_number_{nullptr};
   number::Number *discharge_undertemperature_protection_recovery_number_{nullptr};
-  number::Number *power_tube_overtemperature_protection_number_{nullptr};
-  number::Number *power_tube_overtemperature_protection_recovery_number_{nullptr};
+  number::Number *mosfet_overtemperature_protection_number_{nullptr};
+  number::Number *mosfet_overtemperature_protection_recovery_number_{nullptr};
   number::Number *discharge_precharge_time_number_{nullptr};
   number::Number *heating_start_temperature_number_{nullptr};
   number::Number *heating_stop_temperature_number_{nullptr};
@@ -401,7 +401,7 @@ class JkBmsBle :
   sensor::Sensor *power_sensor_{nullptr};
   sensor::Sensor *charging_power_sensor_{nullptr};
   sensor::Sensor *discharging_power_sensor_{nullptr};
-  sensor::Sensor *power_tube_temperature_sensor_{nullptr};
+  sensor::Sensor *mosfet_temperature_sensor_{nullptr};
   sensor::Sensor *state_of_charge_sensor_{nullptr};
   sensor::Sensor *state_of_health_sensor_{nullptr};
   sensor::Sensor *capacity_remaining_sensor_{nullptr};

--- a/components/jk_bms_ble/number/__init__.py
+++ b/components/jk_bms_ble/number/__init__.py
@@ -17,7 +17,12 @@ from esphome.const import (
     UNIT_VOLT,
 )
 
-from .. import CONF_JK_BMS_BLE_ID, JK_BMS_BLE_COMPONENT_SCHEMA, jk_bms_ble_ns
+from .. import (
+    CONF_JK_BMS_BLE_ID,
+    JK_BMS_BLE_COMPONENT_SCHEMA,
+    deprecated_renames,
+    jk_bms_ble_ns,
+)
 
 DEPENDENCIES = ["jk_bms_ble"]
 
@@ -182,9 +187,9 @@ CONF_DISCHARGE_UNDERTEMPERATURE_PROTECTION = "discharge_undertemperature_protect
 CONF_DISCHARGE_UNDERTEMPERATURE_PROTECTION_RECOVERY = (
     "discharge_undertemperature_protection_recovery"
 )
-CONF_POWER_TUBE_OVERTEMPERATURE_PROTECTION = "power_tube_overtemperature_protection"
-CONF_POWER_TUBE_OVERTEMPERATURE_PROTECTION_RECOVERY = (
-    "power_tube_overtemperature_protection_recovery"
+CONF_MOSFET_OVERTEMPERATURE_PROTECTION = "mosfet_overtemperature_protection"
+CONF_MOSFET_OVERTEMPERATURE_PROTECTION_RECOVERY = (
+    "mosfet_overtemperature_protection_recovery"
 )
 CONF_DISCHARGE_PRECHARGE_TIME = "discharge_precharge_time"
 CONF_HEATING_START_TEMPERATURE = "heating_start_temperature"
@@ -298,14 +303,14 @@ NUMBERS = {
         1.0,
         1,
     ],
-    CONF_POWER_TUBE_OVERTEMPERATURE_PROTECTION: [
+    CONF_MOSFET_OVERTEMPERATURE_PROTECTION: [
         0x00,
         0x1A,
         0x1A,
         10.0,
         4,
     ],
-    CONF_POWER_TUBE_OVERTEMPERATURE_PROTECTION_RECOVERY: [
+    CONF_MOSFET_OVERTEMPERATURE_PROTECTION_RECOVERY: [
         0x00,
         0x1B,
         0x1B,
@@ -337,7 +342,12 @@ JK_NUMBER_SCHEMA = (
     .extend(cv.COMPONENT_SCHEMA)
 )
 
-CONFIG_SCHEMA = JK_BMS_BLE_COMPONENT_SCHEMA.extend(
+_RENAMED_NUMBERS = {
+    "power_tube_overtemperature_protection": "mosfet_overtemperature_protection",
+    "power_tube_overtemperature_protection_recovery": "mosfet_overtemperature_protection_recovery",
+}
+
+_NUMBER_CONFIG_SCHEMA = JK_BMS_BLE_COMPONENT_SCHEMA.extend(
     {
         cv.Optional(CONF_SMART_SLEEP_VOLTAGE): JK_NUMBER_SCHEMA.extend(
             {
@@ -678,9 +688,7 @@ CONFIG_SCHEMA = JK_BMS_BLE_COMPONENT_SCHEMA.extend(
                 ): cv.string_strict,
             }
         ),
-        cv.Optional(
-            CONF_POWER_TUBE_OVERTEMPERATURE_PROTECTION
-        ): JK_NUMBER_SCHEMA.extend(
+        cv.Optional(CONF_MOSFET_OVERTEMPERATURE_PROTECTION): JK_NUMBER_SCHEMA.extend(
             {
                 cv.Optional(CONF_MIN_VALUE, default=50): cv.float_,
                 cv.Optional(CONF_MAX_VALUE, default=110): cv.float_,
@@ -691,7 +699,7 @@ CONFIG_SCHEMA = JK_BMS_BLE_COMPONENT_SCHEMA.extend(
             }
         ),
         cv.Optional(
-            CONF_POWER_TUBE_OVERTEMPERATURE_PROTECTION_RECOVERY
+            CONF_MOSFET_OVERTEMPERATURE_PROTECTION_RECOVERY
         ): JK_NUMBER_SCHEMA.extend(
             {
                 cv.Optional(CONF_MIN_VALUE, default=50): cv.float_,
@@ -734,6 +742,8 @@ CONFIG_SCHEMA = JK_BMS_BLE_COMPONENT_SCHEMA.extend(
         ),
     }
 )
+
+CONFIG_SCHEMA = cv.All(deprecated_renames(_RENAMED_NUMBERS), _NUMBER_CONFIG_SCHEMA)
 
 
 async def to_code(config):

--- a/components/jk_bms_ble/sensor.py
+++ b/components/jk_bms_ble/sensor.py
@@ -43,7 +43,7 @@ CONF_TEMPERATURE_SENSOR_2 = "temperature_sensor_2"
 CONF_TEMPERATURE_SENSOR_3 = "temperature_sensor_3"
 CONF_TEMPERATURE_SENSOR_4 = "temperature_sensor_4"
 CONF_TEMPERATURE_SENSOR_5 = "temperature_sensor_5"
-CONF_POWER_TUBE_TEMPERATURE = "power_tube_temperature"
+CONF_MOSFET_TEMPERATURE = "mosfet_temperature"
 CONF_STATE_OF_CHARGE = "state_of_charge"
 CONF_STATE_OF_HEALTH = "state_of_health"
 CONF_CAPACITY_REMAINING = "capacity_remaining"
@@ -188,7 +188,7 @@ SENSOR_DEFS = {
         "device_class": DEVICE_CLASS_POWER,
         "state_class": STATE_CLASS_MEASUREMENT,
     },
-    CONF_POWER_TUBE_TEMPERATURE: {
+    CONF_MOSFET_TEMPERATURE: {
         "unit_of_measurement": UNIT_CELSIUS,
         "icon": ICON_EMPTY,
         "accuracy_decimals": 1,
@@ -293,6 +293,7 @@ SENSOR_DEFS = {
 _RENAMED_SENSORS = {
     "balancing": "balancer_status",
     "total_battery_capacity_setting": "full_charge_capacity",
+    "power_tube_temperature": "mosfet_temperature",
 }
 
 CONFIG_SCHEMA = cv.All(

--- a/docs/display-protocol/traffic-ble-same-time.txt
+++ b/docs/display-protocol/traffic-ble-same-time.txt
@@ -24,8 +24,8 @@
 [number:012]: 'jk-bms discharge overtemperature protection recovery': Sending state 60.000000
 [number:012]: 'jk-bms charge undertemperature protection': Sending state 5.000000
 [number:012]: 'jk-bms charge undertemperature protection recovery': Sending state 10.000000
-[number:012]: 'jk-bms power tube overtemperature protection': Sending state 100.000000
-[number:012]: 'jk-bms power tube overtemperature protection recovery': Sending state 80.000000
+[number:012]: 'jk-bms mosfet overtemperature protection': Sending state 100.000000
+[number:012]: 'jk-bms mosfet overtemperature protection recovery': Sending state 80.000000
 [number:012]: 'jk-bms cell count': Sending state 13.000000
 [switch:055]: 'jk-bms charging': Sending state ON
 [switch:055]: 'jk-bms discharging': Sending state ON
@@ -136,7 +136,7 @@
 [sensor:094]: 'jk-bms delta cell voltage': Sending state 0.22300 V with 3 decimals of accuracy
 [sensor:094]: 'jk-bms max voltage cell': Sending state 4.00000  with 0 decimals of accuracy
 [sensor:094]: 'jk-bms min voltage cell': Sending state 7.00000  with 0 decimals of accuracy
-[sensor:094]: 'jk-bms power tube temperature': Sending state 26.80000 °C with 1 decimals of accuracy
+[sensor:094]: 'jk-bms mosfet temperature': Sending state 26.80000 °C with 1 decimals of accuracy
 [jk_bms_ble:425]: Wire resistance warning bitmask: 0x00 0x00 0x00 0x00
 [sensor:094]: 'jk-bms total voltage': Sending state 52.52900 V with 2 decimals of accuracy
 [sensor:094]: 'jk-bms current': Sending state 0.00000 A with 2 decimals of accuracy

--- a/docs/protocol-design-uart-ttl-gps-port.md
+++ b/docs/protocol-design-uart-ttl-gps-port.md
@@ -89,7 +89,7 @@ C0 01
 | RW   | Code | Name                                                | Bytes | Type  | Info |
 | ---: | :--- | :-------------------------------------------------- | :---: | :---: | :--- |
 |    R | 0x79 | Individual Cell voltage                             |   3*n |  Hex  | The first byte is the cell number, the next two bytes is the voltage value MV. When reading all the data at the same time, 0x79 is followed by one byte length data, n as shown above, and then a group of three bytes represents the | electricity Cell voltage. |
-|    R | 0x80 | Read power tube temperature                         |    2  |  Hex  | 0-140 (-40 to 100) The part exceeding 100 is negative temperature, such as 101 is negative 1 degree (100 Benchmark) |
+|    R | 0x80 | Read mosfet temperature                         |    2  |  Hex  | 0-140 (-40 to 100) The part exceeding 100 is negative temperature, such as 101 is negative 1 degree (100 Benchmark) |
 |    R | 0x81 | Read the temperature in the battery box             |    2  |  Hex  | 0-140 (-40 to 100) The part exceeding 100 is negative temperature, the same as above (100 reference) |
 |    R | 0x82 | Read battery temperature                            |    2  |  Hex  | 0-140 (-40 to 100) The part exceeding 100 is negative temperature, the same as above (100 reference) |
 |    R | 0x83 | Total battery voltage                               |    2  |  Hex  | 0.01V 3500*0.01=35.00v minimum unit 10mV |

--- a/esp32-ble-example-multiple-devices.yaml
+++ b/esp32-ble-example-multiple-devices.yaml
@@ -176,7 +176,7 @@ sensor:
       name: "power"
       device_id: device0
     mosfet_temperature:
-      name: "power tube temperature"
+      name: "mosfet temperature"
       device_id: device0
     # ...
 
@@ -198,7 +198,7 @@ sensor:
       name: "power"
       device_id: device1
     mosfet_temperature:
-      name: "power tube temperature"
+      name: "mosfet temperature"
       device_id: device1
     # ...
 

--- a/esp32-ble-example-multiple-devices.yaml
+++ b/esp32-ble-example-multiple-devices.yaml
@@ -175,7 +175,7 @@ sensor:
     power:
       name: "power"
       device_id: device0
-    power_tube_temperature:
+    mosfet_temperature:
       name: "power tube temperature"
       device_id: device0
     # ...
@@ -197,7 +197,7 @@ sensor:
     power:
       name: "power"
       device_id: device1
-    power_tube_temperature:
+    mosfet_temperature:
       name: "power tube temperature"
       device_id: device1
     # ...

--- a/esp32-ble-example.yaml
+++ b/esp32-ble-example.yaml
@@ -140,9 +140,9 @@ number:
       name: "charge undertemperature protection"
     charge_undertemperature_protection_recovery:
       name: "charge undertemperature protection recovery"
-    power_tube_overtemperature_protection:
+    mosfet_overtemperature_protection:
       name: "power tube overtemperature protection"
-    power_tube_overtemperature_protection_recovery:
+    mosfet_overtemperature_protection_recovery:
       name: "power tube overtemperature protection recovery"
 
 sensor:
@@ -276,7 +276,7 @@ sensor:
     #   name: "temperature sensor 3"
     # temperature_sensor_4:
     #   name: "temperature sensor 4"
-    power_tube_temperature:
+    mosfet_temperature:
       name: "power tube temperature"
     balancer_status:
       name: "balancer status"

--- a/esp32-ble-example.yaml
+++ b/esp32-ble-example.yaml
@@ -141,9 +141,9 @@ number:
     charge_undertemperature_protection_recovery:
       name: "charge undertemperature protection recovery"
     mosfet_overtemperature_protection:
-      name: "power tube overtemperature protection"
+      name: "mosfet overtemperature protection"
     mosfet_overtemperature_protection_recovery:
-      name: "power tube overtemperature protection recovery"
+      name: "mosfet overtemperature protection recovery"
 
 sensor:
   - platform: jk_bms_ble
@@ -277,7 +277,7 @@ sensor:
     # temperature_sensor_4:
     #   name: "temperature sensor 4"
     mosfet_temperature:
-      name: "power tube temperature"
+      name: "mosfet temperature"
     balancer_status:
       name: "balancer status"
     state_of_charge:

--- a/esp32-ble-jk04-example.yaml
+++ b/esp32-ble-jk04-example.yaml
@@ -189,7 +189,7 @@ sensor:
       name: "total runtime"
     balancing_current:
       name: "balancing current"
-    power_tube_temperature:
+    mosfet_temperature:
       name: "power tube temperature"
 
 switch:

--- a/esp32-ble-jk04-example.yaml
+++ b/esp32-ble-jk04-example.yaml
@@ -190,7 +190,7 @@ sensor:
     balancing_current:
       name: "balancing current"
     mosfet_temperature:
-      name: "power tube temperature"
+      name: "mosfet temperature"
 
 switch:
   - platform: jk_bms_ble

--- a/esp32-ble-uart-hybrid-example.yaml
+++ b/esp32-ble-uart-hybrid-example.yaml
@@ -170,7 +170,7 @@ sensor:
       name: "cell voltage 15"
     cell_voltage_16:
       name: "cell voltage 16"
-    power_tube_temperature:
+    mosfet_temperature:
       name: "power tube temperature"
     temperature_sensor_1:
       name: "temperature sensor 1"

--- a/esp32-ble-uart-hybrid-example.yaml
+++ b/esp32-ble-uart-hybrid-example.yaml
@@ -171,7 +171,7 @@ sensor:
     cell_voltage_16:
       name: "cell voltage 16"
     mosfet_temperature:
-      name: "power tube temperature"
+      name: "mosfet temperature"
     temperature_sensor_1:
       name: "temperature sensor 1"
     temperature_sensor_2:

--- a/esp32-ble-v11-example.yaml
+++ b/esp32-ble-v11-example.yaml
@@ -154,9 +154,9 @@ number:
       name: "discharge undertemperature protection"
     discharge_undertemperature_protection_recovery:
       name: "discharge undertemperature protection recovery"
-    power_tube_overtemperature_protection:
+    mosfet_overtemperature_protection:
       name: "power tube overtemperature protection"
-    power_tube_overtemperature_protection_recovery:
+    mosfet_overtemperature_protection_recovery:
       name: "power tube overtemperature protection recovery"
     discharge_precharge_time:
       name: "discharge precharge time"
@@ -292,7 +292,7 @@ sensor:
       name: "temperature sensor 3"
     temperature_sensor_4:
       name: "temperature sensor 4"
-    power_tube_temperature:
+    mosfet_temperature:
       name: "power tube temperature"
     balancer_status:
       name: "balancer status"

--- a/esp32-ble-v11-example.yaml
+++ b/esp32-ble-v11-example.yaml
@@ -155,9 +155,9 @@ number:
     discharge_undertemperature_protection_recovery:
       name: "discharge undertemperature protection recovery"
     mosfet_overtemperature_protection:
-      name: "power tube overtemperature protection"
+      name: "mosfet overtemperature protection"
     mosfet_overtemperature_protection_recovery:
-      name: "power tube overtemperature protection recovery"
+      name: "mosfet overtemperature protection recovery"
     discharge_precharge_time:
       name: "discharge precharge time"
 
@@ -293,7 +293,7 @@ sensor:
     temperature_sensor_4:
       name: "temperature sensor 4"
     mosfet_temperature:
-      name: "power tube temperature"
+      name: "mosfet temperature"
     balancer_status:
       name: "balancer status"
     state_of_charge:

--- a/esp32-ble-v14-example-multiple-devices.yaml
+++ b/esp32-ble-v14-example-multiple-devices.yaml
@@ -245,10 +245,10 @@ number:
       name: "discharge undertemperature protection recovery"
       device_id: device0
     mosfet_overtemperature_protection:
-      name: "power tube overtemperature protection"
+      name: "mosfet overtemperature protection"
       device_id: device0
     mosfet_overtemperature_protection_recovery:
-      name: "power tube overtemperature protection recovery"
+      name: "mosfet overtemperature protection recovery"
       device_id: device0
     # ...
 
@@ -360,10 +360,10 @@ number:
       name: "discharge undertemperature protection recovery"
       device_id: device1
     mosfet_overtemperature_protection:
-      name: "power tube overtemperature protection"
+      name: "mosfet overtemperature protection"
       device_id: device1
     mosfet_overtemperature_protection_recovery:
-      name: "power tube overtemperature protection recovery"
+      name: "mosfet overtemperature protection recovery"
       device_id: device1
     # ...
 
@@ -566,7 +566,7 @@ sensor:
       name: "temperature sensor 5"
       device_id: device0
     mosfet_temperature:
-      name: "power tube temperature"
+      name: "mosfet temperature"
       device_id: device0
     balancer_status:
       name: "balancer status"
@@ -798,7 +798,7 @@ sensor:
       name: "temperature sensor 5"
       device_id: device1
     mosfet_temperature:
-      name: "power tube temperature"
+      name: "mosfet temperature"
       device_id: device1
     balancer_status:
       name: "balancer status"

--- a/esp32-ble-v14-example-multiple-devices.yaml
+++ b/esp32-ble-v14-example-multiple-devices.yaml
@@ -244,10 +244,10 @@ number:
     discharge_undertemperature_protection_recovery:
       name: "discharge undertemperature protection recovery"
       device_id: device0
-    power_tube_overtemperature_protection:
+    mosfet_overtemperature_protection:
       name: "power tube overtemperature protection"
       device_id: device0
-    power_tube_overtemperature_protection_recovery:
+    mosfet_overtemperature_protection_recovery:
       name: "power tube overtemperature protection recovery"
       device_id: device0
     # ...
@@ -359,10 +359,10 @@ number:
     discharge_undertemperature_protection_recovery:
       name: "discharge undertemperature protection recovery"
       device_id: device1
-    power_tube_overtemperature_protection:
+    mosfet_overtemperature_protection:
       name: "power tube overtemperature protection"
       device_id: device1
-    power_tube_overtemperature_protection_recovery:
+    mosfet_overtemperature_protection_recovery:
       name: "power tube overtemperature protection recovery"
       device_id: device1
     # ...
@@ -565,7 +565,7 @@ sensor:
     temperature_sensor_5:
       name: "temperature sensor 5"
       device_id: device0
-    power_tube_temperature:
+    mosfet_temperature:
       name: "power tube temperature"
       device_id: device0
     balancer_status:
@@ -797,7 +797,7 @@ sensor:
     temperature_sensor_5:
       name: "temperature sensor 5"
       device_id: device1
-    power_tube_temperature:
+    mosfet_temperature:
       name: "power tube temperature"
       device_id: device1
     balancer_status:

--- a/esp32-ble-v14-example.yaml
+++ b/esp32-ble-v14-example.yaml
@@ -162,9 +162,9 @@ number:
       name: "discharge undertemperature protection"
     discharge_undertemperature_protection_recovery:
       name: "discharge undertemperature protection recovery"
-    power_tube_overtemperature_protection:
+    mosfet_overtemperature_protection:
       name: "power tube overtemperature protection"
-    power_tube_overtemperature_protection_recovery:
+    mosfet_overtemperature_protection_recovery:
       name: "power tube overtemperature protection recovery"
     discharge_precharge_time:
       name: "discharge precharge time"
@@ -302,7 +302,7 @@ sensor:
       name: "temperature sensor 4"
     temperature_sensor_5:
       name: "temperature sensor 5"
-    power_tube_temperature:
+    mosfet_temperature:
       name: "power tube temperature"
     balancer_status:
       name: "balancer status"

--- a/esp32-ble-v14-example.yaml
+++ b/esp32-ble-v14-example.yaml
@@ -163,9 +163,9 @@ number:
     discharge_undertemperature_protection_recovery:
       name: "discharge undertemperature protection recovery"
     mosfet_overtemperature_protection:
-      name: "power tube overtemperature protection"
+      name: "mosfet overtemperature protection"
     mosfet_overtemperature_protection_recovery:
-      name: "power tube overtemperature protection recovery"
+      name: "mosfet overtemperature protection recovery"
     discharge_precharge_time:
       name: "discharge precharge time"
 
@@ -303,7 +303,7 @@ sensor:
     temperature_sensor_5:
       name: "temperature sensor 5"
     mosfet_temperature:
-      name: "power tube temperature"
+      name: "mosfet temperature"
     balancer_status:
       name: "balancer status"
     state_of_charge:

--- a/esp32-ble-v15-example.yaml
+++ b/esp32-ble-v15-example.yaml
@@ -163,9 +163,9 @@ number:
     discharge_undertemperature_protection_recovery:
       name: "discharge undertemperature protection recovery"
     mosfet_overtemperature_protection:
-      name: "power tube overtemperature protection"
+      name: "mosfet overtemperature protection"
     mosfet_overtemperature_protection_recovery:
-      name: "power tube overtemperature protection recovery"
+      name: "mosfet overtemperature protection recovery"
     discharge_precharge_time:
       name: "discharge precharge time"
     heating_start_temperature:
@@ -307,7 +307,7 @@ sensor:
     temperature_sensor_5:
       name: "temperature sensor 5"
     mosfet_temperature:
-      name: "power tube temperature"
+      name: "mosfet temperature"
     balancer_status:
       name: "balancer status"
     state_of_charge:

--- a/esp32-ble-v15-example.yaml
+++ b/esp32-ble-v15-example.yaml
@@ -162,9 +162,9 @@ number:
       name: "discharge undertemperature protection"
     discharge_undertemperature_protection_recovery:
       name: "discharge undertemperature protection recovery"
-    power_tube_overtemperature_protection:
+    mosfet_overtemperature_protection:
       name: "power tube overtemperature protection"
-    power_tube_overtemperature_protection_recovery:
+    mosfet_overtemperature_protection_recovery:
       name: "power tube overtemperature protection recovery"
     discharge_precharge_time:
       name: "discharge precharge time"
@@ -306,7 +306,7 @@ sensor:
       name: "temperature sensor 4"
     temperature_sensor_5:
       name: "temperature sensor 5"
-    power_tube_temperature:
+    mosfet_temperature:
       name: "power tube temperature"
     balancer_status:
       name: "balancer status"

--- a/esp32-ble-v19-example.yaml
+++ b/esp32-ble-v19-example.yaml
@@ -165,9 +165,9 @@ number:
     discharge_undertemperature_protection_recovery:
       name: "discharge undertemperature protection recovery"
     mosfet_overtemperature_protection:
-      name: "power tube overtemperature protection"
+      name: "mosfet overtemperature protection"
     mosfet_overtemperature_protection_recovery:
-      name: "power tube overtemperature protection recovery"
+      name: "mosfet overtemperature protection recovery"
     discharge_precharge_time:
       name: "discharge precharge time"
     heating_start_temperature:
@@ -309,7 +309,7 @@ sensor:
     temperature_sensor_5:
       name: "temperature sensor 5"
     mosfet_temperature:
-      name: "power tube temperature"
+      name: "mosfet temperature"
     balancer_status:
       name: "balancer status"
     state_of_charge:

--- a/esp32-ble-v19-example.yaml
+++ b/esp32-ble-v19-example.yaml
@@ -164,9 +164,9 @@ number:
       name: "discharge undertemperature protection"
     discharge_undertemperature_protection_recovery:
       name: "discharge undertemperature protection recovery"
-    power_tube_overtemperature_protection:
+    mosfet_overtemperature_protection:
       name: "power tube overtemperature protection"
-    power_tube_overtemperature_protection_recovery:
+    mosfet_overtemperature_protection_recovery:
       name: "power tube overtemperature protection recovery"
     discharge_precharge_time:
       name: "discharge precharge time"
@@ -308,7 +308,7 @@ sensor:
       name: "temperature sensor 4"
     temperature_sensor_5:
       name: "temperature sensor 5"
-    power_tube_temperature:
+    mosfet_temperature:
       name: "power tube temperature"
     balancer_status:
       name: "balancer status"

--- a/esp32-example-multiple-devices.yaml
+++ b/esp32-example-multiple-devices.yaml
@@ -120,7 +120,7 @@ sensor:
     average_cell_voltage:
       name: "average cell voltage"
       device_id: device0
-    power_tube_temperature:
+    mosfet_temperature:
       name: "power tube temperature"
       device_id: device0
     total_voltage:
@@ -142,7 +142,7 @@ sensor:
     average_cell_voltage:
       name: "average cell voltage"
       device_id: device1
-    power_tube_temperature:
+    mosfet_temperature:
       name: "power tube temperature"
       device_id: device1
     total_voltage:

--- a/esp32-example-multiple-devices.yaml
+++ b/esp32-example-multiple-devices.yaml
@@ -121,7 +121,7 @@ sensor:
       name: "average cell voltage"
       device_id: device0
     mosfet_temperature:
-      name: "power tube temperature"
+      name: "mosfet temperature"
       device_id: device0
     total_voltage:
       name: "total voltage"
@@ -143,7 +143,7 @@ sensor:
       name: "average cell voltage"
       device_id: device1
     mosfet_temperature:
-      name: "power tube temperature"
+      name: "mosfet temperature"
       device_id: device1
     total_voltage:
       name: "total voltage"

--- a/esp32-example.yaml
+++ b/esp32-example.yaml
@@ -137,7 +137,7 @@ sensor:
       name: "cell voltage 23"
     cell_voltage_24:
       name: "cell voltage 24"
-    power_tube_temperature:
+    mosfet_temperature:
       name: "power tube temperature"
     temperature_sensor_1:
       name: "temperature sensor 1"
@@ -199,9 +199,9 @@ sensor:
       name: "balance starting voltage"
     balancing_delta_voltage:
       name: "balance opening pressure difference"
-    power_tube_temperature_protection:
+    mosfet_temperature_protection:
       name: "power tube temperature protection"
-    power_tube_temperature_recovery:
+    mosfet_temperature_recovery:
       name: "power tube temperature recovery"
     temperature_sensor_temperature_protection:
       name: "temperature sensor temperature protection"

--- a/esp32-example.yaml
+++ b/esp32-example.yaml
@@ -138,7 +138,7 @@ sensor:
     cell_voltage_24:
       name: "cell voltage 24"
     mosfet_temperature:
-      name: "power tube temperature"
+      name: "mosfet temperature"
     temperature_sensor_1:
       name: "temperature sensor 1"
     temperature_sensor_2:
@@ -200,9 +200,9 @@ sensor:
     balancing_delta_voltage:
       name: "balance opening pressure difference"
     mosfet_temperature_protection:
-      name: "power tube temperature protection"
+      name: "mosfet temperature protection"
     mosfet_temperature_recovery:
-      name: "power tube temperature recovery"
+      name: "mosfet temperature recovery"
     temperature_sensor_temperature_protection:
       name: "temperature sensor temperature protection"
     temperature_sensor_temperature_recovery:

--- a/esp8266-example.yaml
+++ b/esp8266-example.yaml
@@ -137,7 +137,7 @@ sensor:
     cell_voltage_24:
       name: "cell voltage 24"
     mosfet_temperature:
-      name: "power tube temperature"
+      name: "mosfet temperature"
     temperature_sensor_1:
       name: "temperature sensor 1"
     temperature_sensor_2:
@@ -199,9 +199,9 @@ sensor:
     balancing_delta_voltage:
       name: "balance opening pressure difference"
     mosfet_temperature_protection:
-      name: "power tube temperature protection"
+      name: "mosfet temperature protection"
     mosfet_temperature_recovery:
-      name: "power tube temperature recovery"
+      name: "mosfet temperature recovery"
     temperature_sensor_temperature_protection:
       name: "temperature sensor temperature protection"
     temperature_sensor_temperature_recovery:

--- a/esp8266-example.yaml
+++ b/esp8266-example.yaml
@@ -136,7 +136,7 @@ sensor:
       name: "cell voltage 23"
     cell_voltage_24:
       name: "cell voltage 24"
-    power_tube_temperature:
+    mosfet_temperature:
       name: "power tube temperature"
     temperature_sensor_1:
       name: "temperature sensor 1"
@@ -198,9 +198,9 @@ sensor:
       name: "balance starting voltage"
     balancing_delta_voltage:
       name: "balance opening pressure difference"
-    power_tube_temperature_protection:
+    mosfet_temperature_protection:
       name: "power tube temperature protection"
-    power_tube_temperature_recovery:
+    mosfet_temperature_recovery:
       name: "power tube temperature recovery"
     temperature_sensor_temperature_protection:
       name: "temperature sensor temperature protection"

--- a/lovelace-entities-card.yaml
+++ b/lovelace-entities-card.yaml
@@ -106,12 +106,12 @@ entities:
     name: Operation Mode Bitmask
   - entity: sensor.jk_bms_password
     name: Password
-  - entity: sensor.jk_bms_power_tube_temperature
-    name: Power Tube Temperature
-  - entity: sensor.jk_bms_power_tube_temperature_protection
-    name: Power Tube Temperature Protection
-  - entity: sensor.jk_bms_power_tube_temperature_recovery
-    name: Power Tube Temperature Recovery
+  - entity: sensor.jk_bms_mosfet_temperature
+    name: Mosfet Temperature
+  - entity: sensor.jk_bms_mosfet_temperature_protection
+    name: Mosfet Temperature Protection
+  - entity: sensor.jk_bms_mosfet_temperature_recovery
+    name: Mosfet Temperature Recovery
   - entity: sensor.jk_bms_sleep_wait_time
     name: Sleep Wait Time
   - entity: sensor.jk_bms_software_version

--- a/tests/components/jk_bms/common.h
+++ b/tests/components/jk_bms/common.h
@@ -17,7 +17,7 @@ class TestableJkBms : public JkBms {
 //   min_cell_voltage: 3.811 V (cell 9)   max_cell_voltage: 3.835 V (cell 12)
 //   delta_cell_voltage: 0.024 V          average_cell_voltage: 3.82821 V
 //   total_voltage: 53.59 V               current: 2.08 A (charging, protocol version 1)
-//   power_tube_temperature: 29°C         temperature_sensor_1: 30°C  temperature_sensor_2: 28°C
+//   mosfet_temperature: 29°C         temperature_sensor_1: 30°C  temperature_sensor_2: 28°C
 //   state_of_charge: 15 %                total_battery_capacity: 14 Ah
 //   errors_bitmask: 0                    operation_modes: charging+discharging+balancer (0x07)
 //   cell_count: 14                        charging_cycles: 4
@@ -71,7 +71,7 @@ static const std::vector<uint8_t> STATUS_FRAME_14S = {
     0x0E,
     0xF2,  // cell 14: 3826 → 3.826 V
     // offset = data[1] + 3 = 42 + 3 = 45
-    // bytes 44-46: power tube temperature = 29°C
+    // bytes 44-46: mosfet temperature = 29°C
     0x80,
     0x00,
     0x1D,
@@ -182,11 +182,11 @@ static const std::vector<uint8_t> STATUS_FRAME_14S = {
     // bytes 125-126: balancing switch = on
     0x9D,
     0x01,
-    // bytes 127-129: power tube temperature protection = 90°C
+    // bytes 127-129: mosfet temperature protection = 90°C
     0x9E,
     0x00,
     0x5A,
-    // bytes 130-132: power tube temperature recovery = 70°C
+    // bytes 130-132: mosfet temperature recovery = 70°C
     0x9F,
     0x00,
     0x46,

--- a/tests/components/jk_bms/jk_bms_test.cpp
+++ b/tests/components/jk_bms/jk_bms_test.cpp
@@ -81,7 +81,7 @@ TEST(JkBmsStatusDataTest, ChargingCurrentAndPower) {
 TEST(JkBmsStatusDataTest, Temperatures) {
   TestableJkBms bms;
   sensor::Sensor tube, t1, t2, count;
-  bms.set_power_tube_temperature_sensor(&tube);
+  bms.set_mosfet_temperature_sensor(&tube);
   bms.set_temperature_sensor_1_sensor(&t1);
   bms.set_temperature_sensor_2_sensor(&t2);
   bms.set_temperature_sensor_count_sensor(&count);

--- a/tests/components/jk_bms_ble/jk_bms_ble_jk02_24s_v10_test.cpp
+++ b/tests/components/jk_bms_ble/jk_bms_ble_jk02_24s_v10_test.cpp
@@ -53,7 +53,7 @@ TEST(JkBmsV10CellInfoTest, Temperatures) {
   sensor::Sensor t1, t2, tube;
   bms.set_temperature_sensor(0, &t1);
   bms.set_temperature_sensor(1, &t2);
-  bms.set_power_tube_temperature_sensor(&tube);
+  bms.set_mosfet_temperature_sensor(&tube);
   bms.decode_jk02_cell_info_(CELL_INFO_JK02_24S_V10);
   EXPECT_NEAR(t1.state, 20.7f, 0.1f);
   EXPECT_NEAR(t2.state, 20.7f, 0.1f);

--- a/tests/components/jk_bms_ble/jk_bms_ble_jk02_32s_v11_test.cpp
+++ b/tests/components/jk_bms_ble/jk_bms_ble_jk02_32s_v11_test.cpp
@@ -74,7 +74,7 @@ TEST(JkBmsV11CellInfoTest, Temperatures) {
   sensor::Sensor t1, t2, tube;
   bms.set_temperature_sensor(0, &t1);
   bms.set_temperature_sensor(1, &t2);
-  bms.set_power_tube_temperature_sensor(&tube);
+  bms.set_mosfet_temperature_sensor(&tube);
   bms.decode_jk02_cell_info_(CELL_INFO_JK02_32S_V11);
   EXPECT_NEAR(t1.state, 17.7f, 0.1f);
   EXPECT_NEAR(t2.state, 17.7f, 0.1f);

--- a/tests/components/jk_bms_ble/jk_bms_ble_jk02_32s_v14_test.cpp
+++ b/tests/components/jk_bms_ble/jk_bms_ble_jk02_32s_v14_test.cpp
@@ -64,7 +64,7 @@ TEST(JkBmsV14CellInfoTest, Temperatures) {
   sensor::Sensor t1, t2, tube;
   bms.set_temperature_sensor(0, &t1);
   bms.set_temperature_sensor(1, &t2);
-  bms.set_power_tube_temperature_sensor(&tube);
+  bms.set_mosfet_temperature_sensor(&tube);
   bms.decode_jk02_cell_info_(CELL_INFO_JK02_32S_V14);
   EXPECT_NEAR(t1.state, 16.8f, 0.1f);
   EXPECT_NEAR(t2.state, 17.0f, 0.1f);

--- a/tests/components/jk_bms_ble/jk_bms_ble_jk02_32s_v15_test.cpp
+++ b/tests/components/jk_bms_ble/jk_bms_ble_jk02_32s_v15_test.cpp
@@ -73,7 +73,7 @@ TEST(JkBmsV15CellInfoTest, Temperatures) {
   sensor::Sensor t1, t2, tube;
   bms.set_temperature_sensor(0, &t1);
   bms.set_temperature_sensor(1, &t2);
-  bms.set_power_tube_temperature_sensor(&tube);
+  bms.set_mosfet_temperature_sensor(&tube);
   bms.decode_jk02_cell_info_(CELL_INFO_JK02_32S_V15);
   EXPECT_NEAR(t1.state, 13.4f, 0.1f);
   EXPECT_NEAR(t2.state, 12.8f, 0.1f);

--- a/tests/components/jk_bms_ble/jk_bms_ble_jk02_32s_v19_test.cpp
+++ b/tests/components/jk_bms_ble/jk_bms_ble_jk02_32s_v19_test.cpp
@@ -55,7 +55,7 @@ TEST(JkBmsV19CellInfoTest, Temperatures) {
   sensor::Sensor t1, t2, tube;
   bms.set_temperature_sensor(0, &t1);
   bms.set_temperature_sensor(1, &t2);
-  bms.set_power_tube_temperature_sensor(&tube);
+  bms.set_mosfet_temperature_sensor(&tube);
   bms.decode_jk02_cell_info_(CELL_INFO_JK02_32S_V19);
   EXPECT_NEAR(t1.state, 11.9f, 0.1f);
   EXPECT_NEAR(t2.state, 12.7f, 0.1f);

--- a/tests/components/jk_bms_ble/jk_bms_ble_test.cpp
+++ b/tests/components/jk_bms_ble/jk_bms_ble_test.cpp
@@ -128,7 +128,7 @@ TEST(JkBmsBleJk02CellInfoTest, Temperatures) {
   sensor::Sensor t1, t2, tube;
   bms.set_temperature_sensor(0, &t1);
   bms.set_temperature_sensor(1, &t2);
-  bms.set_power_tube_temperature_sensor(&tube);
+  bms.set_mosfet_temperature_sensor(&tube);
 
   bms.decode_jk02_cell_info_(CELL_INFO_JK02_24S_V10);
 


### PR DESCRIPTION
## Summary

Rename all `power_tube_*` keys to `mosfet_*` across `jk_bms` and `jk_bms_ble`.

"Power tube" is a literal translation of the Chinese datasheet term (功率管). The industry-standard name for the switching element on the high side of a battery pack is **MOSFET** — and both ESPHome `daly_bms` and our sibling `jbd_bms` already use `mosfet_temperature` naming. This aligns `jk_bms` / `jk_bms_ble` with the rest of the ecosystem.

## Renames

**`jk_bms` (sensors):**
- `power_tube_temperature` → `mosfet_temperature`
- `power_tube_temperature_protection` → `mosfet_temperature_protection`
- `power_tube_temperature_recovery` → `mosfet_temperature_recovery`

**`jk_bms_ble` (sensor):**
- `power_tube_temperature` → `mosfet_temperature`

**`jk_bms_ble` (number — writable thresholds):**
- `power_tube_overtemperature_protection` → `mosfet_overtemperature_protection`
- `power_tube_overtemperature_protection_recovery` → `mosfet_overtemperature_protection_recovery`

## Backwards compatibility

All renames are routed via the `deprecated_renames` helper introduced in #975. Existing configs using `power_tube_*` keep working and emit a deprecation warning at validation time:

```
WARNING 'power_tube_temperature' is deprecated, use 'mosfet_temperature' instead. Will be removed in a future release.
```

This PR also **extends the compat layer to `jk_bms_ble/number/__init__.py`**, which previously had no migration support — `deprecated_renames` is now imported from the parent package and wrapping `CONFIG_SCHEMA`.

YAML example display names (`name: "power tube temperature"`) are preserved on purpose to keep Home Assistant entity IDs stable. Only the YAML keys (= schema keys = C++ setter names) change.

## C++ surface

C++ setters, member fields, publish-state calls, and `LOG_SENSOR` strings have all been renamed in `jk_bms.{h,cpp}` and `jk_bms_ble.{h,cpp}`. The two existing protocol-comment references (`// 0x80 0x00 0x1D: Read power tube temperature …` and the alarm bitmask description) are intentionally left alone — they describe JK's own protocol labels, not our identifiers (consistent with the convention used in previous rename PRs).

## Test plan

Manually validated with `esphome config` (ESPHome 2026.5.0) using `main`'s old example YAMLs against this branch:

| File | Result |
|---|---|
| Old `esp32-example.yaml` (modbus, uses `power_tube_temperature` etc.) | ✅ exit 0, 3 deprecation warnings |
| Old `esp32-ble-example.yaml` (BLE, uses both sensor + number old keys) | ✅ exit 0, 2 number warnings + 1 sensor warning |
| New `esp32-example.yaml` with `mosfet_temperature` keys | ✅ exit 0, no warnings |

Sample output (old → new routing):
```
WARNING 'power_tube_temperature' is deprecated, use 'mosfet_temperature' instead. Will be removed in a future release.
WARNING 'power_tube_temperature_protection' is deprecated, use 'mosfet_temperature_protection' instead. Will be removed in a future release.
WARNING 'power_tube_temperature_recovery' is deprecated, use 'mosfet_temperature_recovery' instead. Will be removed in a future release.
WARNING 'power_tube_overtemperature_protection' is deprecated, use 'mosfet_overtemperature_protection' instead. Will be removed in a future release.
WARNING 'power_tube_overtemperature_protection_recovery' is deprecated, use 'mosfet_overtemperature_protection_recovery' instead. Will be removed in a future release.
```

Additional checks:
- [x] `pre-commit run --all-files` passes (ruff + clang-format auto-applied)
- [x] All 13 in-repo example YAMLs use the new keys
- [x] All 7 C++ tests use the new setter name
- [x] HA entity IDs unchanged (display `name:` preserved)
- [ ] CI green