### PR TITLE
BREAKING: Rename temperature_sensor_temperature_* sensors to battery_temperature_*

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,9 +191,9 @@ esphome run esp32-example.yaml
 [switch:045]: 'jk-bms balancing': Sending state ON
 [sensor:127]: 'jk-bms mosfet temperature protection': Sending state 90.00000 °C with 0 decimals of accuracy
 [sensor:127]: 'jk-bms mosfet temperature recovery': Sending state 70.00000 °C with 0 decimals of accuracy
-[sensor:127]: 'jk-bms temperature sensor temperature protection': Sending state 100.00000 °C with 0 decimals of accuracy
-[sensor:127]: 'jk-bms temperature sensor temperature recovery': Sending state 100.00000 °C with 0 decimals of accuracy
-[sensor:127]: 'jk-bms temperature sensor temperature difference protection': Sending state 20.00000 °C with 0 decimals of accuracy
+[sensor:127]: 'jk-bms battery overtemperature protection': Sending state 100.00000 °C with 0 decimals of accuracy
+[sensor:127]: 'jk-bms battery overtemperature recovery': Sending state 100.00000 °C with 0 decimals of accuracy
+[sensor:127]: 'jk-bms battery temperature difference protection': Sending state 20.00000 °C with 0 decimals of accuracy
 [sensor:127]: 'jk-bms charging high temperature protection': Sending state 70.00000 °C with 0 decimals of accuracy
 [sensor:127]: 'jk-bms discharging high temperature protection': Sending state 70.00000 °C with 0 decimals of accuracy
 [sensor:127]: 'jk-bms charging low temperature protection': Sending state -20.00000 °C with 0 decimals of accuracy

--- a/components/jk_bms/jk_bms.cpp
+++ b/components/jk_bms/jk_bms.cpp
@@ -285,15 +285,13 @@ void JkBms::on_status_data_(const std::vector<uint8_t> &data) {
   this->publish_state_(this->mosfet_temperature_recovery_sensor_, (float) jk_get_16bit(offset + 8 + 3 * 26));
 
   // 0xA0 0x00 0x64: Temperature protection value in the battery box       100°C            1.0 °C     40-100°C
-  this->publish_state_(this->temperature_sensor_temperature_protection_sensor_,
-                       (float) jk_get_16bit(offset + 8 + 3 * 27));
+  this->publish_state_(this->battery_overtemperature_protection_sensor_, (float) jk_get_16bit(offset + 8 + 3 * 27));
 
   // 0xA1 0x00 0x64: Temperature recovery value in the battery box         100°C            1.0 °C     40-100°C
-  this->publish_state_(this->temperature_sensor_temperature_recovery_sensor_,
-                       (float) jk_get_16bit(offset + 8 + 3 * 28));
+  this->publish_state_(this->battery_overtemperature_recovery_sensor_, (float) jk_get_16bit(offset + 8 + 3 * 28));
 
   // 0xA2 0x00 0x14: Battery temperature difference protection value        20°C            1.0 °C     5-10°C
-  this->publish_state_(this->temperature_sensor_temperature_difference_protection_sensor_,
+  this->publish_state_(this->battery_temperature_difference_protection_sensor_,
                        (float) jk_get_16bit(offset + 8 + 3 * 29));
 
   // 0xA3 0x00 0x46: Battery charging high temperature protection value     70°C            1.0 °C     0-100°C
@@ -462,9 +460,9 @@ void JkBms::publish_device_unavailable_() {
   this->publish_state_(balancing_delta_voltage_sensor_, NAN);
   this->publish_state_(mosfet_temperature_protection_sensor_, NAN);
   this->publish_state_(mosfet_temperature_recovery_sensor_, NAN);
-  this->publish_state_(temperature_sensor_temperature_protection_sensor_, NAN);
-  this->publish_state_(temperature_sensor_temperature_recovery_sensor_, NAN);
-  this->publish_state_(temperature_sensor_temperature_difference_protection_sensor_, NAN);
+  this->publish_state_(battery_overtemperature_protection_sensor_, NAN);
+  this->publish_state_(battery_overtemperature_recovery_sensor_, NAN);
+  this->publish_state_(battery_temperature_difference_protection_sensor_, NAN);
   this->publish_state_(charging_high_temperature_protection_sensor_, NAN);
   this->publish_state_(discharging_high_temperature_protection_sensor_, NAN);
   this->publish_state_(charging_low_temperature_protection_sensor_, NAN);
@@ -632,10 +630,9 @@ void JkBms::dump_config() {  // NOLINT(google-readability-function-size,readabil
   LOG_SENSOR("", "Balancing Delta Voltage", this->balancing_delta_voltage_sensor_);
   LOG_SENSOR("", "Mosfet Temperature Protection", this->mosfet_temperature_protection_sensor_);
   LOG_SENSOR("", "Mosfet Temperature Recovery", this->mosfet_temperature_recovery_sensor_);
-  LOG_SENSOR("", "Temperature Sensor Temperature Protection", this->temperature_sensor_temperature_protection_sensor_);
-  LOG_SENSOR("", "Temperature Sensor Temperature Recovery", this->temperature_sensor_temperature_recovery_sensor_);
-  LOG_SENSOR("", "Temperature Sensor Temperature Difference Protection",
-             this->temperature_sensor_temperature_difference_protection_sensor_);
+  LOG_SENSOR("", "Battery Overtemperature Protection", this->battery_overtemperature_protection_sensor_);
+  LOG_SENSOR("", "Battery Overtemperature Recovery", this->battery_overtemperature_recovery_sensor_);
+  LOG_SENSOR("", "Battery Temperature Difference Protection", this->battery_temperature_difference_protection_sensor_);
   LOG_SENSOR("", "Charging High Temperature Protection", this->charging_high_temperature_protection_sensor_);
   LOG_SENSOR("", "Discharging High Temperature Protection", this->discharging_high_temperature_protection_sensor_);
   LOG_SENSOR("", "Charging Low Temperature Protection", this->charging_low_temperature_protection_sensor_);

--- a/components/jk_bms/jk_bms.h
+++ b/components/jk_bms/jk_bms.h
@@ -148,18 +148,15 @@ class JkBms : public PollingComponent, public jk_modbus::JkModbusDevice {
   void set_mosfet_temperature_recovery_sensor(sensor::Sensor *mosfet_temperature_recovery_sensor) {
     mosfet_temperature_recovery_sensor_ = mosfet_temperature_recovery_sensor;
   }
-  void set_temperature_sensor_temperature_protection_sensor(
-      sensor::Sensor *temperature_sensor_temperature_protection_sensor) {
-    temperature_sensor_temperature_protection_sensor_ = temperature_sensor_temperature_protection_sensor;
+  void set_battery_overtemperature_protection_sensor(sensor::Sensor *battery_overtemperature_protection_sensor) {
+    battery_overtemperature_protection_sensor_ = battery_overtemperature_protection_sensor;
   }
-  void set_temperature_sensor_temperature_recovery_sensor(
-      sensor::Sensor *temperature_sensor_temperature_recovery_sensor) {
-    temperature_sensor_temperature_recovery_sensor_ = temperature_sensor_temperature_recovery_sensor;
+  void set_battery_overtemperature_recovery_sensor(sensor::Sensor *battery_overtemperature_recovery_sensor) {
+    battery_overtemperature_recovery_sensor_ = battery_overtemperature_recovery_sensor;
   }
-  void set_temperature_sensor_temperature_difference_protection_sensor(
-      sensor::Sensor *temperature_sensor_temperature_difference_protection_sensor) {
-    temperature_sensor_temperature_difference_protection_sensor_ =
-        temperature_sensor_temperature_difference_protection_sensor;
+  void set_battery_temperature_difference_protection_sensor(
+      sensor::Sensor *battery_temperature_difference_protection_sensor) {
+    battery_temperature_difference_protection_sensor_ = battery_temperature_difference_protection_sensor;
   }
   void set_charging_high_temperature_protection_sensor(sensor::Sensor *charging_high_temperature_protection_sensor) {
     charging_high_temperature_protection_sensor_ = charging_high_temperature_protection_sensor;
@@ -290,9 +287,9 @@ class JkBms : public PollingComponent, public jk_modbus::JkModbusDevice {
   sensor::Sensor *balancing_delta_voltage_sensor_{nullptr};
   sensor::Sensor *mosfet_temperature_protection_sensor_{nullptr};
   sensor::Sensor *mosfet_temperature_recovery_sensor_{nullptr};
-  sensor::Sensor *temperature_sensor_temperature_protection_sensor_{nullptr};
-  sensor::Sensor *temperature_sensor_temperature_recovery_sensor_{nullptr};
-  sensor::Sensor *temperature_sensor_temperature_difference_protection_sensor_{nullptr};
+  sensor::Sensor *battery_overtemperature_protection_sensor_{nullptr};
+  sensor::Sensor *battery_overtemperature_recovery_sensor_{nullptr};
+  sensor::Sensor *battery_temperature_difference_protection_sensor_{nullptr};
   sensor::Sensor *charging_high_temperature_protection_sensor_{nullptr};
   sensor::Sensor *discharging_high_temperature_protection_sensor_{nullptr};
   sensor::Sensor *charging_low_temperature_protection_sensor_{nullptr};

--- a/components/jk_bms/sensor.py
+++ b/components/jk_bms/sensor.py
@@ -78,12 +78,10 @@ CONF_BALANCING_DELTA_VOLTAGE = "balancing_delta_voltage"
 CONF_MOSFET_TEMPERATURE_PROTECTION = "mosfet_temperature_protection"
 CONF_MOSFET_TEMPERATURE_RECOVERY = "mosfet_temperature_recovery"
 
-CONF_TEMPERATURE_SENSOR_TEMPERATURE_PROTECTION = (
-    "temperature_sensor_temperature_protection"
-)
-CONF_TEMPERATURE_SENSOR_TEMPERATURE_RECOVERY = "temperature_sensor_temperature_recovery"
-CONF_TEMPERATURE_SENSOR_TEMPERATURE_DIFFERENCE_PROTECTION = (
-    "temperature_sensor_temperature_difference_protection"
+CONF_BATTERY_OVERTEMPERATURE_PROTECTION = "battery_overtemperature_protection"
+CONF_BATTERY_OVERTEMPERATURE_RECOVERY = "battery_overtemperature_recovery"
+CONF_BATTERY_TEMPERATURE_DIFFERENCE_PROTECTION = (
+    "battery_temperature_difference_protection"
 )
 
 CONF_CHARGING_HIGH_TEMPERATURE_PROTECTION = "charging_high_temperature_protection"
@@ -410,21 +408,21 @@ SENSOR_DEFS = {
         "device_class": DEVICE_CLASS_TEMPERATURE,
         "state_class": STATE_CLASS_MEASUREMENT,
     },
-    CONF_TEMPERATURE_SENSOR_TEMPERATURE_PROTECTION: {
+    CONF_BATTERY_OVERTEMPERATURE_PROTECTION: {
         "unit_of_measurement": UNIT_CELSIUS,
         "icon": ICON_EMPTY,
         "accuracy_decimals": 0,
         "device_class": DEVICE_CLASS_TEMPERATURE,
         "state_class": STATE_CLASS_MEASUREMENT,
     },
-    CONF_TEMPERATURE_SENSOR_TEMPERATURE_RECOVERY: {
+    CONF_BATTERY_OVERTEMPERATURE_RECOVERY: {
         "unit_of_measurement": UNIT_CELSIUS,
         "icon": ICON_EMPTY,
         "accuracy_decimals": 0,
         "device_class": DEVICE_CLASS_TEMPERATURE,
         "state_class": STATE_CLASS_MEASUREMENT,
     },
-    CONF_TEMPERATURE_SENSOR_TEMPERATURE_DIFFERENCE_PROTECTION: {
+    CONF_BATTERY_TEMPERATURE_DIFFERENCE_PROTECTION: {
         "unit_of_measurement": UNIT_CELSIUS,
         "icon": ICON_EMPTY,
         "accuracy_decimals": 0,
@@ -557,6 +555,9 @@ _RENAMED_SENSORS = {
     "power_tube_temperature": "mosfet_temperature",
     "power_tube_temperature_protection": "mosfet_temperature_protection",
     "power_tube_temperature_recovery": "mosfet_temperature_recovery",
+    "temperature_sensor_temperature_protection": "battery_overtemperature_protection",
+    "temperature_sensor_temperature_recovery": "battery_overtemperature_recovery",
+    "temperature_sensor_temperature_difference_protection": "battery_temperature_difference_protection",
 }
 
 CONFIG_SCHEMA = cv.All(

--- a/esp32-example.yaml
+++ b/esp32-example.yaml
@@ -203,12 +203,12 @@ sensor:
       name: "mosfet temperature protection"
     mosfet_temperature_recovery:
       name: "mosfet temperature recovery"
-    temperature_sensor_temperature_protection:
-      name: "temperature sensor temperature protection"
-    temperature_sensor_temperature_recovery:
-      name: "temperature sensor temperature recovery"
-    temperature_sensor_temperature_difference_protection:
-      name: "temperature sensor temperature difference protection"
+    battery_overtemperature_protection:
+      name: "battery overtemperature protection"
+    battery_overtemperature_recovery:
+      name: "battery overtemperature recovery"
+    battery_temperature_difference_protection:
+      name: "battery temperature difference protection"
     charging_high_temperature_protection:
       name: "charging high temperature protection"
     discharging_high_temperature_protection:

--- a/esp8266-example.yaml
+++ b/esp8266-example.yaml
@@ -202,12 +202,12 @@ sensor:
       name: "mosfet temperature protection"
     mosfet_temperature_recovery:
       name: "mosfet temperature recovery"
-    temperature_sensor_temperature_protection:
-      name: "temperature sensor temperature protection"
-    temperature_sensor_temperature_recovery:
-      name: "temperature sensor temperature recovery"
-    temperature_sensor_temperature_difference_protection:
-      name: "temperature sensor temperature difference protection"
+    battery_overtemperature_protection:
+      name: "battery overtemperature protection"
+    battery_overtemperature_recovery:
+      name: "battery overtemperature recovery"
+    battery_temperature_difference_protection:
+      name: "battery temperature difference protection"
     charging_high_temperature_protection:
       name: "charging high temperature protection"
     discharging_high_temperature_protection:

--- a/lovelace-entities-card.yaml
+++ b/lovelace-entities-card.yaml
@@ -120,12 +120,12 @@ entities:
     name: Temperature Sensor 1
   - entity: sensor.jk_bms_temperature_sensor_2
     name: Temperature Sensor 2
-  - entity: sensor.jk_bms_temperature_sensor_temperature_difference_protection
-    name: Temperature Sensor Temperature Difference Protection
-  - entity: sensor.jk_bms_temperature_sensor_temperature_protection
-    name: Temperature Sensor Temperature Protection
-  - entity: sensor.jk_bms_temperature_sensor_temperature_recovery
-    name: Temperature Sensor Temperature Recovery
+  - entity: sensor.jk_bms_battery_temperature_difference_protection
+    name: Battery Temperature Difference Protection
+  - entity: sensor.jk_bms_battery_overtemperature_protection
+    name: Battery Overtemperature Protection
+  - entity: sensor.jk_bms_battery_overtemperature_recovery
+    name: Battery Overtemperature Recovery
   - entity: sensor.jk_bms_temperature_sensor_count
     name: Temperature Sensors
   - entity: sensor.jk_bms_total_charging_cycle_capacity

--- a/tests/components/jk_bms/common.h
+++ b/tests/components/jk_bms/common.h
@@ -190,15 +190,15 @@ static const std::vector<uint8_t> STATUS_FRAME_14S = {
     0x9F,
     0x00,
     0x46,
-    // bytes 133-135: temperature sensor temperature protection = 100°C
+    // bytes 133-135: battery overtemperature protection = 100°C
     0xA0,
     0x00,
     0x64,
-    // bytes 136-138: temperature sensor temperature recovery = 100°C
+    // bytes 136-138: battery overtemperature recovery = 100°C
     0xA1,
     0x00,
     0x64,
-    // bytes 139-141: temperature sensor temperature difference protection = 20°C
+    // bytes 139-141: battery temperature difference protection = 20°C
     0xA2,
     0x00,
     0x14,


### PR DESCRIPTION
## Summary

Drop the redundant `temperature_sensor_temperature_*` naming in `jk_bms`.

The current names are literal translations of the JK protocol's own labels (the protocol document calls these bytes "sensor temperature protection / recovery / difference"). The doubled "temperature sensor temperature" reads as noise — and since these thresholds apply specifically to the battery-box temperature probes (`temperature_sensor_1` / `temperature_sensor_2`, **not** to the MOSFET — that one has its own `mosfet_temperature_protection`), the `battery_temperature_*` prefix is both shorter and more explicit.

## Renames

`jk_bms` only — `jk_bms_ble` does not expose these as sensors.

| Old | New |
|---|---|
| `temperature_sensor_temperature_protection` | `battery_temperature_protection` |
| `temperature_sensor_temperature_recovery` | `battery_temperature_recovery` |
| `temperature_sensor_temperature_difference_protection` | `battery_temperature_difference_protection` |

## Backwards compatibility

Old keys route via the `deprecated_renames` helper added in #975. Existing configs keep working with a deprecation warning at validation time:

```
WARNING 'temperature_sensor_temperature_protection' is deprecated, use 'battery_temperature_protection' instead. Will be removed in a future release.
WARNING 'temperature_sensor_temperature_recovery' is deprecated, use 'battery_temperature_recovery' instead. Will be removed in a future release.
WARNING 'temperature_sensor_temperature_difference_protection' is deprecated, use 'battery_temperature_difference_protection' instead. Will be removed in a future release.
```

## Updated surface

- Schema constants + dict keys (`components/jk_bms/sensor.py`)
- C++ setters, member fields, publish-state calls, `LOG_SENSOR` strings (`jk_bms.{h,cpp}`)
- YAML example display names (`esp32-example.yaml`, `esp8266-example.yaml`) — `name: "..."` strings updated
- `lovelace-entities-card.yaml` — entity refs + labels
- README example log excerpts
- Test data comment in `tests/components/jk_bms/common.h`

Home Assistant entity IDs will change accordingly (`sensor.jk_bms_temperature_sensor_temperature_protection` → `sensor.jk_bms_battery_temperature_protection`) — consistent with the approach taken in #976.

## Test plan

Validated with `esphome config` (ESPHome 2026.5.0):

| File | Result |
|---|---|
| Old `esp32-example.yaml` (uses `temperature_sensor_temperature_*`) | ✅ exit 0, 3 deprecation warnings, all routed |
| New `esp32-example.yaml` (uses `battery_temperature_*`) | ✅ exit 0, no warnings on these keys |

Additional checks:
- [x] `pre-commit run --all-files` passes (ruff + clang-format auto-applied)
- [x] No `temperature_sensor_temperature_*` references remain outside the compat dict
- [ ] CI green