### PR TITLE
BREAKING: Remove deprecated charging_switch and discharging_switch binary sensors

### DIFF
--- a/components/jk_bms/binary_sensor.py
+++ b/components/jk_bms/binary_sensor.py
@@ -10,30 +10,20 @@ DEPENDENCIES = ["jk_bms"]
 
 CODEOWNERS = ["@syssi"]
 
-CONF_CHARGING_SWITCH = (
-    "charging_switch"  # @DEPRECATED and superseded by switch.charging
-)
-CONF_DISCHARGING_SWITCH = (
-    "discharging_switch"  # @DEPRECATED and superseded by switch.discharging
-)
 CONF_BALANCING = "balancing"
 CONF_BALANCING_SWITCH = "balancing_switch"
 CONF_DEDICATED_CHARGER_SWITCH = "dedicated_charger_switch"
 CONF_ONLINE_STATUS = "online_status"
 
 ICON_CHARGING = "mdi:battery-charging"
-ICON_CHARGING_SWITCH = "mdi:battery-charging"
 ICON_DISCHARGING = "mdi:power-plug"
-ICON_DISCHARGING_SWITCH = "mdi:power-plug"
 ICON_BALANCING = "mdi:battery-heart-variant"
 ICON_BALANCING_SWITCH = "mdi:battery-heart-variant"
 ICON_DEDICATED_CHARGER_SWITCH = "mdi:battery-charging"
 
 BINARY_SENSOR_DEFS = {
     CONF_CHARGING: {"icon": ICON_CHARGING},
-    CONF_CHARGING_SWITCH: {"icon": ICON_CHARGING_SWITCH},
     CONF_DISCHARGING: {"icon": ICON_DISCHARGING},
-    CONF_DISCHARGING_SWITCH: {"icon": ICON_DISCHARGING_SWITCH},
     CONF_BALANCING: {"icon": ICON_BALANCING},
     CONF_BALANCING_SWITCH: {"icon": ICON_BALANCING_SWITCH},
     CONF_DEDICATED_CHARGER_SWITCH: {"icon": ICON_DEDICATED_CHARGER_SWITCH},
@@ -47,6 +37,15 @@ CONFIG_SCHEMA = JK_BMS_COMPONENT_SCHEMA.extend(
     {
         cv.Optional(key): binary_sensor.binary_sensor_schema(**kwargs)
         for key, kwargs in BINARY_SENSOR_DEFS.items()
+    }
+).extend(
+    {
+        cv.Optional("charging_switch"): cv.invalid(
+            "binary_sensor.charging_switch has been removed; use switch.charging instead"
+        ),
+        cv.Optional("discharging_switch"): cv.invalid(
+            "binary_sensor.discharging_switch has been removed; use switch.discharging instead"
+        ),
     }
 )
 

--- a/components/jk_bms/jk_bms.cpp
+++ b/components/jk_bms/jk_bms.cpp
@@ -324,11 +324,9 @@ void JkBms::on_status_data_(const std::vector<uint8_t> &data) {
   this->publish_state_(this->capacity_remaining_sensor_, (float) (raw_full_charge_capacity * (raw_soc * 0.01f)));
 
   // 0xAB 0x01: Charging MOS tube switch                                     1 (on)         Bool       0 (off), 1 (on)
-  this->publish_state_(this->charging_switch_binary_sensor_, (bool) data[offset + 15 + 3 * 36]);
   this->publish_state_(this->charging_switch_, (bool) data[offset + 15 + 3 * 36]);
 
   // 0xAC 0x01: Discharge MOS tube switch                                    1 (on)         Bool       0 (off), 1 (on)
-  this->publish_state_(this->discharging_switch_binary_sensor_, (bool) data[offset + 17 + 3 * 36]);
   this->publish_state_(this->discharging_switch_, (bool) data[offset + 17 + 3 * 36]);
 
   // 0xAD 0x04 0x11: Current calibration                       1041mA * 0.001 = 1.041A     0.001 A     0.1-2.0A
@@ -561,9 +559,7 @@ void JkBms::dump_config() {  // NOLINT(google-readability-function-size,readabil
   LOG_BINARY_SENSOR("", "Balancing", this->balancing_binary_sensor_);
   LOG_BINARY_SENSOR("", "Balancing Switch", this->balancing_switch_binary_sensor_);
   LOG_BINARY_SENSOR("", "Charging", this->charging_binary_sensor_);
-  LOG_BINARY_SENSOR("", "Charging Switch", this->charging_switch_binary_sensor_);
   LOG_BINARY_SENSOR("", "Discharging", this->discharging_binary_sensor_);
-  LOG_BINARY_SENSOR("", "Discharging Switch", this->discharging_switch_binary_sensor_);
   LOG_BINARY_SENSOR("", "Dedicated Charger Switch", this->dedicated_charger_switch_binary_sensor_);
   LOG_BINARY_SENSOR("", "Online Status", this->online_status_binary_sensor_);
   LOG_SENSOR("", "Minimum Cell Voltage", this->min_cell_voltage_sensor_);

--- a/components/jk_bms/jk_bms.h
+++ b/components/jk_bms/jk_bms.h
@@ -20,14 +20,8 @@ class JkBms : public PollingComponent, public jk_modbus::JkModbusDevice {
   void set_charging_binary_sensor(binary_sensor::BinarySensor *charging_binary_sensor) {
     charging_binary_sensor_ = charging_binary_sensor;
   }
-  void set_charging_switch_binary_sensor(binary_sensor::BinarySensor *charging_switch_binary_sensor) {
-    charging_switch_binary_sensor_ = charging_switch_binary_sensor;
-  }
   void set_discharging_binary_sensor(binary_sensor::BinarySensor *discharging_binary_sensor) {
     discharging_binary_sensor_ = discharging_binary_sensor;
-  }
-  void set_discharging_switch_binary_sensor(binary_sensor::BinarySensor *discharging_switch_binary_sensor) {
-    discharging_switch_binary_sensor_ = discharging_switch_binary_sensor;
   }
   void set_dedicated_charger_switch_binary_sensor(binary_sensor::BinarySensor *dedicated_charger_switch_binary_sensor) {
     dedicated_charger_switch_binary_sensor_ = dedicated_charger_switch_binary_sensor;
@@ -242,9 +236,7 @@ class JkBms : public PollingComponent, public jk_modbus::JkModbusDevice {
   binary_sensor::BinarySensor *balancing_binary_sensor_{nullptr};
   binary_sensor::BinarySensor *balancing_switch_binary_sensor_{nullptr};
   binary_sensor::BinarySensor *charging_binary_sensor_{nullptr};
-  binary_sensor::BinarySensor *charging_switch_binary_sensor_{nullptr};
   binary_sensor::BinarySensor *discharging_binary_sensor_{nullptr};
-  binary_sensor::BinarySensor *discharging_switch_binary_sensor_{nullptr};
   binary_sensor::BinarySensor *dedicated_charger_switch_binary_sensor_{nullptr};
   binary_sensor::BinarySensor *online_status_binary_sensor_{nullptr};
 

--- a/tests/components/jk_bms/common.h
+++ b/tests/components/jk_bms/common.h
@@ -2,8 +2,13 @@
 #include <cstdint>
 #include <vector>
 #include "esphome/components/jk_bms/jk_bms.h"
+#include "esphome/components/switch/switch.h"
 
 namespace esphome::jk_bms::testing {
+
+struct TestSwitch : switch_::Switch {
+  void write_state(bool) override {}
+};
 
 class TestableJkBms : public JkBms {
  public:

--- a/tests/components/jk_bms/jk_bms_test.cpp
+++ b/tests/components/jk_bms/jk_bms_test.cpp
@@ -162,9 +162,10 @@ TEST(JkBmsStatusDataTest, OperationModes) {
 
 TEST(JkBmsStatusDataTest, SwitchStates) {
   TestableJkBms bms;
-  binary_sensor::BinarySensor charging_sw, discharging_sw, balancing_sw;
-  bms.set_charging_switch_binary_sensor(&charging_sw);
-  bms.set_discharging_switch_binary_sensor(&discharging_sw);
+  TestSwitch charging_sw, discharging_sw;
+  binary_sensor::BinarySensor balancing_sw;
+  bms.set_charging_switch(&charging_sw);
+  bms.set_discharging_switch(&discharging_sw);
   bms.set_balancing_switch_binary_sensor(&balancing_sw);
 
   bms.on_jk_modbus_data(FUNCTION_READ_ALL, STATUS_FRAME_14S);

--- a/tests/test_component_schemas.py
+++ b/tests/test_component_schemas.py
@@ -78,7 +78,7 @@ class TestJkBmsBinarySensorConstants:
         assert CONF_DISCHARGING in binary_sensor.BINARY_SENSOR_DEFS
         assert binary_sensor.CONF_BALANCING in binary_sensor.BINARY_SENSOR_DEFS
         assert binary_sensor.CONF_ONLINE_STATUS in binary_sensor.BINARY_SENSOR_DEFS
-        assert len(binary_sensor.BINARY_SENSOR_DEFS) == 8
+        assert len(binary_sensor.BINARY_SENSOR_DEFS) == 6
 
 
 class TestJkBmsTextSensorConstants:


### PR DESCRIPTION
## Breaking Change

`binary_sensor.charging_switch` and `binary_sensor.discharging_switch` are removed from the `jk_bms` component. Configs that still use them will now fail at validation time with a clear error message.

## Migration

| Removed | Replace with |
|---------|-------------|
| `binary_sensor.charging_switch` | `switch.charging` |
| `binary_sensor.discharging_switch` | `switch.discharging` |

## Changes

- `binary_sensor.py`: removed both keys from `BINARY_SENSOR_DEFS`; added `cv.invalid` entries that point to the switch replacements
- `jk_bms.h`: removed `set_charging_switch_binary_sensor` / `set_discharging_switch_binary_sensor` setters and their member variables
- `jk_bms.cpp`: removed `publish_state_` and `LOG_BINARY_SENSOR` calls for both removed members
- `tests/test_component_schemas.py`: updated expected `BINARY_SENSOR_DEFS` size from 8 → 6

## Background

A `binary_sensor` with `_switch` in its name suggests controllability that does not exist. The actual switch entities (`switch.charging`, `switch.discharging`) supersede these and have been available for some time.

`balancing_switch` and `dedicated_charger_switch` are out of scope for this PR.