### PR TITLE
BREAKING: Rename balance_starting_voltage to balancing_start_voltage

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ esphome run esp32-example.yaml
 [sensor:127]: 'jk-bms discharging overcurrent delay': Sending state 300.00000 s with 0 decimals of accuracy
 [sensor:127]: 'jk-bms charging overcurrent protection': Sending state 25.00000 A with 0 decimals of accuracy
 [sensor:127]: 'jk-bms charging overcurrent delay': Sending state 30.00000 s with 0 decimals of accuracy
-[sensor:127]: 'jk-bms balance starting voltage': Sending state 3.30000 V with 3 decimals of accuracy
+[sensor:127]: 'jk-bms balancing start voltage': Sending state 3.30000 V with 3 decimals of accuracy
 [sensor:127]: 'jk-bms balance opening pressure difference': Sending state 0.01000 V with 3 decimals of accuracy
 [switch:045]: 'jk-bms balancing': Sending state ON
 [sensor:127]: 'jk-bms mosfet temperature protection': Sending state 90.00000 °C with 0 decimals of accuracy

--- a/components/jk_bms/jk_bms.cpp
+++ b/components/jk_bms/jk_bms.cpp
@@ -269,7 +269,7 @@ void JkBms::on_status_data_(const std::vector<uint8_t> &data) {
   this->publish_state_(this->charging_overcurrent_delay_sensor_, (float) jk_get_16bit(offset + 6 + 3 * 22));
 
   // 0x9B 0x0C 0xE4: Balanced starting voltage                   3300 * 0.001 = 3.300V     0.001 V
-  this->publish_state_(this->balance_starting_voltage_sensor_, (float) jk_get_16bit(offset + 6 + 3 * 23) * 0.001f);
+  this->publish_state_(this->balancing_start_voltage_sensor_, (float) jk_get_16bit(offset + 6 + 3 * 23) * 0.001f);
 
   // 0x9C 0x00 0x08: Balanced opening pressure difference           8 * 0.001 = 0.008V     0.001 V     0.01-1V
   this->publish_state_(this->balancing_delta_voltage_sensor_, (float) jk_get_16bit(offset + 6 + 3 * 24) * 0.001f);
@@ -456,7 +456,7 @@ void JkBms::publish_device_unavailable_() {
   this->publish_state_(discharging_overcurrent_delay_sensor_, NAN);
   this->publish_state_(charging_overcurrent_protection_sensor_, NAN);
   this->publish_state_(charging_overcurrent_delay_sensor_, NAN);
-  this->publish_state_(balance_starting_voltage_sensor_, NAN);
+  this->publish_state_(balancing_start_voltage_sensor_, NAN);
   this->publish_state_(balancing_delta_voltage_sensor_, NAN);
   this->publish_state_(mosfet_temperature_protection_sensor_, NAN);
   this->publish_state_(mosfet_temperature_recovery_sensor_, NAN);
@@ -626,7 +626,7 @@ void JkBms::dump_config() {  // NOLINT(google-readability-function-size,readabil
   LOG_SENSOR("", "Discharging Overcurrent Delay", this->discharging_overcurrent_delay_sensor_);
   LOG_SENSOR("", "Charging Overcurrent Protection", this->charging_overcurrent_protection_sensor_);
   LOG_SENSOR("", "Charging Overcurrent Delay", this->charging_overcurrent_delay_sensor_);
-  LOG_SENSOR("", "Balance Starting Voltage", this->balance_starting_voltage_sensor_);
+  LOG_SENSOR("", "Balancing Start Voltage", this->balancing_start_voltage_sensor_);
   LOG_SENSOR("", "Balancing Delta Voltage", this->balancing_delta_voltage_sensor_);
   LOG_SENSOR("", "Mosfet Temperature Protection", this->mosfet_temperature_protection_sensor_);
   LOG_SENSOR("", "Mosfet Temperature Recovery", this->mosfet_temperature_recovery_sensor_);

--- a/components/jk_bms/jk_bms.h
+++ b/components/jk_bms/jk_bms.h
@@ -136,8 +136,8 @@ class JkBms : public PollingComponent, public jk_modbus::JkModbusDevice {
   void set_charging_overcurrent_delay_sensor(sensor::Sensor *charging_overcurrent_delay_sensor) {
     charging_overcurrent_delay_sensor_ = charging_overcurrent_delay_sensor;
   }
-  void set_balance_starting_voltage_sensor(sensor::Sensor *balance_starting_voltage_sensor) {
-    balance_starting_voltage_sensor_ = balance_starting_voltage_sensor;
+  void set_balancing_start_voltage_sensor(sensor::Sensor *balancing_start_voltage_sensor) {
+    balancing_start_voltage_sensor_ = balancing_start_voltage_sensor;
   }
   void set_balancing_delta_voltage_sensor(sensor::Sensor *balancing_delta_voltage_sensor) {
     balancing_delta_voltage_sensor_ = balancing_delta_voltage_sensor;
@@ -283,7 +283,7 @@ class JkBms : public PollingComponent, public jk_modbus::JkModbusDevice {
   sensor::Sensor *discharging_overcurrent_delay_sensor_{nullptr};
   sensor::Sensor *charging_overcurrent_protection_sensor_{nullptr};
   sensor::Sensor *charging_overcurrent_delay_sensor_{nullptr};
-  sensor::Sensor *balance_starting_voltage_sensor_{nullptr};
+  sensor::Sensor *balancing_start_voltage_sensor_{nullptr};
   sensor::Sensor *balancing_delta_voltage_sensor_{nullptr};
   sensor::Sensor *mosfet_temperature_protection_sensor_{nullptr};
   sensor::Sensor *mosfet_temperature_recovery_sensor_{nullptr};

--- a/components/jk_bms/sensor.py
+++ b/components/jk_bms/sensor.py
@@ -72,7 +72,7 @@ CONF_DISCHARGING_OVERCURRENT_DELAY = "discharging_overcurrent_delay"
 CONF_CHARGING_OVERCURRENT_PROTECTION = "charging_overcurrent_protection"
 CONF_CHARGING_OVERCURRENT_DELAY = "charging_overcurrent_delay"
 
-CONF_BALANCE_STARTING_VOLTAGE = "balance_starting_voltage"
+CONF_BALANCING_START_VOLTAGE = "balancing_start_voltage"
 CONF_BALANCING_DELTA_VOLTAGE = "balancing_delta_voltage"
 
 CONF_MOSFET_TEMPERATURE_PROTECTION = "mosfet_temperature_protection"
@@ -380,7 +380,7 @@ SENSOR_DEFS = {
         "device_class": DEVICE_CLASS_EMPTY,
         "state_class": STATE_CLASS_MEASUREMENT,
     },
-    CONF_BALANCE_STARTING_VOLTAGE: {
+    CONF_BALANCING_START_VOLTAGE: {
         "unit_of_measurement": UNIT_VOLT,
         "icon": ICON_EMPTY,
         "accuracy_decimals": 3,
@@ -558,6 +558,7 @@ _RENAMED_SENSORS = {
     "temperature_sensor_temperature_protection": "battery_overtemperature_protection",
     "temperature_sensor_temperature_recovery": "battery_overtemperature_recovery",
     "temperature_sensor_temperature_difference_protection": "battery_temperature_difference_protection",
+    "balance_starting_voltage": "balancing_start_voltage",
 }
 
 CONFIG_SCHEMA = cv.All(

--- a/components/jk_bms_ble/jk_bms_ble.cpp
+++ b/components/jk_bms_ble/jk_bms_ble.cpp
@@ -1078,7 +1078,7 @@ void JkBmsBle::decode_jk02_settings_(const std::vector<uint8_t> &data) {
 
   // 138   4   0xE4 0x0C 0x00 0x00    Start balance voltage
   ESP_LOGV(TAG, "  Start balance voltage: %f V", (float) jk_get_32bit(138) * 0.001f);
-  this->publish_state_(this->balance_starting_voltage_number_, (float) jk_get_32bit(138) * 0.001f);
+  this->publish_state_(this->balancing_start_voltage_number_, (float) jk_get_32bit(138) * 0.001f);
 
   if (this->protocol_version_ == PROTOCOL_VERSION_JK02_24S) {
     ESP_LOGD(TAG, "  Unknown142: %f", (float) jk_get_32bit(142) * 0.001f);

--- a/components/jk_bms_ble/jk_bms_ble.h
+++ b/components/jk_bms_ble/jk_bms_ble.h
@@ -77,8 +77,8 @@ class JkBmsBle :
   void set_cell_voltage_undervoltage_recovery_number(number::Number *cell_voltage_undervoltage_recovery_number) {
     cell_voltage_undervoltage_recovery_number_ = cell_voltage_undervoltage_recovery_number;
   }
-  void set_balance_starting_voltage_number(number::Number *balance_starting_voltage_number) {
-    balance_starting_voltage_number_ = balance_starting_voltage_number;
+  void set_balancing_start_voltage_number(number::Number *balancing_start_voltage_number) {
+    balancing_start_voltage_number_ = balancing_start_voltage_number;
   }
   void set_voltage_calibration_number(number::Number *voltage_calibration_number) {
     voltage_calibration_number_ = voltage_calibration_number;
@@ -361,7 +361,7 @@ class JkBmsBle :
   number::Number *cell_voltage_overvoltage_recovery_number_{nullptr};
   number::Number *cell_voltage_undervoltage_protection_number_{nullptr};
   number::Number *cell_voltage_undervoltage_recovery_number_{nullptr};
-  number::Number *balance_starting_voltage_number_{nullptr};
+  number::Number *balancing_start_voltage_number_{nullptr};
   number::Number *voltage_calibration_number_{nullptr};  // @FIXME: Identify value at the settings frame
   number::Number *current_calibration_number_{nullptr};  // @FIXME: Identify value at the settings frame
   number::Number *power_off_voltage_number_{nullptr};

--- a/components/jk_bms_ble/number/__init__.py
+++ b/components/jk_bms_ble/number/__init__.py
@@ -153,7 +153,7 @@ CONF_RE_BULK_SOC = "re_bulk_soc"
 CONF_CELL_COUNT = "cell_count"
 CONF_TOTAL_BATTERY_CAPACITY = "total_battery_capacity"
 
-CONF_BALANCE_STARTING_VOLTAGE = "balance_starting_voltage"
+CONF_BALANCING_START_VOLTAGE = "balancing_start_voltage"
 CONF_VOLTAGE_CALIBRATION = "voltage_calibration"
 CONF_CURRENT_CALIBRATION = "current_calibration"
 CONF_POWER_OFF_VOLTAGE = "power_off_voltage"
@@ -216,7 +216,7 @@ NUMBERS = {
     CONF_RE_BULK_SOC: [0x00, 0x00, 0xB7, 1.0, 1],
     CONF_CELL_COUNT: [0x00, 0x1C, 0x1C, 1.0, 4],
     CONF_TOTAL_BATTERY_CAPACITY: [0x00, 0x20, 0x20, 1000.0, 4],
-    CONF_BALANCE_STARTING_VOLTAGE: [0x00, 0x26, 0x22, 1000.0, 4],
+    CONF_BALANCING_START_VOLTAGE: [0x00, 0x26, 0x22, 1000.0, 4],
     CONF_VOLTAGE_CALIBRATION: [0x00, 0x21, 0x64, 1000.0, 4],
     CONF_CURRENT_CALIBRATION: [0x00, 0x24, 0x67, 1000.0, 4],
     CONF_POWER_OFF_VOLTAGE: [0x00, 0x0B, 0x0B, 1000.0, 4],
@@ -345,6 +345,7 @@ JK_NUMBER_SCHEMA = (
 _RENAMED_NUMBERS = {
     "power_tube_overtemperature_protection": "mosfet_overtemperature_protection",
     "power_tube_overtemperature_protection_recovery": "mosfet_overtemperature_protection_recovery",
+    "balance_starting_voltage": "balancing_start_voltage",
 }
 
 _NUMBER_CONFIG_SCHEMA = JK_BMS_BLE_COMPONENT_SCHEMA.extend(
@@ -469,7 +470,7 @@ _NUMBER_CONFIG_SCHEMA = JK_BMS_BLE_COMPONENT_SCHEMA.extend(
                 ): cv.string_strict,
             }
         ),
-        cv.Optional(CONF_BALANCE_STARTING_VOLTAGE): JK_NUMBER_SCHEMA.extend(
+        cv.Optional(CONF_BALANCING_START_VOLTAGE): JK_NUMBER_SCHEMA.extend(
             {
                 cv.Optional(CONF_MIN_VALUE, default=1.20): cv.float_,
                 cv.Optional(CONF_MAX_VALUE, default=4.25): cv.float_,

--- a/docs/display-protocol/traffic-ble-same-time.txt
+++ b/docs/display-protocol/traffic-ble-same-time.txt
@@ -32,7 +32,7 @@
 [switch:055]: 'jk-bms balancer': Sending state OFF
 [number:012]: 'jk-bms total battery capacity': Sending state 40.000000
 [number:012]: 'jk-bms short circuit protection delay': Sending state 1500.000000
-[number:012]: 'jk-bms balance starting voltage': Sending state 3.000000
+[number:012]: 'jk-bms balancing start voltage': Sending state 3.000000
 [jk_bms_ble:992]:   Con. wire resistance 1: 0.000000 Ohm
 [jk_bms_ble:992]:   Con. wire resistance 2: 0.000000 Ohm
 [jk_bms_ble:992]:   Con. wire resistance 3: 0.000000 Ohm

--- a/esp32-ble-example-multiple-devices.yaml
+++ b/esp32-ble-example-multiple-devices.yaml
@@ -136,8 +136,8 @@ number:
     balance_trigger_voltage:
       name: "balance trigger voltage"
       device_id: device0
-    balance_starting_voltage:
-      name: "balance starting voltage"
+    balancing_start_voltage:
+      name: "balancing start voltage"
       device_id: device0
     power_off_voltage:
       name: "power off voltage"
@@ -149,8 +149,8 @@ number:
     balance_trigger_voltage:
       name: "balance trigger voltage"
       device_id: device1
-    balance_starting_voltage:
-      name: "balance starting voltage"
+    balancing_start_voltage:
+      name: "balancing start voltage"
       device_id: device1
     power_off_voltage:
       name: "power off voltage"

--- a/esp32-ble-example.yaml
+++ b/esp32-ble-example.yaml
@@ -102,8 +102,8 @@ number:
       name: "cell voltage undervoltage protection"
     cell_voltage_undervoltage_recovery:
       name: "cell voltage undervoltage recovery"
-    balance_starting_voltage:
-      name: "balance starting voltage"
+    balancing_start_voltage:
+      name: "balancing start voltage"
     voltage_calibration:
       name: "voltage calibration"
     current_calibration:

--- a/esp32-ble-uart-hybrid-example.yaml
+++ b/esp32-ble-uart-hybrid-example.yaml
@@ -116,8 +116,8 @@ number:
     jk_bms_ble_id: bmsble0
     balance_trigger_voltage:
       name: "balance trigger voltage"
-    balance_starting_voltage:
-      name: "balance starting voltage"
+    balancing_start_voltage:
+      name: "balancing start voltage"
     power_off_voltage:
       name: "power off voltage"
     max_balance_current:

--- a/esp32-ble-v11-example.yaml
+++ b/esp32-ble-v11-example.yaml
@@ -102,8 +102,8 @@ number:
       name: "cell voltage undervoltage protection"
     cell_voltage_undervoltage_recovery:
       name: "cell voltage undervoltage recovery"
-    balance_starting_voltage:
-      name: "balance starting voltage"
+    balancing_start_voltage:
+      name: "balancing start voltage"
     voltage_calibration:
       name: "voltage calibration"
     current_calibration:

--- a/esp32-ble-v14-example-multiple-devices.yaml
+++ b/esp32-ble-v14-example-multiple-devices.yaml
@@ -160,8 +160,8 @@ number:
     cell_voltage_undervoltage_recovery:
       name: "cell voltage undervoltage recovery"
       device_id: device0
-    balance_starting_voltage:
-      name: "balance starting voltage"
+    balancing_start_voltage:
+      name: "balancing start voltage"
       device_id: device0
     voltage_calibration:
       name: "voltage calibration"
@@ -275,8 +275,8 @@ number:
     cell_voltage_undervoltage_recovery:
       name: "cell voltage undervoltage recovery"
       device_id: device1
-    balance_starting_voltage:
-      name: "balance starting voltage"
+    balancing_start_voltage:
+      name: "balancing start voltage"
       device_id: device1
     voltage_calibration:
       name: "voltage calibration"

--- a/esp32-ble-v14-example.yaml
+++ b/esp32-ble-v14-example.yaml
@@ -106,8 +106,8 @@ number:
       name: "cell voltage undervoltage protection"
     cell_voltage_undervoltage_recovery:
       name: "cell voltage undervoltage recovery"
-    balance_starting_voltage:
-      name: "balance starting voltage"
+    balancing_start_voltage:
+      name: "balancing start voltage"
     voltage_calibration:
       name: "voltage calibration"
     current_calibration:

--- a/esp32-ble-v15-example.yaml
+++ b/esp32-ble-v15-example.yaml
@@ -106,8 +106,8 @@ number:
       name: "cell voltage undervoltage protection"
     cell_voltage_undervoltage_recovery:
       name: "cell voltage undervoltage recovery"
-    balance_starting_voltage:
-      name: "balance starting voltage"
+    balancing_start_voltage:
+      name: "balancing start voltage"
     voltage_calibration:
       name: "voltage calibration"
     current_calibration:

--- a/esp32-ble-v19-example.yaml
+++ b/esp32-ble-v19-example.yaml
@@ -106,8 +106,8 @@ number:
       name: "cell voltage undervoltage protection"
     cell_voltage_undervoltage_recovery:
       name: "cell voltage undervoltage recovery"
-    balance_starting_voltage:
-      name: "balance starting voltage"
+    balancing_start_voltage:
+      name: "balancing start voltage"
     voltage_calibration:
       name: "voltage calibration"
     current_calibration:

--- a/esp32-example.yaml
+++ b/esp32-example.yaml
@@ -195,8 +195,8 @@ sensor:
       name: "charging overcurrent protection"
     charging_overcurrent_delay:
       name: "charging overcurrent delay"
-    balance_starting_voltage:
-      name: "balance starting voltage"
+    balancing_start_voltage:
+      name: "balancing start voltage"
     balancing_delta_voltage:
       name: "balance opening pressure difference"
     mosfet_temperature_protection:

--- a/esp8266-example.yaml
+++ b/esp8266-example.yaml
@@ -194,8 +194,8 @@ sensor:
       name: "charging overcurrent protection"
     charging_overcurrent_delay:
       name: "charging overcurrent delay"
-    balance_starting_voltage:
-      name: "balance starting voltage"
+    balancing_start_voltage:
+      name: "balancing start voltage"
     balancing_delta_voltage:
       name: "balance opening pressure difference"
     mosfet_temperature_protection:

--- a/lovelace-entities-card.yaml
+++ b/lovelace-entities-card.yaml
@@ -44,8 +44,8 @@ entities:
     name: Alarm Low Volume
   - entity: sensor.jk_bms_balancing_delta_voltage
     name: Balance Opening Pressure Difference
-  - entity: sensor.jk_bms_balance_starting_voltage
-    name: Balance Starting Voltage
+  - entity: sensor.jk_bms_balancing_start_voltage
+    name: Balancing Start Voltage
   - entity: sensor.jk_bms_battery_type
     name: Battery Type
   - entity: sensor.jk_bms_cell_voltage_difference_protection

--- a/tests/components/jk_bms/common.h
+++ b/tests/components/jk_bms/common.h
@@ -171,7 +171,7 @@ static const std::vector<uint8_t> STATUS_FRAME_14S = {
     0x9A,
     0x00,
     0x05,
-    // bytes 119-121: balance starting voltage = 3300 × 0.001 = 3.300 V
+    // bytes 119-121: balancing start voltage = 3300 × 0.001 = 3.300 V
     0x9B,
     0x0C,
     0xE4,

--- a/tests/components/jk_bms/jk_bms_test.cpp
+++ b/tests/components/jk_bms/jk_bms_test.cpp
@@ -115,7 +115,7 @@ TEST(JkBmsStatusDataTest, Capacity) {
 TEST(JkBmsStatusDataTest, BalancingConfig) {
   TestableJkBms bms;
   sensor::Sensor starting_voltage, delta_voltage;
-  bms.set_balance_starting_voltage_sensor(&starting_voltage);
+  bms.set_balancing_start_voltage_sensor(&starting_voltage);
   bms.set_balancing_delta_voltage_sensor(&delta_voltage);
 
   bms.on_jk_modbus_data(FUNCTION_READ_ALL, STATUS_FRAME_14S);

--- a/tests/esp32-ble-b2a25s-example.yaml
+++ b/tests/esp32-ble-b2a25s-example.yaml
@@ -102,8 +102,8 @@ number:
       name: "cell voltage undervoltage protection"
     cell_voltage_undervoltage_recovery:
       name: "cell voltage undervoltage recovery"
-    balance_starting_voltage:
-      name: "balance starting voltage"
+    balancing_start_voltage:
+      name: "balancing start voltage"
     voltage_calibration:
       name: "voltage calibration"
     current_calibration:


### PR DESCRIPTION
## Summary

Align the balancer-threshold key with the rest of the balancing-related schema. `balance_starting_voltage` was the odd one out: every other balancing-related key already uses the `balancing_*` prefix.

| Existing | This PR |
|---|---|
| `balancing_delta_voltage` | `balancing_start_voltage` ← new |
| `balancing_current` | |
| `balancing_switch` | |
| `mosfet_overtemperature_protection` (#976) | |

The new name also reads better in English (gerund + noun rather than verb stem + gerund + noun).

## Rename

| Old | New |
|---|---|
| `balance_starting_voltage` | `balancing_start_voltage` |

Affects both components:
- `jk_bms` — RO sensor exposing the threshold value read from the BMS
- `jk_bms_ble` — writable `number` for setting the threshold via BLE

## Backwards compatibility

Routed via the `deprecated_renames` helper (#975), with entries added to both `_RENAMED_SENSORS` (`jk_bms`) and `_RENAMED_NUMBERS` (`jk_bms_ble`). Existing configs validate cleanly with a deprecation warning:

```
WARNING 'balance_starting_voltage' is deprecated, use 'balancing_start_voltage' instead. Will be removed in a future release.
```

## Updated surface

- Schema constants (`components/jk_bms/sensor.py`, `components/jk_bms_ble/number/__init__.py`)
- C++ setters, member fields, publish-state calls, `LOG_SENSOR` strings (`jk_bms.{h,cpp}`, `jk_bms_ble.{h,cpp}`)
- All YAML examples — keys + `name: "..."` display strings updated
- `lovelace-entities-card.yaml` — entity refs + labels
- README example log excerpts
- `tests/` (C++ test + YAML test config)
- Protocol-doc captured log

Home Assistant entity IDs will change accordingly (`sensor.jk_bms_balance_starting_voltage` → `sensor.jk_bms_balancing_start_voltage` etc.) — consistent with the approach taken in #976 and #977.

## Test plan

Validated with `esphome config` (ESPHome 2026.5.0):

| File | Result |
|---|---|
| Old `esp32-example.yaml` (modbus sensor, uses `balance_starting_voltage:`) | ✅ exit 0, 1 deprecation warning, routed |
| Old `esp32-ble-example.yaml` (BLE number, uses `balance_starting_voltage:`) | ✅ exit 0, 1 deprecation warning, routed |

Additional checks:
- [x] `pre-commit run --all-files` passes (ruff + clang-format auto-applied)
- [x] No `balance_starting_voltage` references remain outside the compat dicts
- [ ] CI green