### PR TITLE
Rename detail_log_count to detail_log_entry_count

### DIFF
--- a/components/jk_bms_ble/jk_bms_ble.cpp
+++ b/components/jk_bms_ble/jk_bms_ble.cpp
@@ -699,7 +699,7 @@ void JkBmsBle::decode_jk02_cell_info_(const std::vector<uint8_t> &data) {
                          (float) ((int16_t) jk_get_16bit(226 + offset)) * 0.1f);
 
     // 234+32  4   0x3E 0x00 0x00 0x00    Detail log count     1
-    this->publish_state_(this->detail_log_count_sensor_, (float) jk_get_32bit(234 + offset));
+    this->publish_state_(this->detail_log_entry_count_sensor_, (float) jk_get_32bit(234 + offset));
 
     // 243+32  1   0x00                   Battery type code    0=LFP, 1=Li-ion, 2=LTO
     this->publish_state_(this->battery_type_id_sensor_, (float) data[243 + offset]);

--- a/components/jk_bms_ble/jk_bms_ble.h
+++ b/components/jk_bms_ble/jk_bms_ble.h
@@ -268,8 +268,8 @@ class JkBmsBle :
   void set_charge_status_time_elapsed_sensor(sensor::Sensor *charge_status_time_elapsed_sensor) {
     charge_status_time_elapsed_sensor_ = charge_status_time_elapsed_sensor;
   }
-  void set_detail_log_count_sensor(sensor::Sensor *detail_log_count_sensor) {
-    detail_log_count_sensor_ = detail_log_count_sensor;
+  void set_detail_log_entry_count_sensor(sensor::Sensor *detail_log_entry_count_sensor) {
+    detail_log_entry_count_sensor_ = detail_log_entry_count_sensor;
   }
   void set_battery_type_id_sensor(sensor::Sensor *battery_type_id_sensor) {
     battery_type_id_sensor_ = battery_type_id_sensor;
@@ -414,7 +414,7 @@ class JkBmsBle :
   sensor::Sensor *heating_current_sensor_{nullptr};
   sensor::Sensor *charge_status_id_sensor_{nullptr};
   sensor::Sensor *charge_status_time_elapsed_sensor_{nullptr};
-  sensor::Sensor *detail_log_count_sensor_{nullptr};
+  sensor::Sensor *detail_log_entry_count_sensor_{nullptr};
   sensor::Sensor *battery_type_id_sensor_{nullptr};
 
   switch_::Switch *charging_switch_{nullptr};

--- a/components/jk_bms_ble/sensor.py
+++ b/components/jk_bms_ble/sensor.py
@@ -56,7 +56,7 @@ CONF_EMERGENCY_TIME_COUNTDOWN = "emergency_time_countdown"
 CONF_HEATING_CURRENT = "heating_current"
 CONF_CHARGE_STATUS_ID = "charge_status_id"
 CONF_CHARGE_STATUS_TIME_ELAPSED = "charge_status_time_elapsed"
-CONF_DETAIL_LOG_COUNT = "detail_log_count"
+CONF_DETAIL_LOG_ENTRY_COUNT = "detail_log_entry_count"
 CONF_BATTERY_TYPE_ID = "battery_type_id"
 CONF_BALANCER_STATUS = "balancer_status"
 
@@ -274,7 +274,7 @@ SENSOR_DEFS = {
         "accuracy_decimals": 0,
         "device_class": DEVICE_CLASS_EMPTY,
     },
-    CONF_DETAIL_LOG_COUNT: {
+    CONF_DETAIL_LOG_ENTRY_COUNT: {
         "unit_of_measurement": UNIT_EMPTY,
         "icon": ICON_COUNTER,
         "accuracy_decimals": 0,
@@ -294,6 +294,7 @@ _RENAMED_SENSORS = {
     "balancing": "balancer_status",
     "total_battery_capacity_setting": "full_charge_capacity",
     "power_tube_temperature": "mosfet_temperature",
+    "detail_log_count": "detail_log_entry_count",
 }
 
 CONFIG_SCHEMA = cv.All(

--- a/esp32-ble-v11-example.yaml
+++ b/esp32-ble-v11-example.yaml
@@ -313,7 +313,7 @@ sensor:
     emergency_time_countdown:
       name: "emergency time countdown"
     detail_log_entry_count:
-      name: "Detail log entry count"
+      name: "detail log entry count"
 
 switch:
   - platform: jk_bms_ble

--- a/esp32-ble-v11-example.yaml
+++ b/esp32-ble-v11-example.yaml
@@ -312,8 +312,8 @@ sensor:
       name: "balancing current"
     emergency_time_countdown:
       name: "emergency time countdown"
-    detail_log_count:
-      name: "detail log count"
+    detail_log_entry_count:
+      name: "Detail log entry count"
 
 switch:
   - platform: jk_bms_ble

--- a/esp32-ble-v14-example-multiple-devices.yaml
+++ b/esp32-ble-v14-example-multiple-devices.yaml
@@ -595,8 +595,8 @@ sensor:
     emergency_time_countdown:
       name: "emergency time countdown"
       device_id: device0
-    detail_log_count:
-      name: "detail log count"
+    detail_log_entry_count:
+      name: "Detail log entry count"
       device_id: device0
     # ...
 
@@ -827,8 +827,8 @@ sensor:
     emergency_time_countdown:
       name: "emergency time countdown"
       device_id: device1
-    detail_log_count:
-      name: "detail log count"
+    detail_log_entry_count:
+      name: "Detail log entry count"
       device_id: device1
     # ...
 

--- a/esp32-ble-v14-example-multiple-devices.yaml
+++ b/esp32-ble-v14-example-multiple-devices.yaml
@@ -596,7 +596,7 @@ sensor:
       name: "emergency time countdown"
       device_id: device0
     detail_log_entry_count:
-      name: "Detail log entry count"
+      name: "detail log entry count"
       device_id: device0
     # ...
 
@@ -828,7 +828,7 @@ sensor:
       name: "emergency time countdown"
       device_id: device1
     detail_log_entry_count:
-      name: "Detail log entry count"
+      name: "detail log entry count"
       device_id: device1
     # ...
 

--- a/esp32-ble-v14-example.yaml
+++ b/esp32-ble-v14-example.yaml
@@ -328,8 +328,8 @@ sensor:
       name: "charge status id"
     charge_status_time_elapsed:
       name: "charge status time elapsed"
-    detail_log_count:
-      name: "detail log count"
+    detail_log_entry_count:
+      name: "Detail log entry count"
     battery_type_id:
       name: "battery type id"
 switch:

--- a/esp32-ble-v14-example.yaml
+++ b/esp32-ble-v14-example.yaml
@@ -329,7 +329,7 @@ sensor:
     charge_status_time_elapsed:
       name: "charge status time elapsed"
     detail_log_entry_count:
-      name: "Detail log entry count"
+      name: "detail log entry count"
     battery_type_id:
       name: "battery type id"
 switch:

--- a/esp32-ble-v15-example.yaml
+++ b/esp32-ble-v15-example.yaml
@@ -332,8 +332,8 @@ sensor:
       name: "charge status id"
     charge_status_time_elapsed:
       name: "charge status time elapsed"
-    detail_log_count:
-      name: "detail log count"
+    detail_log_entry_count:
+      name: "Detail log entry count"
     battery_type_id:
       name: "battery type id"
 switch:

--- a/esp32-ble-v15-example.yaml
+++ b/esp32-ble-v15-example.yaml
@@ -333,7 +333,7 @@ sensor:
     charge_status_time_elapsed:
       name: "charge status time elapsed"
     detail_log_entry_count:
-      name: "Detail log entry count"
+      name: "detail log entry count"
     battery_type_id:
       name: "battery type id"
 switch:

--- a/esp32-ble-v19-example.yaml
+++ b/esp32-ble-v19-example.yaml
@@ -334,8 +334,8 @@ sensor:
       name: "charge status id"
     charge_status_time_elapsed:
       name: "charge status time elapsed"
-    detail_log_count:
-      name: "detail log count"
+    detail_log_entry_count:
+      name: "Detail log entry count"
     battery_type_id:
       name: "battery type id"
 switch:

--- a/esp32-ble-v19-example.yaml
+++ b/esp32-ble-v19-example.yaml
@@ -335,7 +335,7 @@ sensor:
     charge_status_time_elapsed:
       name: "charge status time elapsed"
     detail_log_entry_count:
-      name: "Detail log entry count"
+      name: "detail log entry count"
     battery_type_id:
       name: "battery type id"
 switch:

--- a/tests/components/jk_bms_ble/jk_bms_ble_jk02_32s_v19_test.cpp
+++ b/tests/components/jk_bms_ble/jk_bms_ble_jk02_32s_v19_test.cpp
@@ -114,10 +114,10 @@ TEST(JkBmsV19CellInfoTest, MosfetState) {
 TEST(JkBmsV19CellInfoTest, DetailLogCount) {
   TestableJkBmsBle bms;
   bms.set_protocol_version(PROTOCOL_VERSION_JK02_32S);
-  sensor::Sensor detail_log_count;
-  bms.set_detail_log_count_sensor(&detail_log_count);
+  sensor::Sensor detail_log_entry_count;
+  bms.set_detail_log_entry_count_sensor(&detail_log_entry_count);
   bms.decode_jk02_cell_info_(CELL_INFO_JK02_32S_V19);
-  EXPECT_FLOAT_EQ(detail_log_count.state, 62.0f);
+  EXPECT_FLOAT_EQ(detail_log_entry_count.state, 62.0f);
 }
 
 TEST(JkBmsV19CellInfoTest, BatteryTypeCode) {

--- a/tests/test_component_schemas.py
+++ b/tests/test_component_schemas.py
@@ -116,7 +116,7 @@ class TestJkBmsBleSensorLists:
         assert "total_voltage" in ble_sensor.SENSOR_DEFS
         assert "full_charge_capacity" in ble_sensor.SENSOR_DEFS
         assert "balancer_status" in ble_sensor.SENSOR_DEFS
-        assert "detail_log_count" in ble_sensor.SENSOR_DEFS
+        assert "detail_log_entry_count" in ble_sensor.SENSOR_DEFS
         assert "battery_type_id" in ble_sensor.SENSOR_DEFS
         assert len(ble_sensor.SENSOR_DEFS) == 27
 


### PR DESCRIPTION
## Summary

- `sensor.detail_log_count` → `sensor.detail_log_entry_count`

The old name was ambiguous — count of *what*? The new name makes clear it is the number of entries in the detail log.

## Migration

The old key `detail_log_count` is kept as a deprecated alias via `_RENAMED_SENSORS`. ESPHome will emit a deprecation warning and auto-migrate the key at config validation time — no manual changes required.

## Scope

10 files changed: `sensor.py` (rename + deprecation entry), `jk_bms_ble.h`, `jk_bms_ble.cpp`, 5 example YAMLs (key + display name), unit test, schema test.