### PR TITLE
Rename UART temperature protection/recovery sensors

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,17 +189,17 @@ esphome run esp32-example.yaml
 [sensor:127]: 'jk-bms balancing start voltage': Sending state 3.30000 V with 3 decimals of accuracy
 [sensor:127]: 'jk-bms balance opening pressure difference': Sending state 0.01000 V with 3 decimals of accuracy
 [switch:045]: 'jk-bms balancing': Sending state ON
-[sensor:127]: 'jk-bms mosfet temperature protection': Sending state 90.00000 °C with 0 decimals of accuracy
-[sensor:127]: 'jk-bms mosfet temperature recovery': Sending state 70.00000 °C with 0 decimals of accuracy
+[sensor:127]: 'jk-bms mosfet overtemperature protection': Sending state 90.00000 °C with 0 decimals of accuracy
+[sensor:127]: 'jk-bms mosfet overtemperature recovery': Sending state 70.00000 °C with 0 decimals of accuracy
 [sensor:127]: 'jk-bms battery overtemperature protection': Sending state 100.00000 °C with 0 decimals of accuracy
 [sensor:127]: 'jk-bms battery overtemperature recovery': Sending state 100.00000 °C with 0 decimals of accuracy
 [sensor:127]: 'jk-bms battery temperature difference protection': Sending state 20.00000 °C with 0 decimals of accuracy
-[sensor:127]: 'jk-bms charging high temperature protection': Sending state 70.00000 °C with 0 decimals of accuracy
-[sensor:127]: 'jk-bms discharging high temperature protection': Sending state 70.00000 °C with 0 decimals of accuracy
-[sensor:127]: 'jk-bms charging low temperature protection': Sending state -20.00000 °C with 0 decimals of accuracy
-[sensor:127]: 'jk-bms charging low temperature recovery': Sending state -10.00000 °C with 0 decimals of accuracy
-[sensor:127]: 'jk-bms discharging low temperature protection': Sending state -20.00000 °C with 0 decimals of accuracy
-[sensor:127]: 'jk-bms discharging low temperature recovery': Sending state -10.00000 °C with 0 decimals of accuracy
+[sensor:127]: 'jk-bms charging overtemperature protection': Sending state 70.00000 °C with 0 decimals of accuracy
+[sensor:127]: 'jk-bms discharging overtemperature protection': Sending state 70.00000 °C with 0 decimals of accuracy
+[sensor:127]: 'jk-bms charging undertemperature protection': Sending state -20.00000 °C with 0 decimals of accuracy
+[sensor:127]: 'jk-bms charging undertemperature recovery': Sending state -10.00000 °C with 0 decimals of accuracy
+[sensor:127]: 'jk-bms discharging undertemperature protection': Sending state -20.00000 °C with 0 decimals of accuracy
+[sensor:127]: 'jk-bms discharging undertemperature recovery': Sending state -10.00000 °C with 0 decimals of accuracy
 [switch:045]: 'jk-bms charging': Sending state OFF
 [switch:045]: 'jk-bms discharging': Sending state OFF
 [sensor:127]: 'jk-bms current calibration': Sending state 0.72500 A with 3 decimals of accuracy

--- a/components/jk_bms/jk_bms.cpp
+++ b/components/jk_bms/jk_bms.cpp
@@ -298,8 +298,7 @@ void JkBms::on_status_data_(const std::vector<uint8_t> &data) {
   this->publish_state_(this->charging_overtemperature_protection_sensor_, (float) jk_get_16bit(offset + 8 + 3 * 30));
 
   // 0xA4 0x00 0x46: Battery discharge high temperature protection value    70°C            1.0 °C     0-100°C
-  this->publish_state_(this->discharging_overtemperature_protection_sensor_,
-                       (float) jk_get_16bit(offset + 8 + 3 * 31));
+  this->publish_state_(this->discharging_overtemperature_protection_sensor_, (float) jk_get_16bit(offset + 8 + 3 * 31));
 
   // 0xA5 0xFF 0xEC: Charging low temperature protection value             -20°C            1.0 °C     -45...25°C
   this->publish_state_(this->charging_undertemperature_protection_sensor_,

--- a/components/jk_bms/jk_bms.cpp
+++ b/components/jk_bms/jk_bms.cpp
@@ -279,10 +279,10 @@ void JkBms::on_status_data_(const std::vector<uint8_t> &data) {
   this->publish_state_(this->balancer_switch_, (bool) data[offset + 6 + 3 * 25]);
 
   // 0x9E 0x00 0x5A: Power tube temperature protection value                90°C            1.0 °C     0-100°C
-  this->publish_state_(this->mosfet_temperature_protection_sensor_, (float) jk_get_16bit(offset + 8 + 3 * 25));
+  this->publish_state_(this->mosfet_overtemperature_protection_sensor_, (float) jk_get_16bit(offset + 8 + 3 * 25));
 
   // 0x9F 0x00 0x46: Power tube temperature recovery value                  70°C            1.0 °C     0-100°C
-  this->publish_state_(this->mosfet_temperature_recovery_sensor_, (float) jk_get_16bit(offset + 8 + 3 * 26));
+  this->publish_state_(this->mosfet_overtemperature_recovery_sensor_, (float) jk_get_16bit(offset + 8 + 3 * 26));
 
   // 0xA0 0x00 0x64: Temperature protection value in the battery box       100°C            1.0 °C     40-100°C
   this->publish_state_(this->battery_overtemperature_protection_sensor_, (float) jk_get_16bit(offset + 8 + 3 * 27));
@@ -295,26 +295,26 @@ void JkBms::on_status_data_(const std::vector<uint8_t> &data) {
                        (float) jk_get_16bit(offset + 8 + 3 * 29));
 
   // 0xA3 0x00 0x46: Battery charging high temperature protection value     70°C            1.0 °C     0-100°C
-  this->publish_state_(this->charging_high_temperature_protection_sensor_, (float) jk_get_16bit(offset + 8 + 3 * 30));
+  this->publish_state_(this->charging_overtemperature_protection_sensor_, (float) jk_get_16bit(offset + 8 + 3 * 30));
 
   // 0xA4 0x00 0x46: Battery discharge high temperature protection value    70°C            1.0 °C     0-100°C
-  this->publish_state_(this->discharging_high_temperature_protection_sensor_,
+  this->publish_state_(this->discharging_overtemperature_protection_sensor_,
                        (float) jk_get_16bit(offset + 8 + 3 * 31));
 
   // 0xA5 0xFF 0xEC: Charging low temperature protection value             -20°C            1.0 °C     -45...25°C
-  this->publish_state_(this->charging_low_temperature_protection_sensor_,
+  this->publish_state_(this->charging_undertemperature_protection_sensor_,
                        (float) (int16_t) jk_get_16bit(offset + 8 + 3 * 32));
 
   // 0xA6 0xFF 0xF6: Charging low temperature protection recovery value    -10°C            1.0 °C     -45...25°C
-  this->publish_state_(this->charging_low_temperature_recovery_sensor_,
+  this->publish_state_(this->charging_undertemperature_recovery_sensor_,
                        (float) (int16_t) jk_get_16bit(offset + 8 + 3 * 33));
 
   // 0xA7 0xFF 0xEC: Discharge low temperature protection value            -20°C            1.0 °C     -45...25°C
-  this->publish_state_(this->discharging_low_temperature_protection_sensor_,
+  this->publish_state_(this->discharging_undertemperature_protection_sensor_,
                        (float) (int16_t) jk_get_16bit(offset + 8 + 3 * 34));
 
   // 0xA8 0xFF 0xF6: Discharge low temperature protection recovery value   -10°C            1.0 °C     -45...25°C
-  this->publish_state_(this->discharging_low_temperature_recovery_sensor_,
+  this->publish_state_(this->discharging_undertemperature_recovery_sensor_,
                        (float) (int16_t) jk_get_16bit(offset + 8 + 3 * 35));
 
   // 0xA9 0x0E: Battery string setting                                      14              1.0 count
@@ -458,17 +458,17 @@ void JkBms::publish_device_unavailable_() {
   this->publish_state_(charging_overcurrent_delay_sensor_, NAN);
   this->publish_state_(balancing_start_voltage_sensor_, NAN);
   this->publish_state_(balancing_delta_voltage_sensor_, NAN);
-  this->publish_state_(mosfet_temperature_protection_sensor_, NAN);
-  this->publish_state_(mosfet_temperature_recovery_sensor_, NAN);
+  this->publish_state_(mosfet_overtemperature_protection_sensor_, NAN);
+  this->publish_state_(mosfet_overtemperature_recovery_sensor_, NAN);
   this->publish_state_(battery_overtemperature_protection_sensor_, NAN);
   this->publish_state_(battery_overtemperature_recovery_sensor_, NAN);
   this->publish_state_(battery_temperature_difference_protection_sensor_, NAN);
-  this->publish_state_(charging_high_temperature_protection_sensor_, NAN);
-  this->publish_state_(discharging_high_temperature_protection_sensor_, NAN);
-  this->publish_state_(charging_low_temperature_protection_sensor_, NAN);
-  this->publish_state_(charging_low_temperature_recovery_sensor_, NAN);
-  this->publish_state_(discharging_low_temperature_protection_sensor_, NAN);
-  this->publish_state_(discharging_low_temperature_recovery_sensor_, NAN);
+  this->publish_state_(charging_overtemperature_protection_sensor_, NAN);
+  this->publish_state_(discharging_overtemperature_protection_sensor_, NAN);
+  this->publish_state_(charging_undertemperature_protection_sensor_, NAN);
+  this->publish_state_(charging_undertemperature_recovery_sensor_, NAN);
+  this->publish_state_(discharging_undertemperature_protection_sensor_, NAN);
+  this->publish_state_(discharging_undertemperature_recovery_sensor_, NAN);
   this->publish_state_(full_charge_capacity_sensor_, NAN);
   this->publish_state_(charging_sensor_, NAN);
   this->publish_state_(discharging_sensor_, NAN);
@@ -628,17 +628,17 @@ void JkBms::dump_config() {  // NOLINT(google-readability-function-size,readabil
   LOG_SENSOR("", "Charging Overcurrent Delay", this->charging_overcurrent_delay_sensor_);
   LOG_SENSOR("", "Balancing Start Voltage", this->balancing_start_voltage_sensor_);
   LOG_SENSOR("", "Balancing Delta Voltage", this->balancing_delta_voltage_sensor_);
-  LOG_SENSOR("", "Mosfet Temperature Protection", this->mosfet_temperature_protection_sensor_);
-  LOG_SENSOR("", "Mosfet Temperature Recovery", this->mosfet_temperature_recovery_sensor_);
+  LOG_SENSOR("", "Mosfet Overtemperature Protection", this->mosfet_overtemperature_protection_sensor_);
+  LOG_SENSOR("", "Mosfet Overtemperature Recovery", this->mosfet_overtemperature_recovery_sensor_);
   LOG_SENSOR("", "Battery Overtemperature Protection", this->battery_overtemperature_protection_sensor_);
   LOG_SENSOR("", "Battery Overtemperature Recovery", this->battery_overtemperature_recovery_sensor_);
   LOG_SENSOR("", "Battery Temperature Difference Protection", this->battery_temperature_difference_protection_sensor_);
-  LOG_SENSOR("", "Charging High Temperature Protection", this->charging_high_temperature_protection_sensor_);
-  LOG_SENSOR("", "Discharging High Temperature Protection", this->discharging_high_temperature_protection_sensor_);
-  LOG_SENSOR("", "Charging Low Temperature Protection", this->charging_low_temperature_protection_sensor_);
-  LOG_SENSOR("", "Charging Low Temperature Recovery", this->charging_low_temperature_recovery_sensor_);
-  LOG_SENSOR("", "Discharging Low Temperature Protection", this->discharging_low_temperature_protection_sensor_);
-  LOG_SENSOR("", "Discharging Low Temperature Recovery", this->discharging_low_temperature_recovery_sensor_);
+  LOG_SENSOR("", "Charging Overtemperature Protection", this->charging_overtemperature_protection_sensor_);
+  LOG_SENSOR("", "Discharging Overtemperature Protection", this->discharging_overtemperature_protection_sensor_);
+  LOG_SENSOR("", "Charging Undertemperature Protection", this->charging_undertemperature_protection_sensor_);
+  LOG_SENSOR("", "Charging Undertemperature Recovery", this->charging_undertemperature_recovery_sensor_);
+  LOG_SENSOR("", "Discharging Undertemperature Protection", this->discharging_undertemperature_protection_sensor_);
+  LOG_SENSOR("", "Discharging Undertemperature Recovery", this->discharging_undertemperature_recovery_sensor_);
   LOG_SENSOR("", "Full Charge Capacity", this->full_charge_capacity_sensor_);
   LOG_SENSOR("", "Current Calibration", this->current_calibration_sensor_);
   LOG_SENSOR("", "Device Address", this->device_address_sensor_);

--- a/components/jk_bms/jk_bms.h
+++ b/components/jk_bms/jk_bms.h
@@ -142,11 +142,11 @@ class JkBms : public PollingComponent, public jk_modbus::JkModbusDevice {
   void set_balancing_delta_voltage_sensor(sensor::Sensor *balancing_delta_voltage_sensor) {
     balancing_delta_voltage_sensor_ = balancing_delta_voltage_sensor;
   }
-  void set_mosfet_temperature_protection_sensor(sensor::Sensor *mosfet_temperature_protection_sensor) {
-    mosfet_temperature_protection_sensor_ = mosfet_temperature_protection_sensor;
+  void set_mosfet_overtemperature_protection_sensor(sensor::Sensor *mosfet_overtemperature_protection_sensor) {
+    mosfet_overtemperature_protection_sensor_ = mosfet_overtemperature_protection_sensor;
   }
-  void set_mosfet_temperature_recovery_sensor(sensor::Sensor *mosfet_temperature_recovery_sensor) {
-    mosfet_temperature_recovery_sensor_ = mosfet_temperature_recovery_sensor;
+  void set_mosfet_overtemperature_recovery_sensor(sensor::Sensor *mosfet_overtemperature_recovery_sensor) {
+    mosfet_overtemperature_recovery_sensor_ = mosfet_overtemperature_recovery_sensor;
   }
   void set_battery_overtemperature_protection_sensor(sensor::Sensor *battery_overtemperature_protection_sensor) {
     battery_overtemperature_protection_sensor_ = battery_overtemperature_protection_sensor;
@@ -158,25 +158,25 @@ class JkBms : public PollingComponent, public jk_modbus::JkModbusDevice {
       sensor::Sensor *battery_temperature_difference_protection_sensor) {
     battery_temperature_difference_protection_sensor_ = battery_temperature_difference_protection_sensor;
   }
-  void set_charging_high_temperature_protection_sensor(sensor::Sensor *charging_high_temperature_protection_sensor) {
-    charging_high_temperature_protection_sensor_ = charging_high_temperature_protection_sensor;
+  void set_charging_overtemperature_protection_sensor(sensor::Sensor *charging_overtemperature_protection_sensor) {
+    charging_overtemperature_protection_sensor_ = charging_overtemperature_protection_sensor;
   }
-  void set_discharging_high_temperature_protection_sensor(
-      sensor::Sensor *discharging_high_temperature_protection_sensor) {
-    discharging_high_temperature_protection_sensor_ = discharging_high_temperature_protection_sensor;
+  void set_discharging_overtemperature_protection_sensor(
+      sensor::Sensor *discharging_overtemperature_protection_sensor) {
+    discharging_overtemperature_protection_sensor_ = discharging_overtemperature_protection_sensor;
   }
-  void set_charging_low_temperature_protection_sensor(sensor::Sensor *charging_low_temperature_protection_sensor) {
-    charging_low_temperature_protection_sensor_ = charging_low_temperature_protection_sensor;
+  void set_charging_undertemperature_protection_sensor(sensor::Sensor *charging_undertemperature_protection_sensor) {
+    charging_undertemperature_protection_sensor_ = charging_undertemperature_protection_sensor;
   }
-  void set_charging_low_temperature_recovery_sensor(sensor::Sensor *charging_low_temperature_recovery_sensor) {
-    charging_low_temperature_recovery_sensor_ = charging_low_temperature_recovery_sensor;
+  void set_charging_undertemperature_recovery_sensor(sensor::Sensor *charging_undertemperature_recovery_sensor) {
+    charging_undertemperature_recovery_sensor_ = charging_undertemperature_recovery_sensor;
   }
-  void set_discharging_low_temperature_protection_sensor(
-      sensor::Sensor *discharging_low_temperature_protection_sensor) {
-    discharging_low_temperature_protection_sensor_ = discharging_low_temperature_protection_sensor;
+  void set_discharging_undertemperature_protection_sensor(
+      sensor::Sensor *discharging_undertemperature_protection_sensor) {
+    discharging_undertemperature_protection_sensor_ = discharging_undertemperature_protection_sensor;
   }
-  void set_discharging_low_temperature_recovery_sensor(sensor::Sensor *discharging_low_temperature_recovery_sensor) {
-    discharging_low_temperature_recovery_sensor_ = discharging_low_temperature_recovery_sensor;
+  void set_discharging_undertemperature_recovery_sensor(sensor::Sensor *discharging_undertemperature_recovery_sensor) {
+    discharging_undertemperature_recovery_sensor_ = discharging_undertemperature_recovery_sensor;
   }
   void set_full_charge_capacity_sensor(sensor::Sensor *full_charge_capacity_sensor) {
     full_charge_capacity_sensor_ = full_charge_capacity_sensor;
@@ -285,17 +285,17 @@ class JkBms : public PollingComponent, public jk_modbus::JkModbusDevice {
   sensor::Sensor *charging_overcurrent_delay_sensor_{nullptr};
   sensor::Sensor *balancing_start_voltage_sensor_{nullptr};
   sensor::Sensor *balancing_delta_voltage_sensor_{nullptr};
-  sensor::Sensor *mosfet_temperature_protection_sensor_{nullptr};
-  sensor::Sensor *mosfet_temperature_recovery_sensor_{nullptr};
+  sensor::Sensor *mosfet_overtemperature_protection_sensor_{nullptr};
+  sensor::Sensor *mosfet_overtemperature_recovery_sensor_{nullptr};
   sensor::Sensor *battery_overtemperature_protection_sensor_{nullptr};
   sensor::Sensor *battery_overtemperature_recovery_sensor_{nullptr};
   sensor::Sensor *battery_temperature_difference_protection_sensor_{nullptr};
-  sensor::Sensor *charging_high_temperature_protection_sensor_{nullptr};
-  sensor::Sensor *discharging_high_temperature_protection_sensor_{nullptr};
-  sensor::Sensor *charging_low_temperature_protection_sensor_{nullptr};
-  sensor::Sensor *charging_low_temperature_recovery_sensor_{nullptr};
-  sensor::Sensor *discharging_low_temperature_protection_sensor_{nullptr};
-  sensor::Sensor *discharging_low_temperature_recovery_sensor_{nullptr};
+  sensor::Sensor *charging_overtemperature_protection_sensor_{nullptr};
+  sensor::Sensor *discharging_overtemperature_protection_sensor_{nullptr};
+  sensor::Sensor *charging_undertemperature_protection_sensor_{nullptr};
+  sensor::Sensor *charging_undertemperature_recovery_sensor_{nullptr};
+  sensor::Sensor *discharging_undertemperature_protection_sensor_{nullptr};
+  sensor::Sensor *discharging_undertemperature_recovery_sensor_{nullptr};
   sensor::Sensor *full_charge_capacity_sensor_{nullptr};
   sensor::Sensor *charging_sensor_{nullptr};
   sensor::Sensor *discharging_sensor_{nullptr};

--- a/components/jk_bms/sensor.py
+++ b/components/jk_bms/sensor.py
@@ -75,8 +75,8 @@ CONF_CHARGING_OVERCURRENT_DELAY = "charging_overcurrent_delay"
 CONF_BALANCING_START_VOLTAGE = "balancing_start_voltage"
 CONF_BALANCING_DELTA_VOLTAGE = "balancing_delta_voltage"
 
-CONF_MOSFET_TEMPERATURE_PROTECTION = "mosfet_temperature_protection"
-CONF_MOSFET_TEMPERATURE_RECOVERY = "mosfet_temperature_recovery"
+CONF_MOSFET_OVERTEMPERATURE_PROTECTION = "mosfet_overtemperature_protection"
+CONF_MOSFET_OVERTEMPERATURE_RECOVERY = "mosfet_overtemperature_recovery"
 
 CONF_BATTERY_OVERTEMPERATURE_PROTECTION = "battery_overtemperature_protection"
 CONF_BATTERY_OVERTEMPERATURE_RECOVERY = "battery_overtemperature_recovery"
@@ -84,13 +84,13 @@ CONF_BATTERY_TEMPERATURE_DIFFERENCE_PROTECTION = (
     "battery_temperature_difference_protection"
 )
 
-CONF_CHARGING_HIGH_TEMPERATURE_PROTECTION = "charging_high_temperature_protection"
-CONF_DISCHARGING_HIGH_TEMPERATURE_PROTECTION = "discharging_high_temperature_protection"
+CONF_CHARGING_OVERTEMPERATURE_PROTECTION = "charging_overtemperature_protection"
+CONF_DISCHARGING_OVERTEMPERATURE_PROTECTION = "discharging_overtemperature_protection"
 
-CONF_CHARGING_LOW_TEMPERATURE_PROTECTION = "charging_low_temperature_protection"
-CONF_CHARGING_LOW_TEMPERATURE_RECOVERY = "charging_low_temperature_recovery"
-CONF_DISCHARGING_LOW_TEMPERATURE_PROTECTION = "discharging_low_temperature_protection"
-CONF_DISCHARGING_LOW_TEMPERATURE_RECOVERY = "discharging_low_temperature_recovery"
+CONF_CHARGING_UNDERTEMPERATURE_PROTECTION = "charging_undertemperature_protection"
+CONF_CHARGING_UNDERTEMPERATURE_RECOVERY = "charging_undertemperature_recovery"
+CONF_DISCHARGING_UNDERTEMPERATURE_PROTECTION = "discharging_undertemperature_protection"
+CONF_DISCHARGING_UNDERTEMPERATURE_RECOVERY = "discharging_undertemperature_recovery"
 
 # r/w
 # CONF_CELL_COUNT = "cell_count"
@@ -394,14 +394,14 @@ SENSOR_DEFS = {
         "device_class": DEVICE_CLASS_VOLTAGE,
         "state_class": STATE_CLASS_MEASUREMENT,
     },
-    CONF_MOSFET_TEMPERATURE_PROTECTION: {
+    CONF_MOSFET_OVERTEMPERATURE_PROTECTION: {
         "unit_of_measurement": UNIT_CELSIUS,
         "icon": ICON_EMPTY,
         "accuracy_decimals": 0,
         "device_class": DEVICE_CLASS_TEMPERATURE,
         "state_class": STATE_CLASS_MEASUREMENT,
     },
-    CONF_MOSFET_TEMPERATURE_RECOVERY: {
+    CONF_MOSFET_OVERTEMPERATURE_RECOVERY: {
         "unit_of_measurement": UNIT_CELSIUS,
         "icon": ICON_EMPTY,
         "accuracy_decimals": 0,
@@ -429,42 +429,42 @@ SENSOR_DEFS = {
         "device_class": DEVICE_CLASS_TEMPERATURE,
         "state_class": STATE_CLASS_MEASUREMENT,
     },
-    CONF_CHARGING_HIGH_TEMPERATURE_PROTECTION: {
+    CONF_CHARGING_OVERTEMPERATURE_PROTECTION: {
         "unit_of_measurement": UNIT_CELSIUS,
         "icon": ICON_EMPTY,
         "accuracy_decimals": 0,
         "device_class": DEVICE_CLASS_TEMPERATURE,
         "state_class": STATE_CLASS_MEASUREMENT,
     },
-    CONF_DISCHARGING_HIGH_TEMPERATURE_PROTECTION: {
+    CONF_DISCHARGING_OVERTEMPERATURE_PROTECTION: {
         "unit_of_measurement": UNIT_CELSIUS,
         "icon": ICON_EMPTY,
         "accuracy_decimals": 0,
         "device_class": DEVICE_CLASS_TEMPERATURE,
         "state_class": STATE_CLASS_MEASUREMENT,
     },
-    CONF_CHARGING_LOW_TEMPERATURE_PROTECTION: {
+    CONF_CHARGING_UNDERTEMPERATURE_PROTECTION: {
         "unit_of_measurement": UNIT_CELSIUS,
         "icon": ICON_EMPTY,
         "accuracy_decimals": 0,
         "device_class": DEVICE_CLASS_TEMPERATURE,
         "state_class": STATE_CLASS_MEASUREMENT,
     },
-    CONF_CHARGING_LOW_TEMPERATURE_RECOVERY: {
+    CONF_CHARGING_UNDERTEMPERATURE_RECOVERY: {
         "unit_of_measurement": UNIT_CELSIUS,
         "icon": ICON_EMPTY,
         "accuracy_decimals": 0,
         "device_class": DEVICE_CLASS_TEMPERATURE,
         "state_class": STATE_CLASS_MEASUREMENT,
     },
-    CONF_DISCHARGING_LOW_TEMPERATURE_PROTECTION: {
+    CONF_DISCHARGING_UNDERTEMPERATURE_PROTECTION: {
         "unit_of_measurement": UNIT_CELSIUS,
         "icon": ICON_EMPTY,
         "accuracy_decimals": 0,
         "device_class": DEVICE_CLASS_TEMPERATURE,
         "state_class": STATE_CLASS_MEASUREMENT,
     },
-    CONF_DISCHARGING_LOW_TEMPERATURE_RECOVERY: {
+    CONF_DISCHARGING_UNDERTEMPERATURE_RECOVERY: {
         "unit_of_measurement": UNIT_CELSIUS,
         "icon": ICON_EMPTY,
         "accuracy_decimals": 0,
@@ -553,8 +553,16 @@ _RENAMED_SENSORS = {
     "temperature_sensors": "temperature_sensor_count",
     "total_battery_capacity_setting": "full_charge_capacity",
     "power_tube_temperature": "mosfet_temperature",
-    "power_tube_temperature_protection": "mosfet_temperature_protection",
-    "power_tube_temperature_recovery": "mosfet_temperature_recovery",
+    "power_tube_temperature_protection": "mosfet_overtemperature_protection",
+    "power_tube_temperature_recovery": "mosfet_overtemperature_recovery",
+    "mosfet_temperature_protection": "mosfet_overtemperature_protection",
+    "mosfet_temperature_recovery": "mosfet_overtemperature_recovery",
+    "charging_high_temperature_protection": "charging_overtemperature_protection",
+    "discharging_high_temperature_protection": "discharging_overtemperature_protection",
+    "charging_low_temperature_protection": "charging_undertemperature_protection",
+    "charging_low_temperature_recovery": "charging_undertemperature_recovery",
+    "discharging_low_temperature_protection": "discharging_undertemperature_protection",
+    "discharging_low_temperature_recovery": "discharging_undertemperature_recovery",
     "temperature_sensor_temperature_protection": "battery_overtemperature_protection",
     "temperature_sensor_temperature_recovery": "battery_overtemperature_recovery",
     "temperature_sensor_temperature_difference_protection": "battery_temperature_difference_protection",

--- a/esp32-example.yaml
+++ b/esp32-example.yaml
@@ -199,28 +199,28 @@ sensor:
       name: "balancing start voltage"
     balancing_delta_voltage:
       name: "balance opening pressure difference"
-    mosfet_temperature_protection:
-      name: "mosfet temperature protection"
-    mosfet_temperature_recovery:
-      name: "mosfet temperature recovery"
+    mosfet_overtemperature_protection:
+      name: "mosfet overtemperature protection"
+    mosfet_overtemperature_recovery:
+      name: "mosfet overtemperature recovery"
     battery_overtemperature_protection:
       name: "battery overtemperature protection"
     battery_overtemperature_recovery:
       name: "battery overtemperature recovery"
     battery_temperature_difference_protection:
       name: "battery temperature difference protection"
-    charging_high_temperature_protection:
-      name: "charging high temperature protection"
-    discharging_high_temperature_protection:
-      name: "discharging high temperature protection"
-    charging_low_temperature_protection:
-      name: "charging low temperature protection"
-    charging_low_temperature_recovery:
-      name: "charging low temperature recovery"
-    discharging_low_temperature_protection:
-      name: "discharging low temperature protection"
-    discharging_low_temperature_recovery:
-      name: "discharging low temperature recovery"
+    charging_overtemperature_protection:
+      name: "charging overtemperature protection"
+    discharging_overtemperature_protection:
+      name: "discharging overtemperature protection"
+    charging_undertemperature_protection:
+      name: "charging undertemperature protection"
+    charging_undertemperature_recovery:
+      name: "charging undertemperature recovery"
+    discharging_undertemperature_protection:
+      name: "discharging undertemperature protection"
+    discharging_undertemperature_recovery:
+      name: "discharging undertemperature recovery"
     full_charge_capacity:
       name: "full charge capacity"
     current_calibration:

--- a/esp8266-example.yaml
+++ b/esp8266-example.yaml
@@ -198,28 +198,28 @@ sensor:
       name: "balancing start voltage"
     balancing_delta_voltage:
       name: "balance opening pressure difference"
-    mosfet_temperature_protection:
-      name: "mosfet temperature protection"
-    mosfet_temperature_recovery:
-      name: "mosfet temperature recovery"
+    mosfet_overtemperature_protection:
+      name: "mosfet overtemperature protection"
+    mosfet_overtemperature_recovery:
+      name: "mosfet overtemperature recovery"
     battery_overtemperature_protection:
       name: "battery overtemperature protection"
     battery_overtemperature_recovery:
       name: "battery overtemperature recovery"
     battery_temperature_difference_protection:
       name: "battery temperature difference protection"
-    charging_high_temperature_protection:
-      name: "charging high temperature protection"
-    discharging_high_temperature_protection:
-      name: "discharging high temperature protection"
-    charging_low_temperature_protection:
-      name: "charging low temperature protection"
-    charging_low_temperature_recovery:
-      name: "charging low temperature recovery"
-    discharging_low_temperature_protection:
-      name: "discharging low temperature protection"
-    discharging_low_temperature_recovery:
-      name: "discharging low temperature recovery"
+    charging_overtemperature_protection:
+      name: "charging overtemperature protection"
+    discharging_overtemperature_protection:
+      name: "discharging overtemperature protection"
+    charging_undertemperature_protection:
+      name: "charging undertemperature protection"
+    charging_undertemperature_recovery:
+      name: "charging undertemperature recovery"
+    discharging_undertemperature_protection:
+      name: "discharging undertemperature protection"
+    discharging_undertemperature_recovery:
+      name: "discharging undertemperature recovery"
     full_charge_capacity:
       name: "full charge capacity"
     current_calibration:

--- a/lovelace-entities-card.yaml
+++ b/lovelace-entities-card.yaml
@@ -64,11 +64,11 @@ entities:
     name: Cell Voltage Undervoltage Recovery
   - entity: sensor.jk_bms_charging_cycles
     name: Charging Cycles
-  - entity: sensor.jk_bms_charging_high_temperature_protection
+  - entity: sensor.jk_bms_charging_overtemperature_protection
     name: Charging High Temperature Protection
-  - entity: sensor.jk_bms_charging_low_temperature_protection
+  - entity: sensor.jk_bms_charging_undertemperature_protection
     name: Charging Low Temperature Protection
-  - entity: sensor.jk_bms_charging_low_temperature_recovery
+  - entity: sensor.jk_bms_charging_undertemperature_recovery
     name: Charging Low Temperature Recovery
   - entity: sensor.jk_bms_charging_overcurrent_delay
     name: Charging Overcurrent Delay
@@ -82,11 +82,11 @@ entities:
     name: Device Address
   - entity: sensor.jk_bms_device_type
     name: Device Type
-  - entity: sensor.jk_bms_discharging_high_temperature_protection
+  - entity: sensor.jk_bms_discharging_overtemperature_protection
     name: Discharging High Temperature Protection
-  - entity: sensor.jk_bms_discharging_low_temperature_protection
+  - entity: sensor.jk_bms_discharging_undertemperature_protection
     name: Discharging Low Temperature Protection
-  - entity: sensor.jk_bms_discharging_low_temperature_recovery
+  - entity: sensor.jk_bms_discharging_undertemperature_recovery
     name: Discharging Low Temperature Recovery
   - entity: sensor.jk_bms_discharging_overcurrent_delay
     name: Discharging Overcurrent Delay
@@ -108,9 +108,9 @@ entities:
     name: Password
   - entity: sensor.jk_bms_mosfet_temperature
     name: Mosfet Temperature
-  - entity: sensor.jk_bms_mosfet_temperature_protection
+  - entity: sensor.jk_bms_mosfet_overtemperature_protection
     name: Mosfet Temperature Protection
-  - entity: sensor.jk_bms_mosfet_temperature_recovery
+  - entity: sensor.jk_bms_mosfet_overtemperature_recovery
     name: Mosfet Temperature Recovery
   - entity: sensor.jk_bms_sleep_wait_time
     name: Sleep Wait Time

--- a/tests/components/jk_bms/common.h
+++ b/tests/components/jk_bms/common.h
@@ -182,11 +182,11 @@ static const std::vector<uint8_t> STATUS_FRAME_14S = {
     // bytes 125-126: balancing switch = on
     0x9D,
     0x01,
-    // bytes 127-129: mosfet temperature protection = 90°C
+    // bytes 127-129: mosfet overtemperature protection = 90°C
     0x9E,
     0x00,
     0x5A,
-    // bytes 130-132: mosfet temperature recovery = 70°C
+    // bytes 130-132: mosfet overtemperature recovery = 70°C
     0x9F,
     0x00,
     0x46,
@@ -202,27 +202,27 @@ static const std::vector<uint8_t> STATUS_FRAME_14S = {
     0xA2,
     0x00,
     0x14,
-    // bytes 142-144: charging high temperature protection = 70°C
+    // bytes 142-144: charging overtemperature protection = 70°C
     0xA3,
     0x00,
     0x46,
-    // bytes 145-147: discharging high temperature protection = 70°C
+    // bytes 145-147: discharging overtemperature protection = 70°C
     0xA4,
     0x00,
     0x46,
-    // bytes 148-150: charging low temperature protection = (int16_t)0xFFEC = -20°C
+    // bytes 148-150: charging undertemperature protection = (int16_t)0xFFEC = -20°C
     0xA5,
     0xFF,
     0xEC,
-    // bytes 151-153: charging low temperature recovery = (int16_t)0xFFF6 = -10°C
+    // bytes 151-153: charging undertemperature recovery = (int16_t)0xFFF6 = -10°C
     0xA6,
     0xFF,
     0xF6,
-    // bytes 154-156: discharging low temperature protection = -20°C
+    // bytes 154-156: discharging undertemperature protection = -20°C
     0xA7,
     0xFF,
     0xEC,
-    // bytes 157-159: discharging low temperature recovery = -10°C
+    // bytes 157-159: discharging undertemperature recovery = -10°C
     0xA8,
     0xFF,
     0xF6,


### PR DESCRIPTION
## Summary

Disambiguate the `jk_bms` temperature sensor names that were either misleading
or inconsistent with the equivalents already used in `jk_bms_ble`.

Renames (UART-only):

- `mosfet_temperature_protection` → `mosfet_overtemperature_protection`
- `mosfet_temperature_recovery` → `mosfet_overtemperature_recovery`
- `charging_high_temperature_protection` → `charging_overtemperature_protection`
- `discharging_high_temperature_protection` → `discharging_overtemperature_protection`
- `charging_low_temperature_protection` → `charging_undertemperature_protection`
- `charging_low_temperature_recovery` → `charging_undertemperature_recovery`
- `discharging_low_temperature_protection` → `discharging_undertemperature_protection`
- `discharging_low_temperature_recovery` → `discharging_undertemperature_recovery`

`mosfet_temperature_protection` in particular suggested a generic temperature
limit while in fact carrying the over-temperature threshold (the BMS exposes
both a protection threshold and a recovery threshold). The new names mirror
the `over`/`undertemperature` wording already used by `jk_bms_ble`.

Old config keys keep working through `_RENAMED_SENSORS` and emit a deprecation
`WARNING` at validation time. The existing
`power_tube_temperature_protection`/`_recovery` aliases (left over from the
earlier `power_tube_*` → `mosfet_*` rename) are repointed to the new keys.

C++ header/source identifiers, log labels, the `esp32-example.yaml` /
`esp8266-example.yaml` examples, the Lovelace card (entity IDs and friendly
names), README log snippets and `tests/components/jk_bms/common.h` comments
are updated alongside.

## Test plan

- [x] `esphome -s external_components_source components config esp32-example.yaml` succeeds
- [x] `esphome -s external_components_source components config esp8266-example.yaml` succeeds
- [x] Old keys (e.g. `mosfet_temperature_protection`, `charging_high_temperature_protection`) still validate and produce a deprecation `WARNING`