### PR TITLE
Rename charge_*/discharge_* BLE entities to charging_*/discharging_*

### DIFF
--- a/components/jk_bms_ble/jk_bms_ble.cpp
+++ b/components/jk_bms_ble/jk_bms_ble.cpp
@@ -175,15 +175,15 @@ void JkBmsBle::dump_config() {  // NOLINT(google-readability-function-size,reada
   LOG_SENSOR("", "Heating Current", this->heating_current_sensor_);
   LOG_SENSOR("", "Balancing Current", this->balancing_current_sensor_);
   LOG_SENSOR("", "Emergency Time Countdown", this->emergency_time_countdown_sensor_);
-  LOG_SENSOR("", "Charge Status ID", this->charge_status_id_sensor_);
-  LOG_SENSOR("", "Charge Status Time Elapsed", this->charge_status_time_elapsed_sensor_);
+  LOG_SENSOR("", "Charging Status ID", this->charging_status_id_sensor_);
+  LOG_SENSOR("", "Charging Status Time Elapsed", this->charging_status_time_elapsed_sensor_);
   LOG_SENSOR("", "Battery Type ID", this->battery_type_id_sensor_);
 
   LOG_TEXT_SENSOR("", "Operation Status", this->operation_status_text_sensor_);
   LOG_TEXT_SENSOR("", "Total Runtime Formatted", this->total_runtime_formatted_text_sensor_);
   LOG_TEXT_SENSOR("", "Errors", this->errors_text_sensor_);
   LOG_TEXT_SENSOR("", "Errors Bitmask Hex", this->errors_bitmask_hex_text_sensor_);
-  LOG_TEXT_SENSOR("", "Charge Status", this->charge_status_text_sensor_);
+  LOG_TEXT_SENSOR("", "Charging Status", this->charging_status_text_sensor_);
   LOG_TEXT_SENSOR("", "Software Version", this->software_version_text_sensor_);
   LOG_TEXT_SENSOR("", "Hardware Version", this->hardware_version_text_sensor_);
   LOG_TEXT_SENSOR("", "Battery Type", this->battery_type_text_sensor_);
@@ -706,13 +706,13 @@ void JkBmsBle::decode_jk02_cell_info_(const std::vector<uint8_t> &data) {
     this->publish_state_(this->battery_type_text_sensor_, this->battery_type_id_to_string_(data[243 + offset]));
 
     // 246+32  2   0x00 0x00              Charge status time
-    this->publish_state_(this->charge_status_time_elapsed_sensor_, (float) jk_get_16bit(246 + offset));
+    this->publish_state_(this->charging_status_time_elapsed_sensor_, (float) jk_get_16bit(246 + offset));
 
     // 248+32  1   0x00                   Charge status                                0x00: Bulk
     //                                                                                 0x01: Absorption
     //                                                                                 0x02: Float
-    this->publish_state_(this->charge_status_id_sensor_, (float) data[248 + offset]);
-    this->publish_state_(this->charge_status_text_sensor_, this->charge_status_id_to_string_(data[248 + offset]));
+    this->publish_state_(this->charging_status_id_sensor_, (float) data[248 + offset]);
+    this->publish_state_(this->charging_status_text_sensor_, this->charging_status_id_to_string_(data[248 + offset]));
   }
 
   // 299   1   0xCD                   CRC
@@ -988,27 +988,27 @@ void JkBmsBle::decode_jk02_settings_(const std::vector<uint8_t> &data) {
 
   // 50    4   0xA8 0x61 0x00 0x00    Max. charge current
   ESP_LOGV(TAG, "  Max. charge current: %f A", (float) jk_get_32bit(50) * 0.001f);
-  this->publish_state_(this->max_charge_current_number_, (float) jk_get_32bit(50) * 0.001f);
+  this->publish_state_(this->max_charging_current_number_, (float) jk_get_32bit(50) * 0.001f);
 
   // 54    4   0x1E 0x00 0x00 0x00    Charge OCP delay
   ESP_LOGV(TAG, "  Charge OCP delay: %f s", (float) jk_get_32bit(54));
-  this->publish_state_(this->charge_overcurrent_protection_delay_number_, (float) jk_get_32bit(54));
+  this->publish_state_(this->charging_overcurrent_protection_delay_number_, (float) jk_get_32bit(54));
 
   // 58    4   0x3C 0x00 0x00 0x00    Charge OCP recovery time
   ESP_LOGV(TAG, "  Charge OCP recovery time: %f s", (float) jk_get_32bit(58));
-  this->publish_state_(this->charge_overcurrent_protection_recovery_time_number_, (float) jk_get_32bit(58));
+  this->publish_state_(this->charging_overcurrent_protection_recovery_time_number_, (float) jk_get_32bit(58));
 
   // 62    4   0xF0 0x49 0x02 0x00    Max. discharge current
   ESP_LOGV(TAG, "  Max. discharge current: %f A", (float) jk_get_32bit(62) * 0.001f);
-  this->publish_state_(this->max_discharge_current_number_, (float) jk_get_32bit(62) * 0.001f);
+  this->publish_state_(this->max_discharging_current_number_, (float) jk_get_32bit(62) * 0.001f);
 
   // 66    4   0x2C 0x01 0x00 0x00    Discharge OCP delay
   ESP_LOGV(TAG, "  Discharge OCP delay: %f s", (float) jk_get_32bit(66));
-  this->publish_state_(this->discharge_overcurrent_protection_delay_number_, (float) jk_get_32bit(66));
+  this->publish_state_(this->discharging_overcurrent_protection_delay_number_, (float) jk_get_32bit(66));
 
   // 70    4   0x3C 0x00 0x00 0x00    Discharge OCP recovery time
   ESP_LOGV(TAG, "  Discharge OCP recovery time: %f s", (float) jk_get_32bit(70));
-  this->publish_state_(this->discharge_overcurrent_protection_recovery_time_number_, (float) jk_get_32bit(70));
+  this->publish_state_(this->discharging_overcurrent_protection_recovery_time_number_, (float) jk_get_32bit(70));
 
   // 74    4   0x3C 0x00 0x00 0x00    SCPR time
   ESP_LOGV(TAG, "  Short circuit protection recovery time: %f s", (float) jk_get_32bit(74));
@@ -1020,27 +1020,27 @@ void JkBmsBle::decode_jk02_settings_(const std::vector<uint8_t> &data) {
 
   // 82    4   0xBC 0x02 0x00 0x00    Charge OTP
   ESP_LOGV(TAG, "  Charge OTP: %f °C", (float) jk_get_32bit(82) * 0.1f);
-  this->publish_state_(this->charge_overtemperature_protection_number_, (float) jk_get_32bit(82) * 0.1f);
+  this->publish_state_(this->charging_overtemperature_protection_number_, (float) jk_get_32bit(82) * 0.1f);
 
   // 86    4   0x58 0x02 0x00 0x00    Charge OTP Recovery
   ESP_LOGV(TAG, "  Charge OTP recovery: %f °C", (float) jk_get_32bit(86) * 0.1f);
-  this->publish_state_(this->charge_overtemperature_protection_recovery_number_, (float) jk_get_32bit(86) * 0.1f);
+  this->publish_state_(this->charging_overtemperature_protection_recovery_number_, (float) jk_get_32bit(86) * 0.1f);
 
   // 90    4   0xBC 0x02 0x00 0x00    Discharge OTP
   ESP_LOGV(TAG, "  Discharge OTP: %f °C", (float) jk_get_32bit(90) * 0.1f);
-  this->publish_state_(this->discharge_overtemperature_protection_number_, (float) jk_get_32bit(90) * 0.1f);
+  this->publish_state_(this->discharging_overtemperature_protection_number_, (float) jk_get_32bit(90) * 0.1f);
 
   // 94    4   0x58 0x02 0x00 0x00    Discharge OTP Recovery
   ESP_LOGV(TAG, "  Discharge OTP recovery: %f °C", (float) jk_get_32bit(94) * 0.1f);
-  this->publish_state_(this->discharge_overtemperature_protection_recovery_number_, (float) jk_get_32bit(94) * 0.1f);
+  this->publish_state_(this->discharging_overtemperature_protection_recovery_number_, (float) jk_get_32bit(94) * 0.1f);
 
   // 98    4   0x38 0xFF 0xFF 0xFF    Charge UTP
   ESP_LOGV(TAG, "  Charge UTP: %f °C", (float) ((int32_t) jk_get_32bit(98)) * 0.1f);
-  this->publish_state_(this->charge_undertemperature_protection_number_, (float) ((int32_t) jk_get_32bit(98)) * 0.1f);
+  this->publish_state_(this->charging_undertemperature_protection_number_, (float) ((int32_t) jk_get_32bit(98)) * 0.1f);
 
   // 102   4   0x9C 0xFF 0xFF 0xFF    Charge UTP Recovery
   ESP_LOGV(TAG, "  Charge UTP recovery: %f °C", (float) ((int32_t) jk_get_32bit(102)) * 0.1f);
-  this->publish_state_(this->charge_undertemperature_protection_recovery_number_,
+  this->publish_state_(this->charging_undertemperature_protection_recovery_number_,
                        (float) ((int32_t) jk_get_32bit(102)) * 0.1f);
 
   // 106   4   0x84 0x03 0x00 0x00    MOS OTP
@@ -1140,7 +1140,7 @@ void JkBmsBle::decode_jk02_settings_(const std::vector<uint8_t> &data) {
 
     // 274   4   0x00 0x00 0x00 0x00
     ESP_LOGI(TAG, "  Precharge time: %d s", data[274]);
-    this->publish_state_(this->discharge_precharge_time_number_, (float) data[274]);
+    this->publish_state_(this->discharging_precharge_time_number_, (float) data[274]);
 
     // 278   4   0x00 0x00 0x00 0x00
     // 282   2   0x00 0x00                 New controls bitmask
@@ -1192,11 +1192,11 @@ void JkBmsBle::decode_jk02_settings_(const std::vector<uint8_t> &data) {
 
     // 296   1   0x00                   Discharge UTP
     ESP_LOGV(TAG, "  Discharge UTP: %d °C", (int8_t) data[296]);
-    this->publish_state_(this->discharge_undertemperature_protection_number_, (float) ((int8_t) data[296]));
+    this->publish_state_(this->discharging_undertemperature_protection_number_, (float) ((int8_t) data[296]));
 
     // 297   1   0x00                   Discharge UTP Recovery
     ESP_LOGV(TAG, "  Discharge UTP recovery: %d °C", (int8_t) data[297]);
-    this->publish_state_(this->discharge_undertemperature_protection_recovery_number_, (float) ((int8_t) data[297]));
+    this->publish_state_(this->discharging_undertemperature_protection_recovery_number_, (float) ((int8_t) data[297]));
 
     // 298   1   0x00
     // 299   1   0x40                   CRC
@@ -1706,7 +1706,7 @@ std::string JkBmsBle::battery_type_id_to_string_(const uint8_t code) {
   }
 }
 
-std::string JkBmsBle::charge_status_id_to_string_(const uint8_t status) {
+std::string JkBmsBle::charging_status_id_to_string_(const uint8_t status) {
   switch (status) {
     case 0x00:
       return "Bulk";

--- a/components/jk_bms_ble/jk_bms_ble.h
+++ b/components/jk_bms_ble/jk_bms_ble.h
@@ -92,26 +92,26 @@ class JkBmsBle :
   void set_max_balance_current_number(number::Number *max_balance_current_number) {
     max_balance_current_number_ = max_balance_current_number;
   }
-  void set_max_charge_current_number(number::Number *max_charge_current_number) {
-    max_charge_current_number_ = max_charge_current_number;
+  void set_max_charging_current_number(number::Number *max_charging_current_number) {
+    max_charging_current_number_ = max_charging_current_number;
   }
-  void set_max_discharge_current_number(number::Number *max_discharge_current_number) {
-    max_discharge_current_number_ = max_discharge_current_number;
+  void set_max_discharging_current_number(number::Number *max_discharging_current_number) {
+    max_discharging_current_number_ = max_discharging_current_number;
   }
-  void set_charge_overcurrent_protection_delay_number(number::Number *charge_overcurrent_protection_delay_number) {
-    charge_overcurrent_protection_delay_number_ = charge_overcurrent_protection_delay_number;
+  void set_charging_overcurrent_protection_delay_number(number::Number *charging_overcurrent_protection_delay_number) {
+    charging_overcurrent_protection_delay_number_ = charging_overcurrent_protection_delay_number;
   }
-  void set_charge_overcurrent_protection_recovery_time_number(
-      number::Number *charge_overcurrent_protection_recovery_time_number) {
-    charge_overcurrent_protection_recovery_time_number_ = charge_overcurrent_protection_recovery_time_number;
+  void set_charging_overcurrent_protection_recovery_time_number(
+      number::Number *charging_overcurrent_protection_recovery_time_number) {
+    charging_overcurrent_protection_recovery_time_number_ = charging_overcurrent_protection_recovery_time_number;
   }
-  void set_discharge_overcurrent_protection_delay_number(
-      number::Number *discharge_overcurrent_protection_delay_number) {
-    discharge_overcurrent_protection_delay_number_ = discharge_overcurrent_protection_delay_number;
+  void set_discharging_overcurrent_protection_delay_number(
+      number::Number *discharging_overcurrent_protection_delay_number) {
+    discharging_overcurrent_protection_delay_number_ = discharging_overcurrent_protection_delay_number;
   }
-  void set_discharge_overcurrent_protection_recovery_time_number(
-      number::Number *discharge_overcurrent_protection_recovery_time_number) {
-    discharge_overcurrent_protection_recovery_time_number_ = discharge_overcurrent_protection_recovery_time_number;
+  void set_discharging_overcurrent_protection_recovery_time_number(
+      number::Number *discharging_overcurrent_protection_recovery_time_number) {
+    discharging_overcurrent_protection_recovery_time_number_ = discharging_overcurrent_protection_recovery_time_number;
   }
   void set_short_circuit_protection_delay_number(number::Number *short_circuit_protection_delay_number) {
     short_circuit_protection_delay_number_ = short_circuit_protection_delay_number;
@@ -120,33 +120,33 @@ class JkBmsBle :
       number::Number *short_circuit_protection_recovery_time_number) {
     short_circuit_protection_recovery_time_number_ = short_circuit_protection_recovery_time_number;
   }
-  void set_charge_overtemperature_protection_number(number::Number *charge_overtemperature_protection_number) {
-    charge_overtemperature_protection_number_ = charge_overtemperature_protection_number;
+  void set_charging_overtemperature_protection_number(number::Number *charging_overtemperature_protection_number) {
+    charging_overtemperature_protection_number_ = charging_overtemperature_protection_number;
   }
-  void set_charge_overtemperature_protection_recovery_number(
-      number::Number *charge_overtemperature_protection_recovery_number) {
-    charge_overtemperature_protection_recovery_number_ = charge_overtemperature_protection_recovery_number;
+  void set_charging_overtemperature_protection_recovery_number(
+      number::Number *charging_overtemperature_protection_recovery_number) {
+    charging_overtemperature_protection_recovery_number_ = charging_overtemperature_protection_recovery_number;
   }
-  void set_discharge_overtemperature_protection_number(number::Number *discharge_overtemperature_protection_number) {
-    discharge_overtemperature_protection_number_ = discharge_overtemperature_protection_number;
+  void set_discharging_overtemperature_protection_number(number::Number *discharging_overtemperature_protection_number) {
+    discharging_overtemperature_protection_number_ = discharging_overtemperature_protection_number;
   }
-  void set_discharge_overtemperature_protection_recovery_number(
-      number::Number *discharge_overtemperature_protection_recovery_number) {
-    discharge_overtemperature_protection_recovery_number_ = discharge_overtemperature_protection_recovery_number;
+  void set_discharging_overtemperature_protection_recovery_number(
+      number::Number *discharging_overtemperature_protection_recovery_number) {
+    discharging_overtemperature_protection_recovery_number_ = discharging_overtemperature_protection_recovery_number;
   }
-  void set_charge_undertemperature_protection_number(number::Number *charge_undertemperature_protection_number) {
-    charge_undertemperature_protection_number_ = charge_undertemperature_protection_number;
+  void set_charging_undertemperature_protection_number(number::Number *charging_undertemperature_protection_number) {
+    charging_undertemperature_protection_number_ = charging_undertemperature_protection_number;
   }
-  void set_charge_undertemperature_protection_recovery_number(
-      number::Number *charge_undertemperature_protection_recovery_number) {
-    charge_undertemperature_protection_recovery_number_ = charge_undertemperature_protection_recovery_number;
+  void set_charging_undertemperature_protection_recovery_number(
+      number::Number *charging_undertemperature_protection_recovery_number) {
+    charging_undertemperature_protection_recovery_number_ = charging_undertemperature_protection_recovery_number;
   }
-  void set_discharge_undertemperature_protection_number(number::Number *discharge_undertemperature_protection_number) {
-    discharge_undertemperature_protection_number_ = discharge_undertemperature_protection_number;
+  void set_discharging_undertemperature_protection_number(number::Number *discharging_undertemperature_protection_number) {
+    discharging_undertemperature_protection_number_ = discharging_undertemperature_protection_number;
   }
-  void set_discharge_undertemperature_protection_recovery_number(
-      number::Number *discharge_undertemperature_protection_recovery_number) {
-    discharge_undertemperature_protection_recovery_number_ = discharge_undertemperature_protection_recovery_number;
+  void set_discharging_undertemperature_protection_recovery_number(
+      number::Number *discharging_undertemperature_protection_recovery_number) {
+    discharging_undertemperature_protection_recovery_number_ = discharging_undertemperature_protection_recovery_number;
   }
   void set_mosfet_overtemperature_protection_number(number::Number *mosfet_overtemperature_protection_number) {
     mosfet_overtemperature_protection_number_ = mosfet_overtemperature_protection_number;
@@ -155,8 +155,8 @@ class JkBmsBle :
       number::Number *mosfet_overtemperature_protection_recovery_number) {
     mosfet_overtemperature_protection_recovery_number_ = mosfet_overtemperature_protection_recovery_number;
   }
-  void set_discharge_precharge_time_number(number::Number *discharge_precharge_time_number) {
-    discharge_precharge_time_number_ = discharge_precharge_time_number;
+  void set_discharging_precharge_time_number(number::Number *discharging_precharge_time_number) {
+    discharging_precharge_time_number_ = discharging_precharge_time_number;
   }
   void set_heating_start_temperature_number(number::Number *heating_start_temperature_number) {
     heating_start_temperature_number_ = heating_start_temperature_number;
@@ -262,11 +262,11 @@ class JkBmsBle :
   void set_heating_current_sensor(sensor::Sensor *heating_current_sensor) {
     heating_current_sensor_ = heating_current_sensor;
   }
-  void set_charge_status_id_sensor(sensor::Sensor *charge_status_id_sensor) {
-    charge_status_id_sensor_ = charge_status_id_sensor;
+  void set_charging_status_id_sensor(sensor::Sensor *charging_status_id_sensor) {
+    charging_status_id_sensor_ = charging_status_id_sensor;
   }
-  void set_charge_status_time_elapsed_sensor(sensor::Sensor *charge_status_time_elapsed_sensor) {
-    charge_status_time_elapsed_sensor_ = charge_status_time_elapsed_sensor;
+  void set_charging_status_time_elapsed_sensor(sensor::Sensor *charging_status_time_elapsed_sensor) {
+    charging_status_time_elapsed_sensor_ = charging_status_time_elapsed_sensor;
   }
   void set_detail_log_count_sensor(sensor::Sensor *detail_log_count_sensor) {
     detail_log_count_sensor_ = detail_log_count_sensor;
@@ -285,8 +285,8 @@ class JkBmsBle :
   void set_total_runtime_formatted_text_sensor(text_sensor::TextSensor *total_runtime_formatted_text_sensor) {
     total_runtime_formatted_text_sensor_ = total_runtime_formatted_text_sensor;
   }
-  void set_charge_status_text_sensor(text_sensor::TextSensor *charge_status_text_sensor) {
-    charge_status_text_sensor_ = charge_status_text_sensor;
+  void set_charging_status_text_sensor(text_sensor::TextSensor *charging_status_text_sensor) {
+    charging_status_text_sensor_ = charging_status_text_sensor;
   }
   void set_software_version_text_sensor(text_sensor::TextSensor *software_version_text_sensor) {
     software_version_text_sensor_ = software_version_text_sensor;
@@ -366,25 +366,25 @@ class JkBmsBle :
   number::Number *current_calibration_number_{nullptr};  // @FIXME: Identify value at the settings frame
   number::Number *power_off_voltage_number_{nullptr};
   number::Number *max_balance_current_number_{nullptr};
-  number::Number *max_charge_current_number_{nullptr};
-  number::Number *max_discharge_current_number_{nullptr};
-  number::Number *charge_overcurrent_protection_delay_number_{nullptr};
-  number::Number *charge_overcurrent_protection_recovery_time_number_{nullptr};
-  number::Number *discharge_overcurrent_protection_delay_number_{nullptr};
-  number::Number *discharge_overcurrent_protection_recovery_time_number_{nullptr};
+  number::Number *max_charging_current_number_{nullptr};
+  number::Number *max_discharging_current_number_{nullptr};
+  number::Number *charging_overcurrent_protection_delay_number_{nullptr};
+  number::Number *charging_overcurrent_protection_recovery_time_number_{nullptr};
+  number::Number *discharging_overcurrent_protection_delay_number_{nullptr};
+  number::Number *discharging_overcurrent_protection_recovery_time_number_{nullptr};
   number::Number *short_circuit_protection_delay_number_{nullptr};
   number::Number *short_circuit_protection_recovery_time_number_{nullptr};
-  number::Number *charge_overtemperature_protection_number_{nullptr};
-  number::Number *charge_overtemperature_protection_recovery_number_{nullptr};
-  number::Number *discharge_overtemperature_protection_number_{nullptr};
-  number::Number *discharge_overtemperature_protection_recovery_number_{nullptr};
-  number::Number *charge_undertemperature_protection_number_{nullptr};
-  number::Number *charge_undertemperature_protection_recovery_number_{nullptr};
-  number::Number *discharge_undertemperature_protection_number_{nullptr};
-  number::Number *discharge_undertemperature_protection_recovery_number_{nullptr};
+  number::Number *charging_overtemperature_protection_number_{nullptr};
+  number::Number *charging_overtemperature_protection_recovery_number_{nullptr};
+  number::Number *discharging_overtemperature_protection_number_{nullptr};
+  number::Number *discharging_overtemperature_protection_recovery_number_{nullptr};
+  number::Number *charging_undertemperature_protection_number_{nullptr};
+  number::Number *charging_undertemperature_protection_recovery_number_{nullptr};
+  number::Number *discharging_undertemperature_protection_number_{nullptr};
+  number::Number *discharging_undertemperature_protection_recovery_number_{nullptr};
   number::Number *mosfet_overtemperature_protection_number_{nullptr};
   number::Number *mosfet_overtemperature_protection_recovery_number_{nullptr};
-  number::Number *discharge_precharge_time_number_{nullptr};
+  number::Number *discharging_precharge_time_number_{nullptr};
   number::Number *heating_start_temperature_number_{nullptr};
   number::Number *heating_stop_temperature_number_{nullptr};
   number::Number *re_bulk_soc_number_{nullptr};
@@ -412,8 +412,8 @@ class JkBmsBle :
   sensor::Sensor *balancing_current_sensor_{nullptr};
   sensor::Sensor *emergency_time_countdown_sensor_{nullptr};
   sensor::Sensor *heating_current_sensor_{nullptr};
-  sensor::Sensor *charge_status_id_sensor_{nullptr};
-  sensor::Sensor *charge_status_time_elapsed_sensor_{nullptr};
+  sensor::Sensor *charging_status_id_sensor_{nullptr};
+  sensor::Sensor *charging_status_time_elapsed_sensor_{nullptr};
   sensor::Sensor *detail_log_count_sensor_{nullptr};
   sensor::Sensor *battery_type_id_sensor_{nullptr};
 
@@ -433,7 +433,7 @@ class JkBmsBle :
   text_sensor::TextSensor *errors_text_sensor_{nullptr};
   text_sensor::TextSensor *operation_status_text_sensor_{nullptr};
   text_sensor::TextSensor *total_runtime_formatted_text_sensor_{nullptr};
-  text_sensor::TextSensor *charge_status_text_sensor_{nullptr};
+  text_sensor::TextSensor *charging_status_text_sensor_{nullptr};
   text_sensor::TextSensor *software_version_text_sensor_{nullptr};
   text_sensor::TextSensor *hardware_version_text_sensor_{nullptr};
   text_sensor::TextSensor *battery_type_text_sensor_{nullptr};
@@ -464,7 +464,7 @@ class JkBmsBle :
   void track_online_status_();
   std::string to_hex_string_(uint32_t mask);
   std::string error_bits_to_string_(uint32_t bitmask, const char *const *errors, uint8_t errors_size);
-  std::string charge_status_id_to_string_(uint8_t status);
+  std::string charging_status_id_to_string_(uint8_t status);
   std::string battery_type_id_to_string_(uint8_t code);
 
   std::string format_total_runtime_(const uint32_t value) {

--- a/components/jk_bms_ble/number/__init__.py
+++ b/components/jk_bms_ble/number/__init__.py
@@ -158,40 +158,42 @@ CONF_VOLTAGE_CALIBRATION = "voltage_calibration"
 CONF_CURRENT_CALIBRATION = "current_calibration"
 CONF_POWER_OFF_VOLTAGE = "power_off_voltage"
 CONF_MAX_BALANCE_CURRENT = "max_balance_current"
-CONF_MAX_CHARGE_CURRENT = "max_charge_current"
-CONF_MAX_DISCHARGE_CURRENT = "max_discharge_current"
+CONF_MAX_CHARGING_CURRENT = "max_charging_current"
+CONF_MAX_DISCHARGING_CURRENT = "max_discharging_current"
 
-CONF_CHARGE_OVERCURRENT_PROTECTION_DELAY = "charge_overcurrent_protection_delay"
-CONF_CHARGE_OVERCURRENT_PROTECTION_RECOVERY_TIME = (
-    "charge_overcurrent_protection_recovery_time"
+CONF_CHARGING_OVERCURRENT_PROTECTION_DELAY = "charging_overcurrent_protection_delay"
+CONF_CHARGING_OVERCURRENT_PROTECTION_RECOVERY_TIME = (
+    "charging_overcurrent_protection_recovery_time"
 )
-CONF_DISCHARGE_OVERCURRENT_PROTECTION_DELAY = "discharge_overcurrent_protection_delay"
-CONF_DISCHARGE_OVERCURRENT_PROTECTION_RECOVERY_TIME = (
-    "discharge_overcurrent_protection_recovery_time"
+CONF_DISCHARGING_OVERCURRENT_PROTECTION_DELAY = (
+    "discharging_overcurrent_protection_delay"
+)
+CONF_DISCHARGING_OVERCURRENT_PROTECTION_RECOVERY_TIME = (
+    "discharging_overcurrent_protection_recovery_time"
 )
 CONF_SHORT_CIRCUIT_PROTECTION_DELAY = "short_circuit_protection_delay"
 CONF_SHORT_CIRCUIT_PROTECTION_RECOVERY_TIME = "short_circuit_protection_recovery_time"
-CONF_CHARGE_OVERTEMPERATURE_PROTECTION = "charge_overtemperature_protection"
-CONF_CHARGE_OVERTMPERATURE_PROTECTION_RECOVERY = (
-    "charge_overtemperature_protection_recovery"
+CONF_CHARGING_OVERTEMPERATURE_PROTECTION = "charging_overtemperature_protection"
+CONF_CHARGING_OVERTEMPERATURE_PROTECTION_RECOVERY = (
+    "charging_overtemperature_protection_recovery"
 )
-CONF_DISCHARGE_OVERTEMPERATURE_PROTECTION = "discharge_overtemperature_protection"
-CONF_DISCHARGE_OVERTEMPERATURE_PROTECTION_RECOVERY = (
-    "discharge_overtemperature_protection_recovery"
+CONF_DISCHARGING_OVERTEMPERATURE_PROTECTION = "discharging_overtemperature_protection"
+CONF_DISCHARGING_OVERTEMPERATURE_PROTECTION_RECOVERY = (
+    "discharging_overtemperature_protection_recovery"
 )
-CONF_CHARGE_UNDERTEMPERATURE_PROTECTION = "charge_undertemperature_protection"
-CONF_CHARGE_UNDERTMPERATURE_PROTECTION_RECOVERY = (
-    "charge_undertemperature_protection_recovery"
+CONF_CHARGING_UNDERTEMPERATURE_PROTECTION = "charging_undertemperature_protection"
+CONF_CHARGING_UNDERTEMPERATURE_PROTECTION_RECOVERY = (
+    "charging_undertemperature_protection_recovery"
 )
-CONF_DISCHARGE_UNDERTEMPERATURE_PROTECTION = "discharge_undertemperature_protection"
-CONF_DISCHARGE_UNDERTEMPERATURE_PROTECTION_RECOVERY = (
-    "discharge_undertemperature_protection_recovery"
+CONF_DISCHARGING_UNDERTEMPERATURE_PROTECTION = "discharging_undertemperature_protection"
+CONF_DISCHARGING_UNDERTEMPERATURE_PROTECTION_RECOVERY = (
+    "discharging_undertemperature_protection_recovery"
 )
 CONF_MOSFET_OVERTEMPERATURE_PROTECTION = "mosfet_overtemperature_protection"
 CONF_MOSFET_OVERTEMPERATURE_PROTECTION_RECOVERY = (
     "mosfet_overtemperature_protection_recovery"
 )
-CONF_DISCHARGE_PRECHARGE_TIME = "discharge_precharge_time"
+CONF_DISCHARGING_PRECHARGE_TIME = "discharging_precharge_time"
 CONF_HEATING_START_TEMPERATURE = "heating_start_temperature"
 CONF_HEATING_STOP_TEMPERATURE = "heating_stop_temperature"
 
@@ -221,24 +223,24 @@ NUMBERS = {
     CONF_CURRENT_CALIBRATION: [0x00, 0x24, 0x67, 1000.0, 4],
     CONF_POWER_OFF_VOLTAGE: [0x00, 0x0B, 0x0B, 1000.0, 4],
     CONF_MAX_BALANCE_CURRENT: [0x00, 0x13, 0x13, 1000.0, 4],
-    CONF_MAX_CHARGE_CURRENT: [0x00, 0x0C, 0x0C, 1000.0, 4],
-    CONF_MAX_DISCHARGE_CURRENT: [0x00, 0x0F, 0x0F, 1000.0, 4],
-    CONF_CHARGE_OVERCURRENT_PROTECTION_DELAY: [0x00, 0x0D, 0x0D, 1.0, 4],
-    CONF_CHARGE_OVERCURRENT_PROTECTION_RECOVERY_TIME: [
+    CONF_MAX_CHARGING_CURRENT: [0x00, 0x0C, 0x0C, 1000.0, 4],
+    CONF_MAX_DISCHARGING_CURRENT: [0x00, 0x0F, 0x0F, 1000.0, 4],
+    CONF_CHARGING_OVERCURRENT_PROTECTION_DELAY: [0x00, 0x0D, 0x0D, 1.0, 4],
+    CONF_CHARGING_OVERCURRENT_PROTECTION_RECOVERY_TIME: [
         0x00,
         0x0E,
         0x0E,
         1.0,
         4,
     ],
-    CONF_DISCHARGE_OVERCURRENT_PROTECTION_DELAY: [
+    CONF_DISCHARGING_OVERCURRENT_PROTECTION_DELAY: [
         0x00,
         0x10,
         0x10,
         1.0,
         4,
     ],
-    CONF_DISCHARGE_OVERCURRENT_PROTECTION_RECOVERY_TIME: [
+    CONF_DISCHARGING_OVERCURRENT_PROTECTION_RECOVERY_TIME: [
         0x00,
         0x11,
         0x11,
@@ -253,50 +255,50 @@ NUMBERS = {
         1.0,
         4,
     ],
-    CONF_CHARGE_OVERTEMPERATURE_PROTECTION: [0x00, 0x14, 0x14, 10.0, 4],
-    CONF_CHARGE_OVERTMPERATURE_PROTECTION_RECOVERY: [
+    CONF_CHARGING_OVERTEMPERATURE_PROTECTION: [0x00, 0x14, 0x14, 10.0, 4],
+    CONF_CHARGING_OVERTEMPERATURE_PROTECTION_RECOVERY: [
         0x00,
         0x15,
         0x15,
         10.0,
         4,
     ],
-    CONF_DISCHARGE_OVERTEMPERATURE_PROTECTION: [
+    CONF_DISCHARGING_OVERTEMPERATURE_PROTECTION: [
         0x00,
         0x16,
         0x16,
         10.0,
         4,
     ],
-    CONF_DISCHARGE_OVERTEMPERATURE_PROTECTION_RECOVERY: [
+    CONF_DISCHARGING_OVERTEMPERATURE_PROTECTION_RECOVERY: [
         0x00,
         0x17,
         0x17,
         10.0,
         4,
     ],
-    CONF_CHARGE_UNDERTEMPERATURE_PROTECTION: [
+    CONF_CHARGING_UNDERTEMPERATURE_PROTECTION: [
         0x00,
         0x18,
         0x18,
         10.0,
         4,
     ],
-    CONF_CHARGE_UNDERTMPERATURE_PROTECTION_RECOVERY: [
+    CONF_CHARGING_UNDERTEMPERATURE_PROTECTION_RECOVERY: [
         0x00,
         0x19,
         0x19,
         10.0,
         4,
     ],
-    CONF_DISCHARGE_UNDERTEMPERATURE_PROTECTION: [
+    CONF_DISCHARGING_UNDERTEMPERATURE_PROTECTION: [
         0x00,
         0x00,
         0x3A,
         1.0,
         1,
     ],
-    CONF_DISCHARGE_UNDERTEMPERATURE_PROTECTION_RECOVERY: [
+    CONF_DISCHARGING_UNDERTEMPERATURE_PROTECTION_RECOVERY: [
         0x00,
         0x00,
         0x3B,
@@ -317,7 +319,7 @@ NUMBERS = {
         10.0,
         4,
     ],
-    CONF_DISCHARGE_PRECHARGE_TIME: [0x00, 0x00, 0x25, 1.0, 4],
+    CONF_DISCHARGING_PRECHARGE_TIME: [0x00, 0x00, 0x25, 1.0, 4],
     CONF_HEATING_START_TEMPERATURE: [0x00, 0x00, 0x37, 1.0, 1],
     CONF_HEATING_STOP_TEMPERATURE: [0x00, 0x00, 0x38, 1.0, 1],
 }
@@ -346,6 +348,21 @@ _RENAMED_NUMBERS = {
     "power_tube_overtemperature_protection": "mosfet_overtemperature_protection",
     "power_tube_overtemperature_protection_recovery": "mosfet_overtemperature_protection_recovery",
     "balance_starting_voltage": "balancing_start_voltage",
+    "max_charge_current": "max_charging_current",
+    "max_discharge_current": "max_discharging_current",
+    "charge_overcurrent_protection_delay": "charging_overcurrent_protection_delay",
+    "charge_overcurrent_protection_recovery_time": "charging_overcurrent_protection_recovery_time",
+    "discharge_overcurrent_protection_delay": "discharging_overcurrent_protection_delay",
+    "discharge_overcurrent_protection_recovery_time": "discharging_overcurrent_protection_recovery_time",
+    "charge_overtemperature_protection": "charging_overtemperature_protection",
+    "charge_overtemperature_protection_recovery": "charging_overtemperature_protection_recovery",
+    "discharge_overtemperature_protection": "discharging_overtemperature_protection",
+    "discharge_overtemperature_protection_recovery": "discharging_overtemperature_protection_recovery",
+    "charge_undertemperature_protection": "charging_undertemperature_protection",
+    "charge_undertemperature_protection_recovery": "charging_undertemperature_protection_recovery",
+    "discharge_undertemperature_protection": "discharging_undertemperature_protection",
+    "discharge_undertemperature_protection_recovery": "discharging_undertemperature_protection_recovery",
+    "discharge_precharge_time": "discharging_precharge_time",
 }
 
 _NUMBER_CONFIG_SCHEMA = JK_BMS_BLE_COMPONENT_SCHEMA.extend(
@@ -511,7 +528,7 @@ _NUMBER_CONFIG_SCHEMA = JK_BMS_BLE_COMPONENT_SCHEMA.extend(
                 ): cv.string_strict,
             }
         ),
-        cv.Optional(CONF_MAX_CHARGE_CURRENT): JK_NUMBER_SCHEMA.extend(
+        cv.Optional(CONF_MAX_CHARGING_CURRENT): JK_NUMBER_SCHEMA.extend(
             {
                 cv.Optional(CONF_MIN_VALUE, default=1.0): cv.float_,
                 cv.Optional(CONF_MAX_VALUE, default=600.1): cv.float_,
@@ -521,7 +538,7 @@ _NUMBER_CONFIG_SCHEMA = JK_BMS_BLE_COMPONENT_SCHEMA.extend(
                 ): cv.string_strict,
             }
         ),
-        cv.Optional(CONF_MAX_DISCHARGE_CURRENT): JK_NUMBER_SCHEMA.extend(
+        cv.Optional(CONF_MAX_DISCHARGING_CURRENT): JK_NUMBER_SCHEMA.extend(
             {
                 cv.Optional(CONF_MIN_VALUE, default=1.0): cv.float_,
                 cv.Optional(CONF_MAX_VALUE, default=1200.1): cv.float_,
@@ -531,7 +548,7 @@ _NUMBER_CONFIG_SCHEMA = JK_BMS_BLE_COMPONENT_SCHEMA.extend(
                 ): cv.string_strict,
             }
         ),
-        cv.Optional(CONF_CHARGE_OVERCURRENT_PROTECTION_DELAY): JK_NUMBER_SCHEMA.extend(
+        cv.Optional(CONF_CHARGING_OVERCURRENT_PROTECTION_DELAY): JK_NUMBER_SCHEMA.extend(
             {
                 cv.Optional(CONF_MIN_VALUE, default=2): cv.float_,
                 cv.Optional(CONF_MAX_VALUE, default=600): cv.float_,
@@ -542,7 +559,7 @@ _NUMBER_CONFIG_SCHEMA = JK_BMS_BLE_COMPONENT_SCHEMA.extend(
             }
         ),
         cv.Optional(
-            CONF_CHARGE_OVERCURRENT_PROTECTION_RECOVERY_TIME
+            CONF_CHARGING_OVERCURRENT_PROTECTION_RECOVERY_TIME
         ): JK_NUMBER_SCHEMA.extend(
             {
                 cv.Optional(CONF_MIN_VALUE, default=2): cv.float_,
@@ -554,7 +571,7 @@ _NUMBER_CONFIG_SCHEMA = JK_BMS_BLE_COMPONENT_SCHEMA.extend(
             }
         ),
         cv.Optional(
-            CONF_DISCHARGE_OVERCURRENT_PROTECTION_DELAY
+            CONF_DISCHARGING_OVERCURRENT_PROTECTION_DELAY
         ): JK_NUMBER_SCHEMA.extend(
             {
                 cv.Optional(CONF_MIN_VALUE, default=2): cv.float_,
@@ -566,7 +583,7 @@ _NUMBER_CONFIG_SCHEMA = JK_BMS_BLE_COMPONENT_SCHEMA.extend(
             }
         ),
         cv.Optional(
-            CONF_DISCHARGE_OVERCURRENT_PROTECTION_RECOVERY_TIME
+            CONF_DISCHARGING_OVERCURRENT_PROTECTION_RECOVERY_TIME
         ): JK_NUMBER_SCHEMA.extend(
             {
                 cv.Optional(CONF_MIN_VALUE, default=2): cv.float_,
@@ -599,7 +616,7 @@ _NUMBER_CONFIG_SCHEMA = JK_BMS_BLE_COMPONENT_SCHEMA.extend(
                 ): cv.string_strict,
             }
         ),
-        cv.Optional(CONF_CHARGE_OVERTEMPERATURE_PROTECTION): JK_NUMBER_SCHEMA.extend(
+        cv.Optional(CONF_CHARGING_OVERTEMPERATURE_PROTECTION): JK_NUMBER_SCHEMA.extend(
             {
                 cv.Optional(CONF_MIN_VALUE, default=30): cv.float_,
                 cv.Optional(CONF_MAX_VALUE, default=80): cv.float_,
@@ -610,7 +627,7 @@ _NUMBER_CONFIG_SCHEMA = JK_BMS_BLE_COMPONENT_SCHEMA.extend(
             }
         ),
         cv.Optional(
-            CONF_CHARGE_OVERTMPERATURE_PROTECTION_RECOVERY
+            CONF_CHARGING_OVERTEMPERATURE_PROTECTION_RECOVERY
         ): JK_NUMBER_SCHEMA.extend(
             {
                 cv.Optional(CONF_MIN_VALUE, default=30): cv.float_,
@@ -621,7 +638,7 @@ _NUMBER_CONFIG_SCHEMA = JK_BMS_BLE_COMPONENT_SCHEMA.extend(
                 ): cv.string_strict,
             }
         ),
-        cv.Optional(CONF_DISCHARGE_OVERTEMPERATURE_PROTECTION): JK_NUMBER_SCHEMA.extend(
+        cv.Optional(CONF_DISCHARGING_OVERTEMPERATURE_PROTECTION): JK_NUMBER_SCHEMA.extend(
             {
                 cv.Optional(CONF_MIN_VALUE, default=30): cv.float_,
                 cv.Optional(CONF_MAX_VALUE, default=80): cv.float_,
@@ -632,7 +649,7 @@ _NUMBER_CONFIG_SCHEMA = JK_BMS_BLE_COMPONENT_SCHEMA.extend(
             }
         ),
         cv.Optional(
-            CONF_DISCHARGE_OVERTEMPERATURE_PROTECTION_RECOVERY
+            CONF_DISCHARGING_OVERTEMPERATURE_PROTECTION_RECOVERY
         ): JK_NUMBER_SCHEMA.extend(
             {
                 cv.Optional(CONF_MIN_VALUE, default=30): cv.float_,
@@ -643,7 +660,7 @@ _NUMBER_CONFIG_SCHEMA = JK_BMS_BLE_COMPONENT_SCHEMA.extend(
                 ): cv.string_strict,
             }
         ),
-        cv.Optional(CONF_CHARGE_UNDERTEMPERATURE_PROTECTION): JK_NUMBER_SCHEMA.extend(
+        cv.Optional(CONF_CHARGING_UNDERTEMPERATURE_PROTECTION): JK_NUMBER_SCHEMA.extend(
             {
                 cv.Optional(CONF_MIN_VALUE, default=-45): cv.float_,
                 cv.Optional(CONF_MAX_VALUE, default=20): cv.float_,
@@ -654,7 +671,7 @@ _NUMBER_CONFIG_SCHEMA = JK_BMS_BLE_COMPONENT_SCHEMA.extend(
             }
         ),
         cv.Optional(
-            CONF_CHARGE_UNDERTMPERATURE_PROTECTION_RECOVERY
+            CONF_CHARGING_UNDERTEMPERATURE_PROTECTION_RECOVERY
         ): JK_NUMBER_SCHEMA.extend(
             {
                 cv.Optional(CONF_MIN_VALUE, default=-45): cv.float_,
@@ -666,7 +683,7 @@ _NUMBER_CONFIG_SCHEMA = JK_BMS_BLE_COMPONENT_SCHEMA.extend(
             }
         ),
         cv.Optional(
-            CONF_DISCHARGE_UNDERTEMPERATURE_PROTECTION
+            CONF_DISCHARGING_UNDERTEMPERATURE_PROTECTION
         ): JK_NUMBER_SCHEMA.extend(
             {
                 cv.Optional(CONF_MIN_VALUE, default=-40): cv.float_,
@@ -678,7 +695,7 @@ _NUMBER_CONFIG_SCHEMA = JK_BMS_BLE_COMPONENT_SCHEMA.extend(
             }
         ),
         cv.Optional(
-            CONF_DISCHARGE_UNDERTEMPERATURE_PROTECTION_RECOVERY
+            CONF_DISCHARGING_UNDERTEMPERATURE_PROTECTION_RECOVERY
         ): JK_NUMBER_SCHEMA.extend(
             {
                 cv.Optional(CONF_MIN_VALUE, default=-40): cv.float_,
@@ -711,7 +728,7 @@ _NUMBER_CONFIG_SCHEMA = JK_BMS_BLE_COMPONENT_SCHEMA.extend(
                 ): cv.string_strict,
             }
         ),
-        cv.Optional(CONF_DISCHARGE_PRECHARGE_TIME): JK_NUMBER_SCHEMA.extend(
+        cv.Optional(CONF_DISCHARGING_PRECHARGE_TIME): JK_NUMBER_SCHEMA.extend(
             {
                 cv.Optional(CONF_MIN_VALUE, default=0.0): cv.float_,
                 cv.Optional(CONF_MAX_VALUE, default=255.0): cv.float_,

--- a/components/jk_bms_ble/sensor.py
+++ b/components/jk_bms_ble/sensor.py
@@ -54,8 +54,8 @@ CONF_TOTAL_RUNTIME = "total_runtime"
 CONF_BALANCING_CURRENT = "balancing_current"
 CONF_EMERGENCY_TIME_COUNTDOWN = "emergency_time_countdown"
 CONF_HEATING_CURRENT = "heating_current"
-CONF_CHARGE_STATUS_ID = "charge_status_id"
-CONF_CHARGE_STATUS_TIME_ELAPSED = "charge_status_time_elapsed"
+CONF_CHARGING_STATUS_ID = "charging_status_id"
+CONF_CHARGING_STATUS_TIME_ELAPSED = "charging_status_time_elapsed"
 CONF_DETAIL_LOG_COUNT = "detail_log_count"
 CONF_BATTERY_TYPE_ID = "battery_type_id"
 CONF_BALANCER_STATUS = "balancer_status"
@@ -72,8 +72,8 @@ ICON_CAPACITY_REMAINING = "mdi:battery-50"
 ICON_CHARGING_CYCLES = "mdi:battery-sync"
 ICON_CELL_RESISTANCE = "mdi:omega"
 ICON_BALANCER = "mdi:seesaw"
-ICON_CHARGE_STATUS_ID = "mdi:battery-clock"
-ICON_CHARGE_STATUS_TIME_ELAPSED = "mdi:timer-outline"
+ICON_CHARGING_STATUS_ID = "mdi:battery-clock"
+ICON_CHARGING_STATUS_TIME_ELAPSED = "mdi:timer-outline"
 
 CELL_VOLTAGES = [f"cell_voltage_{i}" for i in range(1, 33)]
 CELL_RESISTANCES = [f"cell_resistance_{i}" for i in range(1, 33)]
@@ -262,15 +262,15 @@ SENSOR_DEFS = {
         "device_class": DEVICE_CLASS_CURRENT,
         "state_class": STATE_CLASS_MEASUREMENT,
     },
-    CONF_CHARGE_STATUS_ID: {
+    CONF_CHARGING_STATUS_ID: {
         "unit_of_measurement": UNIT_EMPTY,
-        "icon": ICON_CHARGE_STATUS_ID,
+        "icon": ICON_CHARGING_STATUS_ID,
         "accuracy_decimals": 0,
         "device_class": DEVICE_CLASS_EMPTY,
     },
-    CONF_CHARGE_STATUS_TIME_ELAPSED: {
+    CONF_CHARGING_STATUS_TIME_ELAPSED: {
         "unit_of_measurement": UNIT_SECONDS,
-        "icon": ICON_CHARGE_STATUS_TIME_ELAPSED,
+        "icon": ICON_CHARGING_STATUS_TIME_ELAPSED,
         "accuracy_decimals": 0,
         "device_class": DEVICE_CLASS_EMPTY,
     },
@@ -294,6 +294,8 @@ _RENAMED_SENSORS = {
     "balancing": "balancer_status",
     "total_battery_capacity_setting": "full_charge_capacity",
     "power_tube_temperature": "mosfet_temperature",
+    "charge_status_id": "charging_status_id",
+    "charge_status_time_elapsed": "charging_status_time_elapsed",
 }
 
 CONFIG_SCHEMA = cv.All(

--- a/components/jk_bms_ble/text_sensor.py
+++ b/components/jk_bms_ble/text_sensor.py
@@ -3,7 +3,7 @@ from esphome.components import text_sensor
 import esphome.config_validation as cv
 from esphome.const import ENTITY_CATEGORY_DIAGNOSTIC, ICON_EMPTY, ICON_TIMELAPSE
 
-from . import CONF_JK_BMS_BLE_ID, JK_BMS_BLE_COMPONENT_SCHEMA
+from . import CONF_JK_BMS_BLE_ID, JK_BMS_BLE_COMPONENT_SCHEMA, deprecated_renames
 
 DEPENDENCIES = ["jk_bms_ble"]
 
@@ -13,14 +13,14 @@ CONF_ERRORS = "errors"
 CONF_ERRORS_BITMASK_HEX = "errors_bitmask_hex"
 CONF_OPERATION_STATUS = "operation_status"
 CONF_TOTAL_RUNTIME_FORMATTED = "total_runtime_formatted"
-CONF_CHARGE_STATUS = "charge_status"
+CONF_CHARGING_STATUS = "charging_status"
 CONF_SOFTWARE_VERSION = "software_version"
 CONF_HARDWARE_VERSION = "hardware_version"
 CONF_BATTERY_TYPE = "battery_type"
 
 ICON_ERRORS = "mdi:alert-circle-outline"
 ICON_OPERATION_STATUS = "mdi:heart-pulse"
-ICON_CHARGE_STATUS = "mdi:battery-clock"
+ICON_CHARGING_STATUS = "mdi:battery-clock"
 ICON_BATTERY_TYPE = "mdi:battery-heart-variant"
 
 TEXT_SENSORS = [
@@ -28,43 +28,50 @@ TEXT_SENSORS = [
     CONF_ERRORS_BITMASK_HEX,
     CONF_OPERATION_STATUS,
     CONF_TOTAL_RUNTIME_FORMATTED,
-    CONF_CHARGE_STATUS,
+    CONF_CHARGING_STATUS,
     CONF_SOFTWARE_VERSION,
     CONF_HARDWARE_VERSION,
     CONF_BATTERY_TYPE,
 ]
 
-CONFIG_SCHEMA = JK_BMS_BLE_COMPONENT_SCHEMA.extend(
-    {
-        cv.Optional(CONF_ERRORS): text_sensor.text_sensor_schema(
-            icon=ICON_ERRORS,
-            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
-        ),
-        cv.Optional(CONF_ERRORS_BITMASK_HEX): text_sensor.text_sensor_schema(
-            text_sensor.TextSensor, icon=ICON_ERRORS
-        ),
-        cv.Optional(CONF_OPERATION_STATUS): text_sensor.text_sensor_schema(
-            icon=ICON_OPERATION_STATUS
-        ),
-        cv.Optional(CONF_TOTAL_RUNTIME_FORMATTED): text_sensor.text_sensor_schema(
-            icon=ICON_TIMELAPSE
-        ),
-        cv.Optional(CONF_CHARGE_STATUS): text_sensor.text_sensor_schema(
-            icon=ICON_CHARGE_STATUS
-        ),
-        cv.Optional(CONF_SOFTWARE_VERSION): text_sensor.text_sensor_schema(
-            icon=ICON_EMPTY,
-            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
-        ),
-        cv.Optional(CONF_HARDWARE_VERSION): text_sensor.text_sensor_schema(
-            icon=ICON_EMPTY,
-            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
-        ),
-        cv.Optional(CONF_BATTERY_TYPE): text_sensor.text_sensor_schema(
-            icon=ICON_BATTERY_TYPE,
-            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
-        ),
-    }
+_RENAMED_TEXT_SENSORS = {
+    "charge_status": "charging_status",
+}
+
+CONFIG_SCHEMA = cv.All(
+    deprecated_renames(_RENAMED_TEXT_SENSORS),
+    JK_BMS_BLE_COMPONENT_SCHEMA.extend(
+        {
+            cv.Optional(CONF_ERRORS): text_sensor.text_sensor_schema(
+                icon=ICON_ERRORS,
+                entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+            ),
+            cv.Optional(CONF_ERRORS_BITMASK_HEX): text_sensor.text_sensor_schema(
+                text_sensor.TextSensor, icon=ICON_ERRORS
+            ),
+            cv.Optional(CONF_OPERATION_STATUS): text_sensor.text_sensor_schema(
+                icon=ICON_OPERATION_STATUS
+            ),
+            cv.Optional(CONF_TOTAL_RUNTIME_FORMATTED): text_sensor.text_sensor_schema(
+                icon=ICON_TIMELAPSE
+            ),
+            cv.Optional(CONF_CHARGING_STATUS): text_sensor.text_sensor_schema(
+                icon=ICON_CHARGING_STATUS
+            ),
+            cv.Optional(CONF_SOFTWARE_VERSION): text_sensor.text_sensor_schema(
+                icon=ICON_EMPTY,
+                entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+            ),
+            cv.Optional(CONF_HARDWARE_VERSION): text_sensor.text_sensor_schema(
+                icon=ICON_EMPTY,
+                entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+            ),
+            cv.Optional(CONF_BATTERY_TYPE): text_sensor.text_sensor_schema(
+                icon=ICON_BATTERY_TYPE,
+                entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+            ),
+        }
+    ),
 )
 
 

--- a/esp32-ble-example.yaml
+++ b/esp32-ble-example.yaml
@@ -112,34 +112,34 @@ number:
       name: "power off voltage"
     max_balance_current:
       name: "max balance current"
-    max_charge_current:
-      name: "max charge current"
-    max_discharge_current:
-      name: "max discharge current"
-    charge_overcurrent_protection_delay:
-      name: "charge overcurrent protection delay"
-    charge_overcurrent_protection_recovery_time:
-      name: "charge overcurrent protection recovery time"
-    discharge_overcurrent_protection_delay:
-      name: "discharge overcurrent protection delay"
-    discharge_overcurrent_protection_recovery_time:
-      name: "discharge overcurrent protection recovery time"
+    max_charging_current:
+      name: "max charging current"
+    max_discharging_current:
+      name: "max discharging current"
+    charging_overcurrent_protection_delay:
+      name: "charging overcurrent protection delay"
+    charging_overcurrent_protection_recovery_time:
+      name: "charging overcurrent protection recovery time"
+    discharging_overcurrent_protection_delay:
+      name: "discharging overcurrent protection delay"
+    discharging_overcurrent_protection_recovery_time:
+      name: "discharging overcurrent protection recovery time"
     short_circuit_protection_delay:
       name: "short circuit protection delay"
     short_circuit_protection_recovery_time:
       name: "short circuit protection recovery time"
-    charge_overtemperature_protection:
-      name: "charge overtemperature protection"
-    charge_overtemperature_protection_recovery:
-      name: "charge overtemperature protection recovery"
-    discharge_overtemperature_protection:
-      name: "discharge overtemperature protection"
-    discharge_overtemperature_protection_recovery:
-      name: "discharge overtemperature protection recovery"
-    charge_undertemperature_protection:
-      name: "charge undertemperature protection"
-    charge_undertemperature_protection_recovery:
-      name: "charge undertemperature protection recovery"
+    charging_overtemperature_protection:
+      name: "charging overtemperature protection"
+    charging_overtemperature_protection_recovery:
+      name: "charging overtemperature protection recovery"
+    discharging_overtemperature_protection:
+      name: "discharging overtemperature protection"
+    discharging_overtemperature_protection_recovery:
+      name: "discharging overtemperature protection recovery"
+    charging_undertemperature_protection:
+      name: "charging undertemperature protection"
+    charging_undertemperature_protection_recovery:
+      name: "charging undertemperature protection recovery"
     mosfet_overtemperature_protection:
       name: "mosfet overtemperature protection"
     mosfet_overtemperature_protection_recovery:

--- a/esp32-ble-v11-example.yaml
+++ b/esp32-ble-v11-example.yaml
@@ -112,10 +112,10 @@ number:
       name: "power off voltage"
     max_balance_current:
       name: "max balance current"
-    max_charge_current:
-      name: "max charge current"
-    max_discharge_current:
-      name: "max discharge current"
+    max_charging_current:
+      name: "max charging current"
+    max_discharging_current:
+      name: "max discharging current"
     smart_sleep_voltage:
       name: "smart sleep voltage"
     cell_soc100_voltage:
@@ -126,40 +126,40 @@ number:
       name: "cell request charge voltage"
     cell_request_float_voltage:
       name: "cell request float voltage"
-    charge_overcurrent_protection_delay:
-      name: "charge overcurrent protection delay"
-    charge_overcurrent_protection_recovery_time:
-      name: "charge overcurrent protection recovery time"
-    discharge_overcurrent_protection_delay:
-      name: "discharge overcurrent protection delay"
-    discharge_overcurrent_protection_recovery_time:
-      name: "discharge overcurrent protection recovery time"
+    charging_overcurrent_protection_delay:
+      name: "charging overcurrent protection delay"
+    charging_overcurrent_protection_recovery_time:
+      name: "charging overcurrent protection recovery time"
+    discharging_overcurrent_protection_delay:
+      name: "discharging overcurrent protection delay"
+    discharging_overcurrent_protection_recovery_time:
+      name: "discharging overcurrent protection recovery time"
     short_circuit_protection_delay:
       name: "short circuit protection delay"
     short_circuit_protection_recovery_time:
       name: "short circuit protection recovery time"
-    charge_overtemperature_protection:
-      name: "charge overtemperature protection"
-    charge_overtemperature_protection_recovery:
-      name: "charge overtemperature protection recovery"
-    discharge_overtemperature_protection:
-      name: "discharge overtemperature protection"
-    discharge_overtemperature_protection_recovery:
-      name: "discharge overtemperature protection recovery"
-    charge_undertemperature_protection:
-      name: "charge undertemperature protection"
-    charge_undertemperature_protection_recovery:
-      name: "charge undertemperature protection recovery"
-    discharge_undertemperature_protection:
-      name: "discharge undertemperature protection"
-    discharge_undertemperature_protection_recovery:
-      name: "discharge undertemperature protection recovery"
+    charging_overtemperature_protection:
+      name: "charging overtemperature protection"
+    charging_overtemperature_protection_recovery:
+      name: "charging overtemperature protection recovery"
+    discharging_overtemperature_protection:
+      name: "discharging overtemperature protection"
+    discharging_overtemperature_protection_recovery:
+      name: "discharging overtemperature protection recovery"
+    charging_undertemperature_protection:
+      name: "charging undertemperature protection"
+    charging_undertemperature_protection_recovery:
+      name: "charging undertemperature protection recovery"
+    discharging_undertemperature_protection:
+      name: "discharging undertemperature protection"
+    discharging_undertemperature_protection_recovery:
+      name: "discharging undertemperature protection recovery"
     mosfet_overtemperature_protection:
       name: "mosfet overtemperature protection"
     mosfet_overtemperature_protection_recovery:
       name: "mosfet overtemperature protection recovery"
-    discharge_precharge_time:
-      name: "discharge precharge time"
+    discharging_precharge_time:
+      name: "discharging precharge time"
 
 sensor:
   - platform: jk_bms_ble

--- a/esp32-ble-v14-example-multiple-devices.yaml
+++ b/esp32-ble-v14-example-multiple-devices.yaml
@@ -175,11 +175,11 @@ number:
     max_balance_current:
       name: "max balance current"
       device_id: device0
-    max_charge_current:
-      name: "max charge current"
+    max_charging_current:
+      name: "max charging current"
       device_id: device0
-    max_discharge_current:
-      name: "max discharge current"
+    max_discharging_current:
+      name: "max discharging current"
       device_id: device0
     smart_sleep_voltage:
       name: "smart sleep voltage"
@@ -202,17 +202,17 @@ number:
     cell_request_float_voltage_time:
       name: "cell request float voltage time"
       device_id: device0
-    charge_overcurrent_protection_delay:
-      name: "charge overcurrent protection delay"
+    charging_overcurrent_protection_delay:
+      name: "charging overcurrent protection delay"
       device_id: device0
-    charge_overcurrent_protection_recovery_time:
-      name: "charge overcurrent protection recovery time"
+    charging_overcurrent_protection_recovery_time:
+      name: "charging overcurrent protection recovery time"
       device_id: device0
-    discharge_overcurrent_protection_delay:
-      name: "discharge overcurrent protection delay"
+    discharging_overcurrent_protection_delay:
+      name: "discharging overcurrent protection delay"
       device_id: device0
-    discharge_overcurrent_protection_recovery_time:
-      name: "discharge overcurrent protection recovery time"
+    discharging_overcurrent_protection_recovery_time:
+      name: "discharging overcurrent protection recovery time"
       device_id: device0
     short_circuit_protection_delay:
       name: "short circuit protection delay"
@@ -220,29 +220,29 @@ number:
     short_circuit_protection_recovery_time:
       name: "short circuit protection recovery time"
       device_id: device0
-    charge_overtemperature_protection:
-      name: "charge overtemperature protection"
+    charging_overtemperature_protection:
+      name: "charging overtemperature protection"
       device_id: device0
-    charge_overtemperature_protection_recovery:
-      name: "charge overtemperature protection recovery"
+    charging_overtemperature_protection_recovery:
+      name: "charging overtemperature protection recovery"
       device_id: device0
-    discharge_overtemperature_protection:
-      name: "discharge overtemperature protection"
+    discharging_overtemperature_protection:
+      name: "discharging overtemperature protection"
       device_id: device0
-    discharge_overtemperature_protection_recovery:
-      name: "discharge overtemperature protection recovery"
+    discharging_overtemperature_protection_recovery:
+      name: "discharging overtemperature protection recovery"
       device_id: device0
-    charge_undertemperature_protection:
-      name: "charge undertemperature protection"
+    charging_undertemperature_protection:
+      name: "charging undertemperature protection"
       device_id: device0
-    charge_undertemperature_protection_recovery:
-      name: "charge undertemperature protection recovery"
+    charging_undertemperature_protection_recovery:
+      name: "charging undertemperature protection recovery"
       device_id: device0
-    discharge_undertemperature_protection:
-      name: "discharge undertemperature protection"
+    discharging_undertemperature_protection:
+      name: "discharging undertemperature protection"
       device_id: device0
-    discharge_undertemperature_protection_recovery:
-      name: "discharge undertemperature protection recovery"
+    discharging_undertemperature_protection_recovery:
+      name: "discharging undertemperature protection recovery"
       device_id: device0
     mosfet_overtemperature_protection:
       name: "mosfet overtemperature protection"
@@ -290,11 +290,11 @@ number:
     max_balance_current:
       name: "max balance current"
       device_id: device1
-    max_charge_current:
-      name: "max charge current"
+    max_charging_current:
+      name: "max charging current"
       device_id: device1
-    max_discharge_current:
-      name: "max discharge current"
+    max_discharging_current:
+      name: "max discharging current"
       device_id: device1
     smart_sleep_voltage:
       name: "smart sleep voltage"
@@ -317,17 +317,17 @@ number:
     cell_request_float_voltage_time:
       name: "cell request float voltage time"
       device_id: device1
-    charge_overcurrent_protection_delay:
-      name: "charge overcurrent protection delay"
+    charging_overcurrent_protection_delay:
+      name: "charging overcurrent protection delay"
       device_id: device1
-    charge_overcurrent_protection_recovery_time:
-      name: "charge overcurrent protection recovery time"
+    charging_overcurrent_protection_recovery_time:
+      name: "charging overcurrent protection recovery time"
       device_id: device1
-    discharge_overcurrent_protection_delay:
-      name: "discharge overcurrent protection delay"
+    discharging_overcurrent_protection_delay:
+      name: "discharging overcurrent protection delay"
       device_id: device1
-    discharge_overcurrent_protection_recovery_time:
-      name: "discharge overcurrent protection recovery time"
+    discharging_overcurrent_protection_recovery_time:
+      name: "discharging overcurrent protection recovery time"
       device_id: device1
     short_circuit_protection_delay:
       name: "short circuit protection delay"
@@ -335,29 +335,29 @@ number:
     short_circuit_protection_recovery_time:
       name: "short circuit protection recovery time"
       device_id: device1
-    charge_overtemperature_protection:
-      name: "charge overtemperature protection"
+    charging_overtemperature_protection:
+      name: "charging overtemperature protection"
       device_id: device1
-    charge_overtemperature_protection_recovery:
-      name: "charge overtemperature protection recovery"
+    charging_overtemperature_protection_recovery:
+      name: "charging overtemperature protection recovery"
       device_id: device1
-    discharge_overtemperature_protection:
-      name: "discharge overtemperature protection"
+    discharging_overtemperature_protection:
+      name: "discharging overtemperature protection"
       device_id: device1
-    discharge_overtemperature_protection_recovery:
-      name: "discharge overtemperature protection recovery"
+    discharging_overtemperature_protection_recovery:
+      name: "discharging overtemperature protection recovery"
       device_id: device1
-    charge_undertemperature_protection:
-      name: "charge undertemperature protection"
+    charging_undertemperature_protection:
+      name: "charging undertemperature protection"
       device_id: device1
-    charge_undertemperature_protection_recovery:
-      name: "charge undertemperature protection recovery"
+    charging_undertemperature_protection_recovery:
+      name: "charging undertemperature protection recovery"
       device_id: device1
-    discharge_undertemperature_protection:
-      name: "discharge undertemperature protection"
+    discharging_undertemperature_protection:
+      name: "discharging undertemperature protection"
       device_id: device1
-    discharge_undertemperature_protection_recovery:
-      name: "discharge undertemperature protection recovery"
+    discharging_undertemperature_protection_recovery:
+      name: "discharging undertemperature protection recovery"
       device_id: device1
     mosfet_overtemperature_protection:
       name: "mosfet overtemperature protection"

--- a/esp32-ble-v14-example.yaml
+++ b/esp32-ble-v14-example.yaml
@@ -116,10 +116,10 @@ number:
       name: "power off voltage"
     max_balance_current:
       name: "max balance current"
-    max_charge_current:
-      name: "max charge current"
-    max_discharge_current:
-      name: "max discharge current"
+    max_charging_current:
+      name: "max charging current"
+    max_discharging_current:
+      name: "max discharging current"
     smart_sleep_voltage:
       name: "smart sleep voltage"
     cell_soc100_voltage:
@@ -134,40 +134,40 @@ number:
       name: "cell request charge voltage time"
     cell_request_float_voltage_time:
       name: "cell request float voltage time"
-    charge_overcurrent_protection_delay:
-      name: "charge overcurrent protection delay"
-    charge_overcurrent_protection_recovery_time:
-      name: "charge overcurrent protection recovery time"
-    discharge_overcurrent_protection_delay:
-      name: "discharge overcurrent protection delay"
-    discharge_overcurrent_protection_recovery_time:
-      name: "discharge overcurrent protection recovery time"
+    charging_overcurrent_protection_delay:
+      name: "charging overcurrent protection delay"
+    charging_overcurrent_protection_recovery_time:
+      name: "charging overcurrent protection recovery time"
+    discharging_overcurrent_protection_delay:
+      name: "discharging overcurrent protection delay"
+    discharging_overcurrent_protection_recovery_time:
+      name: "discharging overcurrent protection recovery time"
     short_circuit_protection_delay:
       name: "short circuit protection delay"
     short_circuit_protection_recovery_time:
       name: "short circuit protection recovery time"
-    charge_overtemperature_protection:
-      name: "charge overtemperature protection"
-    charge_overtemperature_protection_recovery:
-      name: "charge overtemperature protection recovery"
-    discharge_overtemperature_protection:
-      name: "discharge overtemperature protection"
-    discharge_overtemperature_protection_recovery:
-      name: "discharge overtemperature protection recovery"
-    charge_undertemperature_protection:
-      name: "charge undertemperature protection"
-    charge_undertemperature_protection_recovery:
-      name: "charge undertemperature protection recovery"
-    discharge_undertemperature_protection:
-      name: "discharge undertemperature protection"
-    discharge_undertemperature_protection_recovery:
-      name: "discharge undertemperature protection recovery"
+    charging_overtemperature_protection:
+      name: "charging overtemperature protection"
+    charging_overtemperature_protection_recovery:
+      name: "charging overtemperature protection recovery"
+    discharging_overtemperature_protection:
+      name: "discharging overtemperature protection"
+    discharging_overtemperature_protection_recovery:
+      name: "discharging overtemperature protection recovery"
+    charging_undertemperature_protection:
+      name: "charging undertemperature protection"
+    charging_undertemperature_protection_recovery:
+      name: "charging undertemperature protection recovery"
+    discharging_undertemperature_protection:
+      name: "discharging undertemperature protection"
+    discharging_undertemperature_protection_recovery:
+      name: "discharging undertemperature protection recovery"
     mosfet_overtemperature_protection:
       name: "mosfet overtemperature protection"
     mosfet_overtemperature_protection_recovery:
       name: "mosfet overtemperature protection recovery"
-    discharge_precharge_time:
-      name: "discharge precharge time"
+    discharging_precharge_time:
+      name: "discharging precharge time"
 
 sensor:
   - platform: jk_bms_ble
@@ -324,10 +324,10 @@ sensor:
       name: "balancing current"
     emergency_time_countdown:
       name: "emergency time countdown"
-    charge_status_id:
-      name: "charge status id"
-    charge_status_time_elapsed:
-      name: "charge status time elapsed"
+    charging_status_id:
+      name: "charging status id"
+    charging_status_time_elapsed:
+      name: "charging status time elapsed"
     detail_log_count:
       name: "detail log count"
     battery_type_id:
@@ -370,8 +370,8 @@ text_sensor:
       name: "errors bitmask hex"
     total_runtime_formatted:
       name: "total runtime formatted"
-    charge_status:
-      name: "charge status"
+    charging_status:
+      name: "charging status"
     software_version:
       name: "software version"
     hardware_version:

--- a/esp32-ble-v15-example.yaml
+++ b/esp32-ble-v15-example.yaml
@@ -116,10 +116,10 @@ number:
       name: "power off voltage"
     max_balance_current:
       name: "max balance current"
-    max_charge_current:
-      name: "max charge current"
-    max_discharge_current:
-      name: "max discharge current"
+    max_charging_current:
+      name: "max charging current"
+    max_discharging_current:
+      name: "max discharging current"
     smart_sleep_voltage:
       name: "smart sleep voltage"
     cell_soc100_voltage:
@@ -134,40 +134,40 @@ number:
       name: "cell request charge voltage time"
     cell_request_float_voltage_time:
       name: "cell request float voltage time"
-    charge_overcurrent_protection_delay:
-      name: "charge overcurrent protection delay"
-    charge_overcurrent_protection_recovery_time:
-      name: "charge overcurrent protection recovery time"
-    discharge_overcurrent_protection_delay:
-      name: "discharge overcurrent protection delay"
-    discharge_overcurrent_protection_recovery_time:
-      name: "discharge overcurrent protection recovery time"
+    charging_overcurrent_protection_delay:
+      name: "charging overcurrent protection delay"
+    charging_overcurrent_protection_recovery_time:
+      name: "charging overcurrent protection recovery time"
+    discharging_overcurrent_protection_delay:
+      name: "discharging overcurrent protection delay"
+    discharging_overcurrent_protection_recovery_time:
+      name: "discharging overcurrent protection recovery time"
     short_circuit_protection_delay:
       name: "short circuit protection delay"
     short_circuit_protection_recovery_time:
       name: "short circuit protection recovery time"
-    charge_overtemperature_protection:
-      name: "charge overtemperature protection"
-    charge_overtemperature_protection_recovery:
-      name: "charge overtemperature protection recovery"
-    discharge_overtemperature_protection:
-      name: "discharge overtemperature protection"
-    discharge_overtemperature_protection_recovery:
-      name: "discharge overtemperature protection recovery"
-    charge_undertemperature_protection:
-      name: "charge undertemperature protection"
-    charge_undertemperature_protection_recovery:
-      name: "charge undertemperature protection recovery"
-    discharge_undertemperature_protection:
-      name: "discharge undertemperature protection"
-    discharge_undertemperature_protection_recovery:
-      name: "discharge undertemperature protection recovery"
+    charging_overtemperature_protection:
+      name: "charging overtemperature protection"
+    charging_overtemperature_protection_recovery:
+      name: "charging overtemperature protection recovery"
+    discharging_overtemperature_protection:
+      name: "discharging overtemperature protection"
+    discharging_overtemperature_protection_recovery:
+      name: "discharging overtemperature protection recovery"
+    charging_undertemperature_protection:
+      name: "charging undertemperature protection"
+    charging_undertemperature_protection_recovery:
+      name: "charging undertemperature protection recovery"
+    discharging_undertemperature_protection:
+      name: "discharging undertemperature protection"
+    discharging_undertemperature_protection_recovery:
+      name: "discharging undertemperature protection recovery"
     mosfet_overtemperature_protection:
       name: "mosfet overtemperature protection"
     mosfet_overtemperature_protection_recovery:
       name: "mosfet overtemperature protection recovery"
-    discharge_precharge_time:
-      name: "discharge precharge time"
+    discharging_precharge_time:
+      name: "discharging precharge time"
     heating_start_temperature:
       name: "heating start temperature"
     heating_stop_temperature:
@@ -328,10 +328,10 @@ sensor:
       name: "balancing current"
     emergency_time_countdown:
       name: "emergency time countdown"
-    charge_status_id:
-      name: "charge status id"
-    charge_status_time_elapsed:
-      name: "charge status time elapsed"
+    charging_status_id:
+      name: "charging status id"
+    charging_status_time_elapsed:
+      name: "charging status time elapsed"
     detail_log_count:
       name: "detail log count"
     battery_type_id:
@@ -374,8 +374,8 @@ text_sensor:
       name: "errors bitmask hex"
     total_runtime_formatted:
       name: "total runtime formatted"
-    charge_status:
-      name: "charge status"
+    charging_status:
+      name: "charging status"
     software_version:
       name: "software version"
     hardware_version:

--- a/esp32-ble-v19-example.yaml
+++ b/esp32-ble-v19-example.yaml
@@ -116,10 +116,10 @@ number:
       name: "power off voltage"
     max_balance_current:
       name: "max balance current"
-    max_charge_current:
-      name: "max charge current"
-    max_discharge_current:
-      name: "max discharge current"
+    max_charging_current:
+      name: "max charging current"
+    max_discharging_current:
+      name: "max discharging current"
     smart_sleep_voltage:
       name: "smart sleep voltage"
     cell_soc100_voltage:
@@ -136,40 +136,40 @@ number:
       name: "cell request float voltage time"
     re_bulk_soc:
       name: "re-bulk soc"
-    charge_overcurrent_protection_delay:
-      name: "charge overcurrent protection delay"
-    charge_overcurrent_protection_recovery_time:
-      name: "charge overcurrent protection recovery time"
-    discharge_overcurrent_protection_delay:
-      name: "discharge overcurrent protection delay"
-    discharge_overcurrent_protection_recovery_time:
-      name: "discharge overcurrent protection recovery time"
+    charging_overcurrent_protection_delay:
+      name: "charging overcurrent protection delay"
+    charging_overcurrent_protection_recovery_time:
+      name: "charging overcurrent protection recovery time"
+    discharging_overcurrent_protection_delay:
+      name: "discharging overcurrent protection delay"
+    discharging_overcurrent_protection_recovery_time:
+      name: "discharging overcurrent protection recovery time"
     short_circuit_protection_delay:
       name: "short circuit protection delay"
     short_circuit_protection_recovery_time:
       name: "short circuit protection recovery time"
-    charge_overtemperature_protection:
-      name: "charge overtemperature protection"
-    charge_overtemperature_protection_recovery:
-      name: "charge overtemperature protection recovery"
-    discharge_overtemperature_protection:
-      name: "discharge overtemperature protection"
-    discharge_overtemperature_protection_recovery:
-      name: "discharge overtemperature protection recovery"
-    charge_undertemperature_protection:
-      name: "charge undertemperature protection"
-    charge_undertemperature_protection_recovery:
-      name: "charge undertemperature protection recovery"
-    discharge_undertemperature_protection:
-      name: "discharge undertemperature protection"
-    discharge_undertemperature_protection_recovery:
-      name: "discharge undertemperature protection recovery"
+    charging_overtemperature_protection:
+      name: "charging overtemperature protection"
+    charging_overtemperature_protection_recovery:
+      name: "charging overtemperature protection recovery"
+    discharging_overtemperature_protection:
+      name: "discharging overtemperature protection"
+    discharging_overtemperature_protection_recovery:
+      name: "discharging overtemperature protection recovery"
+    charging_undertemperature_protection:
+      name: "charging undertemperature protection"
+    charging_undertemperature_protection_recovery:
+      name: "charging undertemperature protection recovery"
+    discharging_undertemperature_protection:
+      name: "discharging undertemperature protection"
+    discharging_undertemperature_protection_recovery:
+      name: "discharging undertemperature protection recovery"
     mosfet_overtemperature_protection:
       name: "mosfet overtemperature protection"
     mosfet_overtemperature_protection_recovery:
       name: "mosfet overtemperature protection recovery"
-    discharge_precharge_time:
-      name: "discharge precharge time"
+    discharging_precharge_time:
+      name: "discharging precharge time"
     heating_start_temperature:
       name: "heating start temperature"
     heating_stop_temperature:
@@ -330,10 +330,10 @@ sensor:
       name: "balancing current"
     emergency_time_countdown:
       name: "emergency time countdown"
-    charge_status_id:
-      name: "charge status id"
-    charge_status_time_elapsed:
-      name: "charge status time elapsed"
+    charging_status_id:
+      name: "charging status id"
+    charging_status_time_elapsed:
+      name: "charging status time elapsed"
     detail_log_count:
       name: "detail log count"
     battery_type_id:
@@ -376,8 +376,8 @@ text_sensor:
       name: "errors bitmask hex"
     total_runtime_formatted:
       name: "total runtime formatted"
-    charge_status:
-      name: "charge status"
+    charging_status:
+      name: "charging status"
     software_version:
       name: "software version"
     hardware_version:

--- a/tests/esp32-ble-b2a25s-example.yaml
+++ b/tests/esp32-ble-b2a25s-example.yaml
@@ -112,10 +112,10 @@ number:
       name: "power off voltage"
     max_balance_current:
       name: "max balance current"
-    max_charge_current:
-      name: "max charge current"
-    max_discharge_current:
-      name: "max discharge current"
+    max_charging_current:
+      name: "max charging current"
+    max_discharging_current:
+      name: "max discharging current"
     smart_sleep_voltage:
       name: "smart sleep voltage"
     cell_soc100_voltage:
@@ -130,14 +130,14 @@ number:
       name: "cell request charge voltage time"
     cell_request_float_voltage_time:
       name: "cell request float voltage time"
-    charge_overcurrent_protection_delay:
-      name: "charge overcurrent protection delay"
-    charge_overcurrent_protection_recovery_time:
-      name: "charge overcurrent protection recovery time"
-    discharge_overcurrent_protection_delay:
-      name: "discharge overcurrent protection delay"
-    discharge_overcurrent_protection_recovery_time:
-      name: "discharge overcurrent protection recovery time"
+    charging_overcurrent_protection_delay:
+      name: "charging overcurrent protection delay"
+    charging_overcurrent_protection_recovery_time:
+      name: "charging overcurrent protection recovery time"
+    discharging_overcurrent_protection_delay:
+      name: "discharging overcurrent protection delay"
+    discharging_overcurrent_protection_recovery_time:
+      name: "discharging overcurrent protection recovery time"
     short_circuit_protection_delay:
       name: "short circuit protection delay"
     short_circuit_protection_recovery_time:
@@ -316,10 +316,10 @@ sensor:
       name: "balancing current"
     emergency_time_countdown:
       name: "emergency time countdown"
-    charge_status_id:
-      name: "charge status id"
-    charge_status_time_elapsed:
-      name: "charge status time elapsed"
+    charging_status_id:
+      name: "charging status id"
+    charging_status_time_elapsed:
+      name: "charging status time elapsed"
 
 switch:
   - platform: jk_bms_ble
@@ -355,5 +355,5 @@ text_sensor:
       name: "errors bitmask hex"
     total_runtime_formatted:
       name: "total runtime formatted"
-    charge_status:
-      name: "charge status"
+    charging_status:
+      name: "charging status"

--- a/tests/test_component_schemas.py
+++ b/tests/test_component_schemas.py
@@ -160,7 +160,7 @@ class TestJkBleTextSensorConstants:
     def test_text_sensors_list(self):
         assert ble_text_sensor.CONF_ERRORS in ble_text_sensor.TEXT_SENSORS
         assert ble_text_sensor.CONF_OPERATION_STATUS in ble_text_sensor.TEXT_SENSORS
-        assert ble_text_sensor.CONF_CHARGE_STATUS in ble_text_sensor.TEXT_SENSORS
+        assert ble_text_sensor.CONF_CHARGING_STATUS in ble_text_sensor.TEXT_SENSORS
         assert ble_text_sensor.CONF_BATTERY_TYPE in ble_text_sensor.TEXT_SENSORS
         assert len(ble_text_sensor.TEXT_SENSORS) == 8
 


### PR DESCRIPTION
## Summary

Align the jk_bms_ble component with the gerund naming form already used by
jk_bms (`charging_power`, `discharging_power`, `charging_cycles`, …). The
mixed `charge_*` / `discharge_*` forms in `jk_bms_ble` numbers, sensors and
the `charge_status` text sensor are renamed to `charging_*` / `discharging_*`.

Renames (BLE-only):

- **Numbers**:
  - `max_charge_current` → `max_charging_current`
  - `max_discharge_current` → `max_discharging_current`
  - `charge_overcurrent_protection_delay` → `charging_overcurrent_protection_delay`
  - `charge_overcurrent_protection_recovery_time` → `charging_overcurrent_protection_recovery_time`
  - `discharge_overcurrent_protection_delay` → `discharging_overcurrent_protection_delay`
  - `discharge_overcurrent_protection_recovery_time` → `discharging_overcurrent_protection_recovery_time`
  - `charge_overtemperature_protection` → `charging_overtemperature_protection`
  - `charge_overtemperature_protection_recovery` → `charging_overtemperature_protection_recovery`
  - `discharge_overtemperature_protection` → `discharging_overtemperature_protection`
  - `discharge_overtemperature_protection_recovery` → `discharging_overtemperature_protection_recovery`
  - `charge_undertemperature_protection` → `charging_undertemperature_protection`
  - `charge_undertemperature_protection_recovery` → `charging_undertemperature_protection_recovery`
  - `discharge_undertemperature_protection` → `discharging_undertemperature_protection`
  - `discharge_undertemperature_protection_recovery` → `discharging_undertemperature_protection_recovery`
  - `discharge_precharge_time` → `discharging_precharge_time`
- **Sensors**:
  - `charge_status_id` → `charging_status_id`
  - `charge_status_time_elapsed` → `charging_status_time_elapsed`
- **Text sensors**:
  - `charge_status` → `charging_status`

Old config keys keep working through `_RENAMED_NUMBERS` /
`_RENAMED_SENSORS` / `_RENAMED_TEXT_SENSORS` and now emit a deprecation
warning at validation time (`text_sensor.py` gained a `deprecated_renames`
layer for this).

C++ headers, source, the schema unit test, and all BLE example YAMLs
(`esp32-ble-example.yaml`, `esp32-ble-v11/v14/v14-multi/v15/v19`,
`tests/esp32-ble-b2a25s-example.yaml`) have been updated alongside.

## Test plan

- [x] `esphome -s external_components_source components config <example>` succeeds on all six BLE example YAMLs
- [x] Old config keys (e.g. `charge_overtemperature_protection`, `charge_status`) still validate and produce a deprecation `WARNING`
- [x] `tests/test_component_schemas.py` still references the renamed `CONF_CHARGING_STATUS`