### PR TITLE
Rename low_soc_alarm sensor to low_soc_alarm_threshold

### DIFF
--- a/components/jk_bms/jk_bms.cpp
+++ b/components/jk_bms/jk_bms.cpp
@@ -348,7 +348,7 @@ void JkBms::on_status_data_(const std::vector<uint8_t> &data) {
   this->publish_state_(this->sleep_wait_time_sensor_, (float) jk_get_16bit(offset + 23 + 3 * 37));
 
   // 0xB1 0x14: Low volume alarm                                             20%            1.0 %      0-80%
-  this->publish_state_(this->low_soc_alarm_sensor_, (float) data[offset + 23 + 3 * 38]);
+  this->publish_state_(this->low_soc_alarm_threshold_sensor_, (float) data[offset + 23 + 3 * 38]);
 
   // 0xB2 0x31 0x32 0x33 0x34 0x35 0x36 0x00 0x00 0x00 0x00: Modify parameter password
   auto password_begin = data.begin() + offset + 25 + 3 * 38;
@@ -472,7 +472,7 @@ void JkBms::publish_device_unavailable_() {
   this->publish_state_(current_calibration_sensor_, NAN);
   this->publish_state_(device_address_sensor_, NAN);
   this->publish_state_(sleep_wait_time_sensor_, NAN);
-  this->publish_state_(low_soc_alarm_sensor_, NAN);
+  this->publish_state_(low_soc_alarm_threshold_sensor_, NAN);
   this->publish_state_(password_sensor_, NAN);
   this->publish_state_(manufacturing_date_sensor_, NAN);
   this->publish_state_(total_runtime_sensor_, NAN);
@@ -639,7 +639,7 @@ void JkBms::dump_config() {  // NOLINT(google-readability-function-size,readabil
   LOG_SENSOR("", "Device Address", this->device_address_sensor_);
   LOG_TEXT_SENSOR("", "Battery Type", this->battery_type_text_sensor_);
   LOG_SENSOR("", "Sleep Wait Time", this->sleep_wait_time_sensor_);
-  LOG_SENSOR("", "Low SOC Alarm", this->low_soc_alarm_sensor_);
+  LOG_SENSOR("", "Low SOC Alarm", this->low_soc_alarm_threshold_sensor_);
   LOG_TEXT_SENSOR("", "Password", this->password_text_sensor_);
   LOG_TEXT_SENSOR("", "Device Type", this->device_type_text_sensor_);
   LOG_SENSOR("", "Manufacturing Date", this->manufacturing_date_sensor_);

--- a/components/jk_bms/jk_bms.h
+++ b/components/jk_bms/jk_bms.h
@@ -184,7 +184,9 @@ class JkBms : public PollingComponent, public jk_modbus::JkModbusDevice {
   void set_sleep_wait_time_sensor(sensor::Sensor *sleep_wait_time_sensor) {
     sleep_wait_time_sensor_ = sleep_wait_time_sensor;
   }
-  void set_low_soc_alarm_sensor(sensor::Sensor *low_soc_alarm_sensor) { low_soc_alarm_sensor_ = low_soc_alarm_sensor; }
+  void set_low_soc_alarm_threshold_sensor(sensor::Sensor *low_soc_alarm_threshold_sensor) {
+    low_soc_alarm_threshold_sensor_ = low_soc_alarm_threshold_sensor;
+  }
   void set_manufacturing_date_sensor(sensor::Sensor *manufacturing_date_sensor) {
     manufacturing_date_sensor_ = manufacturing_date_sensor;
   }
@@ -294,7 +296,7 @@ class JkBms : public PollingComponent, public jk_modbus::JkModbusDevice {
   sensor::Sensor *current_calibration_sensor_{nullptr};
   sensor::Sensor *device_address_sensor_{nullptr};
   sensor::Sensor *sleep_wait_time_sensor_{nullptr};
-  sensor::Sensor *low_soc_alarm_sensor_{nullptr};
+  sensor::Sensor *low_soc_alarm_threshold_sensor_{nullptr};
   sensor::Sensor *password_sensor_{nullptr};
   sensor::Sensor *manufacturing_date_sensor_{nullptr};
   sensor::Sensor *total_runtime_sensor_{nullptr};

--- a/components/jk_bms/sensor.py
+++ b/components/jk_bms/sensor.py
@@ -99,7 +99,7 @@ CONF_FULL_CHARGE_CAPACITY = "full_charge_capacity"
 CONF_CURRENT_CALIBRATION = "current_calibration"
 CONF_DEVICE_ADDRESS = "device_address"
 CONF_SLEEP_WAIT_TIME = "sleep_wait_time"
-CONF_LOW_SOC_ALARM = "low_soc_alarm"
+CONF_LOW_SOC_ALARM_THRESHOLD = "low_soc_alarm_threshold"
 CONF_MANUFACTURING_DATE = "manufacturing_date"
 CONF_TOTAL_RUNTIME = "total_runtime"
 CONF_START_CURRENT_CALIBRATION = "start_current_calibration"
@@ -119,7 +119,7 @@ ICON_DEVICE_ADDRESS = "mdi:identifier"
 ICON_ERRORS_BITMASK = "mdi:alert-circle-outline"
 ICON_OPERATION_MODE_BITMASK = "mdi:heart-pulse"
 ICON_CHARGING_CYCLES = "mdi:battery-sync"
-ICON_LOW_SOC_ALARM = "mdi:battery-alert"
+ICON_LOW_SOC_ALARM_THRESHOLD = "mdi:battery-alert"
 
 UNIT_SECONDS = "s"
 UNIT_HOURS = "h"
@@ -499,9 +499,9 @@ SENSOR_DEFS = {
         "device_class": DEVICE_CLASS_EMPTY,
         "state_class": STATE_CLASS_MEASUREMENT,
     },
-    CONF_LOW_SOC_ALARM: {
+    CONF_LOW_SOC_ALARM_THRESHOLD: {
         "unit_of_measurement": UNIT_PERCENT,
-        "icon": ICON_LOW_SOC_ALARM,
+        "icon": ICON_LOW_SOC_ALARM_THRESHOLD,
         "accuracy_decimals": 0,
         "device_class": DEVICE_CLASS_EMPTY,
         "state_class": STATE_CLASS_MEASUREMENT,
@@ -546,7 +546,7 @@ SENSOR_DEFS = {
 _RENAMED_SENSORS = {
     "cell_pressure_difference_protection": "cell_voltage_difference_protection",
     "balance_opening_pressure_difference": "balancing_delta_voltage",
-    "alarm_low_volume": "low_soc_alarm",
+    "alarm_low_volume": "low_soc_alarm_threshold",
     "capacity_remaining": "state_of_charge",
     "capacity_remaining_derived": "capacity_remaining",
     "battery_strings": "cell_count",

--- a/esp32-example.yaml
+++ b/esp32-example.yaml
@@ -229,7 +229,7 @@ sensor:
       name: "device address"
     sleep_wait_time:
       name: "sleep wait time"
-    low_soc_alarm:
+    low_soc_alarm_threshold:
       name: "alarm low volume"
     manufacturing_date:
       name: "manufacturing date"

--- a/esp32-example.yaml
+++ b/esp32-example.yaml
@@ -230,7 +230,7 @@ sensor:
     sleep_wait_time:
       name: "sleep wait time"
     low_soc_alarm_threshold:
-      name: "alarm low volume"
+      name: "Low SOC alarm threshold"
     manufacturing_date:
       name: "manufacturing date"
     total_runtime:

--- a/esp8266-example.yaml
+++ b/esp8266-example.yaml
@@ -228,7 +228,7 @@ sensor:
       name: "device address"
     sleep_wait_time:
       name: "sleep wait time"
-    low_soc_alarm:
+    low_soc_alarm_threshold:
       name: "alarm low volume"
     manufacturing_date:
       name: "manufacturing date"

--- a/esp8266-example.yaml
+++ b/esp8266-example.yaml
@@ -229,7 +229,7 @@ sensor:
     sleep_wait_time:
       name: "sleep wait time"
     low_soc_alarm_threshold:
-      name: "alarm low volume"
+      name: "Low SOC alarm threshold"
     manufacturing_date:
       name: "manufacturing date"
     total_runtime:

--- a/lovelace-entities-card.yaml
+++ b/lovelace-entities-card.yaml
@@ -40,7 +40,7 @@ entities:
     name: Capacity Remaining
   - entity: sensor.jk_bms_actual_battery_capacity
     name: Battery Capacity
-  - entity: sensor.jk_bms_low_soc_alarm
+  - entity: sensor.jk_bms_low_soc_alarm_threshold
     name: Alarm Low Volume
   - entity: sensor.jk_bms_balancing_delta_voltage
     name: Balance Opening Pressure Difference

--- a/tests/components/jk_bms/common.h
+++ b/tests/components/jk_bms/common.h
@@ -260,7 +260,7 @@ static const std::vector<uint8_t> STATUS_FRAME_14S = {
     0xB0,
     0x00,
     0x0A,
-    // bytes 181-182: low_soc_alarm = 20 %
+    // bytes 181-182: low_soc_alarm_threshold = 20 %
     0xB1,
     0x14,
     // bytes 183-193: password = "123456" (10 bytes, null-padded)

--- a/tests/components/jk_bms/jk_bms_test.cpp
+++ b/tests/components/jk_bms/jk_bms_test.cpp
@@ -196,12 +196,12 @@ TEST(JkBmsStatusDataTest, BatteryInfo) {
 
 TEST(JkBmsStatusDataTest, LowSocAlarm) {
   TestableJkBms bms;
-  sensor::Sensor low_soc_alarm;
-  bms.set_low_soc_alarm_sensor(&low_soc_alarm);
+  sensor::Sensor low_soc_alarm_threshold;
+  bms.set_low_soc_alarm_threshold_sensor(&low_soc_alarm_threshold);
 
   bms.on_jk_modbus_data(FUNCTION_READ_ALL, STATUS_FRAME_14S);
 
-  EXPECT_FLOAT_EQ(low_soc_alarm.state, 20.0f);  // 0x14 = 20 %
+  EXPECT_FLOAT_EQ(low_soc_alarm_threshold.state, 20.0f);  // 0x14 = 20 %
 }
 
 // ── Version and runtime ──────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- `sensor.low_soc_alarm` → `sensor.low_soc_alarm_threshold`

The sensor publishes a configured percentage threshold (e.g. 20 %), not a boolean alarm state. The old name was misleading because it implied a live alarm condition.

## Scope

Updated in all 8 affected files: `sensor.py`, `jk_bms.h`, `jk_bms.cpp`, `esp32-example.yaml`, `esp8266-example.yaml`, `lovelace-entities-card.yaml`, and the unit test. The `_RENAMED_SENSORS` migration entry for the legacy `alarm_low_volume` key is updated to point to the new name.