### PR TITLE
Refactor balancer status sensors for JK02/JK04 protocol parity

### DIFF
--- a/components/jk_bms_ble/jk_bms_ble.cpp
+++ b/components/jk_bms_ble/jk_bms_ble.cpp
@@ -164,7 +164,7 @@ void JkBmsBle::dump_config() {  // NOLINT(google-readability-function-size,reada
   LOG_SENSOR("", "Temperature Sensor 3", this->temperatures_[2].temperature_sensor_);
   LOG_SENSOR("", "Temperature Sensor 4", this->temperatures_[3].temperature_sensor_);
   LOG_SENSOR("", "Temperature Sensor 5", this->temperatures_[4].temperature_sensor_);
-  LOG_SENSOR("", "Balancing", this->balancer_status_sensor_);
+  LOG_SENSOR("", "Balancer Status Bitmask", this->balancer_status_bitmask_sensor_);
   LOG_SENSOR("", "State Of Charge", this->state_of_charge_sensor_);
   LOG_SENSOR("", "State Of Health", this->state_of_health_sensor_);
   LOG_SENSOR("", "Capacity Remaining", this->capacity_remaining_sensor_);
@@ -179,7 +179,7 @@ void JkBmsBle::dump_config() {  // NOLINT(google-readability-function-size,reada
   LOG_SENSOR("", "Charge Status Time Elapsed", this->charge_status_time_elapsed_sensor_);
   LOG_SENSOR("", "Battery Type ID", this->battery_type_id_sensor_);
 
-  LOG_TEXT_SENSOR("", "Operation Status", this->operation_status_text_sensor_);
+  LOG_TEXT_SENSOR("", "Balancer Status", this->balancer_status_text_sensor_);
   LOG_TEXT_SENSOR("", "Total Runtime Formatted", this->total_runtime_formatted_text_sensor_);
   LOG_TEXT_SENSOR("", "Errors", this->errors_text_sensor_);
   LOG_TEXT_SENSOR("", "Errors Bitmask Hex", this->errors_bitmask_hex_text_sensor_);
@@ -599,8 +599,9 @@ void JkBmsBle::decode_jk02_cell_info_(const std::vector<uint8_t> &data) {
   // 140   1   0x00                   Balancing action                   0x00: Off
   //                                                                     0x01: Charging balancer
   //                                                                     0x02: Discharging balancer
-  this->publish_state_(this->balancer_status_sensor_, (data[140 + offset]));
+  this->publish_state_(this->balancer_status_bitmask_sensor_, (data[140 + offset]));
   this->publish_state_(this->balancing_binary_sensor_, (data[140 + offset] != 0x00));
+  this->publish_state_(this->balancer_status_text_sensor_, (data[140 + offset] != 0x00) ? "Balancing" : "Idle");
   ESP_LOGD(TAG, "Balancing indicator (legacy): %s", YESNO(data[140 + offset] != 0x00));
 
   // 141   1   0x54                   State of charge in   1.0           %
@@ -865,7 +866,8 @@ void JkBmsBle::decode_jk04_cell_info_(const std::vector<uint8_t> &data) {
   // 220   1   0x00                  Blink cells (0x00: Off, 0x01: Charging balancer, 0x02: Discharging balancer)
   bool balancing = (data[220] != 0x00);
   this->publish_state_(this->balancing_binary_sensor_, balancing);
-  this->publish_state_(this->operation_status_text_sensor_, (balancing) ? "Balancing" : "Idle");
+  this->publish_state_(this->balancer_status_bitmask_sensor_, (float) data[220]);
+  this->publish_state_(this->balancer_status_text_sensor_, balancing ? "Balancing" : "Idle");
 
   // 221   1   0x01                  Unknown221
   ESP_LOGD(TAG, "Unknown221: 0x%02X", data[221]);
@@ -1608,7 +1610,7 @@ void JkBmsBle::publish_device_unavailable_() {
   this->publish_state_(charging_power_sensor_, NAN);
   this->publish_state_(discharging_power_sensor_, NAN);
   this->publish_state_(mosfet_temperature_sensor_, NAN);
-  this->publish_state_(balancer_status_sensor_, NAN);
+  this->publish_state_(balancer_status_bitmask_sensor_, NAN);
   this->publish_state_(state_of_charge_sensor_, NAN);
   this->publish_state_(state_of_health_sensor_, NAN);
   this->publish_state_(capacity_remaining_sensor_, NAN);

--- a/components/jk_bms_ble/jk_bms_ble.h
+++ b/components/jk_bms_ble/jk_bms_ble.h
@@ -169,8 +169,8 @@ class JkBmsBle :
   void set_balancing_binary_sensor(binary_sensor::BinarySensor *balancing_binary_sensor) {
     balancing_binary_sensor_ = balancing_binary_sensor;
   }
-  void set_balancer_status_sensor(sensor::Sensor *balancer_status_sensor) {
-    balancer_status_sensor_ = balancer_status_sensor;
+  void set_balancer_status_bitmask_sensor(sensor::Sensor *balancer_status_sensor) {
+    balancer_status_bitmask_sensor_ = balancer_status_sensor;
   }
   void set_precharging_binary_sensor(binary_sensor::BinarySensor *precharging_binary_sensor) {
     precharging_binary_sensor_ = precharging_binary_sensor;
@@ -279,8 +279,8 @@ class JkBmsBle :
     errors_bitmask_hex_text_sensor_ = errors_bitmask_hex_text_sensor;
   }
   void set_errors_text_sensor(text_sensor::TextSensor *errors_text_sensor) { errors_text_sensor_ = errors_text_sensor; }
-  void set_operation_status_text_sensor(text_sensor::TextSensor *operation_status_text_sensor) {
-    operation_status_text_sensor_ = operation_status_text_sensor;
+  void set_balancer_status_text_sensor(text_sensor::TextSensor *operation_status_text_sensor) {
+    balancer_status_text_sensor_ = operation_status_text_sensor;
   }
   void set_total_runtime_formatted_text_sensor(text_sensor::TextSensor *total_runtime_formatted_text_sensor) {
     total_runtime_formatted_text_sensor_ = total_runtime_formatted_text_sensor;
@@ -389,7 +389,7 @@ class JkBmsBle :
   number::Number *heating_stop_temperature_number_{nullptr};
   number::Number *re_bulk_soc_number_{nullptr};
 
-  sensor::Sensor *balancer_status_sensor_{nullptr};
+  sensor::Sensor *balancer_status_bitmask_sensor_{nullptr};
   sensor::Sensor *min_cell_voltage_sensor_{nullptr};
   sensor::Sensor *max_cell_voltage_sensor_{nullptr};
   sensor::Sensor *min_voltage_cell_sensor_{nullptr};
@@ -431,7 +431,7 @@ class JkBmsBle :
 
   text_sensor::TextSensor *errors_bitmask_hex_text_sensor_{nullptr};
   text_sensor::TextSensor *errors_text_sensor_{nullptr};
-  text_sensor::TextSensor *operation_status_text_sensor_{nullptr};
+  text_sensor::TextSensor *balancer_status_text_sensor_{nullptr};
   text_sensor::TextSensor *total_runtime_formatted_text_sensor_{nullptr};
   text_sensor::TextSensor *charge_status_text_sensor_{nullptr};
   text_sensor::TextSensor *software_version_text_sensor_{nullptr};

--- a/components/jk_bms_ble/sensor.py
+++ b/components/jk_bms_ble/sensor.py
@@ -58,7 +58,7 @@ CONF_CHARGE_STATUS_ID = "charge_status_id"
 CONF_CHARGE_STATUS_TIME_ELAPSED = "charge_status_time_elapsed"
 CONF_DETAIL_LOG_ENTRY_COUNT = "detail_log_entry_count"
 CONF_BATTERY_TYPE_ID = "battery_type_id"
-CONF_BALANCER_STATUS = "balancer_status"
+CONF_BALANCER_STATUS_BITMASK = "balancer_status_bitmask"
 
 UNIT_AMPERE_HOURS = "Ah"
 UNIT_OHM = "Ω"
@@ -104,7 +104,7 @@ _TEMPERATURE_SCHEMA = sensor.sensor_schema(
 )
 
 SENSOR_DEFS = {
-    CONF_BALANCER_STATUS: {
+    CONF_BALANCER_STATUS_BITMASK: {
         "unit_of_measurement": UNIT_EMPTY,
         "icon": ICON_BALANCER,
         "accuracy_decimals": 0,
@@ -291,10 +291,11 @@ SENSOR_DEFS = {
 }
 
 _RENAMED_SENSORS = {
-    "balancing": "balancer_status",
+    "balancing": "balancer_status_bitmask",
     "total_battery_capacity_setting": "full_charge_capacity",
     "power_tube_temperature": "mosfet_temperature",
     "detail_log_count": "detail_log_entry_count",
+    "balancer_status": "balancer_status_bitmask",
 }
 
 CONFIG_SCHEMA = cv.All(

--- a/components/jk_bms_ble/text_sensor.py
+++ b/components/jk_bms_ble/text_sensor.py
@@ -3,7 +3,7 @@ from esphome.components import text_sensor
 import esphome.config_validation as cv
 from esphome.const import ENTITY_CATEGORY_DIAGNOSTIC, ICON_EMPTY, ICON_TIMELAPSE
 
-from . import CONF_JK_BMS_BLE_ID, JK_BMS_BLE_COMPONENT_SCHEMA
+from . import CONF_JK_BMS_BLE_ID, JK_BMS_BLE_COMPONENT_SCHEMA, deprecated_renames
 
 DEPENDENCIES = ["jk_bms_ble"]
 
@@ -11,7 +11,7 @@ CODEOWNERS = ["@syssi", "@txubelaxu"]
 
 CONF_ERRORS = "errors"
 CONF_ERRORS_BITMASK_HEX = "errors_bitmask_hex"
-CONF_OPERATION_STATUS = "operation_status"
+CONF_BALANCER_STATUS = "balancer_status"
 CONF_TOTAL_RUNTIME_FORMATTED = "total_runtime_formatted"
 CONF_CHARGE_STATUS = "charge_status"
 CONF_SOFTWARE_VERSION = "software_version"
@@ -19,14 +19,14 @@ CONF_HARDWARE_VERSION = "hardware_version"
 CONF_BATTERY_TYPE = "battery_type"
 
 ICON_ERRORS = "mdi:alert-circle-outline"
-ICON_OPERATION_STATUS = "mdi:heart-pulse"
+ICON_BALANCER_STATUS = "mdi:heart-pulse"
 ICON_CHARGE_STATUS = "mdi:battery-clock"
 ICON_BATTERY_TYPE = "mdi:battery-heart-variant"
 
 TEXT_SENSORS = [
     CONF_ERRORS,
     CONF_ERRORS_BITMASK_HEX,
-    CONF_OPERATION_STATUS,
+    CONF_BALANCER_STATUS,
     CONF_TOTAL_RUNTIME_FORMATTED,
     CONF_CHARGE_STATUS,
     CONF_SOFTWARE_VERSION,
@@ -34,37 +34,44 @@ TEXT_SENSORS = [
     CONF_BATTERY_TYPE,
 ]
 
-CONFIG_SCHEMA = JK_BMS_BLE_COMPONENT_SCHEMA.extend(
-    {
-        cv.Optional(CONF_ERRORS): text_sensor.text_sensor_schema(
-            icon=ICON_ERRORS,
-            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
-        ),
-        cv.Optional(CONF_ERRORS_BITMASK_HEX): text_sensor.text_sensor_schema(
-            text_sensor.TextSensor, icon=ICON_ERRORS
-        ),
-        cv.Optional(CONF_OPERATION_STATUS): text_sensor.text_sensor_schema(
-            icon=ICON_OPERATION_STATUS
-        ),
-        cv.Optional(CONF_TOTAL_RUNTIME_FORMATTED): text_sensor.text_sensor_schema(
-            icon=ICON_TIMELAPSE
-        ),
-        cv.Optional(CONF_CHARGE_STATUS): text_sensor.text_sensor_schema(
-            icon=ICON_CHARGE_STATUS
-        ),
-        cv.Optional(CONF_SOFTWARE_VERSION): text_sensor.text_sensor_schema(
-            icon=ICON_EMPTY,
-            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
-        ),
-        cv.Optional(CONF_HARDWARE_VERSION): text_sensor.text_sensor_schema(
-            icon=ICON_EMPTY,
-            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
-        ),
-        cv.Optional(CONF_BATTERY_TYPE): text_sensor.text_sensor_schema(
-            icon=ICON_BATTERY_TYPE,
-            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
-        ),
-    }
+_RENAMED_TEXT_SENSORS = {
+    "operation_status": "balancer_status",
+}
+
+CONFIG_SCHEMA = cv.All(
+    deprecated_renames(_RENAMED_TEXT_SENSORS),
+    JK_BMS_BLE_COMPONENT_SCHEMA.extend(
+        {
+            cv.Optional(CONF_ERRORS): text_sensor.text_sensor_schema(
+                icon=ICON_ERRORS,
+                entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+            ),
+            cv.Optional(CONF_ERRORS_BITMASK_HEX): text_sensor.text_sensor_schema(
+                text_sensor.TextSensor, icon=ICON_ERRORS
+            ),
+            cv.Optional(CONF_BALANCER_STATUS): text_sensor.text_sensor_schema(
+                icon=ICON_BALANCER_STATUS
+            ),
+            cv.Optional(CONF_TOTAL_RUNTIME_FORMATTED): text_sensor.text_sensor_schema(
+                icon=ICON_TIMELAPSE
+            ),
+            cv.Optional(CONF_CHARGE_STATUS): text_sensor.text_sensor_schema(
+                icon=ICON_CHARGE_STATUS
+            ),
+            cv.Optional(CONF_SOFTWARE_VERSION): text_sensor.text_sensor_schema(
+                icon=ICON_EMPTY,
+                entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+            ),
+            cv.Optional(CONF_HARDWARE_VERSION): text_sensor.text_sensor_schema(
+                icon=ICON_EMPTY,
+                entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+            ),
+            cv.Optional(CONF_BATTERY_TYPE): text_sensor.text_sensor_schema(
+                icon=ICON_BATTERY_TYPE,
+                entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+            ),
+        }
+    ),
 )
 
 

--- a/esp32-ble-example.yaml
+++ b/esp32-ble-example.yaml
@@ -278,8 +278,8 @@ sensor:
     #   name: "temperature sensor 4"
     mosfet_temperature:
       name: "mosfet temperature"
-    balancer_status:
-      name: "balancer status"
+    balancer_status_bitmask:
+      name: "balancer status bitmask"
     state_of_charge:
       name: "state of charge"
     capacity_remaining:
@@ -315,6 +315,8 @@ text_sensor:
       name: "errors"
     errors_bitmask_hex:
       name: "errors bitmask hex"
+    balancer_status:
+      name: "balancer status"
     total_runtime_formatted:
       name: "total runtime formatted"
     software_version:

--- a/esp32-ble-jk04-example.yaml
+++ b/esp32-ble-jk04-example.yaml
@@ -189,6 +189,8 @@ sensor:
       name: "total runtime"
     balancing_current:
       name: "balancing current"
+    balancer_status_bitmask:
+      name: "balancer status bitmask"
     mosfet_temperature:
       name: "mosfet temperature"
 
@@ -204,8 +206,8 @@ switch:
 
 text_sensor:
   - platform: jk_bms_ble
-    operation_status:
-      name: "operation status"
+    balancer_status:
+      name: "balancer status"
     total_runtime_formatted:
       name: "total runtime formatted"
     software_version:

--- a/esp32-ble-v11-example.yaml
+++ b/esp32-ble-v11-example.yaml
@@ -294,8 +294,8 @@ sensor:
       name: "temperature sensor 4"
     mosfet_temperature:
       name: "mosfet temperature"
-    balancer_status:
-      name: "balancer status"
+    balancer_status_bitmask:
+      name: "balancer status bitmask"
     state_of_charge:
       name: "state of charge"
     capacity_remaining:
@@ -351,6 +351,8 @@ text_sensor:
       name: "errors"
     errors_bitmask_hex:
       name: "errors bitmask hex"
+    balancer_status:
+      name: "balancer status"
     total_runtime_formatted:
       name: "total runtime formatted"
     software_version:

--- a/esp32-ble-v14-example-multiple-devices.yaml
+++ b/esp32-ble-v14-example-multiple-devices.yaml
@@ -568,8 +568,8 @@ sensor:
     mosfet_temperature:
       name: "mosfet temperature"
       device_id: device0
-    balancer_status:
-      name: "balancer status"
+    balancer_status_bitmask:
+      name: "balancer status bitmask"
       device_id: device0
     state_of_charge:
       name: "state of charge"
@@ -800,8 +800,8 @@ sensor:
     mosfet_temperature:
       name: "mosfet temperature"
       device_id: device1
-    balancer_status:
-      name: "balancer status"
+    balancer_status_bitmask:
+      name: "balancer status bitmask"
       device_id: device1
     state_of_charge:
       name: "state of charge"
@@ -925,6 +925,9 @@ text_sensor:
     errors_bitmask_hex:
       name: "${bms0} errors bitmask hex"
       device_id: device0
+    balancer_status:
+      name: "${bms0} balancer status"
+      device_id: device0
     total_runtime_formatted:
       name: "total runtime formatted"
       device_id: device0
@@ -942,6 +945,9 @@ text_sensor:
       device_id: device1
     errors_bitmask_hex:
       name: "${bms1} errors bitmask hex"
+      device_id: device1
+    balancer_status:
+      name: "${bms1} balancer status"
       device_id: device1
     total_runtime_formatted:
       name: "total runtime formatted"

--- a/esp32-ble-v14-example.yaml
+++ b/esp32-ble-v14-example.yaml
@@ -304,8 +304,8 @@ sensor:
       name: "temperature sensor 5"
     mosfet_temperature:
       name: "mosfet temperature"
-    balancer_status:
-      name: "balancer status"
+    balancer_status_bitmask:
+      name: "balancer status bitmask"
     state_of_charge:
       name: "state of charge"
     state_of_health:
@@ -368,6 +368,8 @@ text_sensor:
       name: "errors"
     errors_bitmask_hex:
       name: "errors bitmask hex"
+    balancer_status:
+      name: "balancer status"
     total_runtime_formatted:
       name: "total runtime formatted"
     charge_status:

--- a/esp32-ble-v15-example.yaml
+++ b/esp32-ble-v15-example.yaml
@@ -308,8 +308,8 @@ sensor:
       name: "temperature sensor 5"
     mosfet_temperature:
       name: "mosfet temperature"
-    balancer_status:
-      name: "balancer status"
+    balancer_status_bitmask:
+      name: "balancer status bitmask"
     state_of_charge:
       name: "state of charge"
     state_of_health:
@@ -372,6 +372,8 @@ text_sensor:
       name: "errors"
     errors_bitmask_hex:
       name: "errors bitmask hex"
+    balancer_status:
+      name: "balancer status"
     total_runtime_formatted:
       name: "total runtime formatted"
     charge_status:

--- a/esp32-ble-v19-example.yaml
+++ b/esp32-ble-v19-example.yaml
@@ -310,8 +310,8 @@ sensor:
       name: "temperature sensor 5"
     mosfet_temperature:
       name: "mosfet temperature"
-    balancer_status:
-      name: "balancer status"
+    balancer_status_bitmask:
+      name: "balancer status bitmask"
     state_of_charge:
       name: "state of charge"
     state_of_health:
@@ -374,6 +374,8 @@ text_sensor:
       name: "errors"
     errors_bitmask_hex:
       name: "errors bitmask hex"
+    balancer_status:
+      name: "balancer status"
     total_runtime_formatted:
       name: "total runtime formatted"
     charge_status:

--- a/tests/components/jk_bms_ble/jk_bms_ble_test.cpp
+++ b/tests/components/jk_bms_ble/jk_bms_ble_test.cpp
@@ -152,14 +152,14 @@ TEST(JkBmsBleJk02CellInfoTest, NoErrors) {
 
 TEST(JkBmsBleJk02CellInfoTest, BalancingOff) {
   TestableJkBmsBle bms;
-  sensor::Sensor balancer_status;
+  sensor::Sensor balancer_status_bitmask;
   binary_sensor::BinarySensor balancing_binary;
-  bms.set_balancer_status_sensor(&balancer_status);
+  bms.set_balancer_status_bitmask_sensor(&balancer_status_bitmask);
   bms.set_balancing_binary_sensor(&balancing_binary);
 
   bms.decode_jk02_cell_info_(CELL_INFO_JK02_24S_V10);
 
-  EXPECT_FLOAT_EQ(balancer_status.state, 0.0f);
+  EXPECT_FLOAT_EQ(balancer_status_bitmask.state, 0.0f);
   EXPECT_FALSE(balancing_binary.state);
 }
 

--- a/tests/test_component_schemas.py
+++ b/tests/test_component_schemas.py
@@ -115,7 +115,7 @@ class TestJkBmsBleSensorLists:
     def test_sensor_defs_completeness(self):
         assert "total_voltage" in ble_sensor.SENSOR_DEFS
         assert "full_charge_capacity" in ble_sensor.SENSOR_DEFS
-        assert "balancer_status" in ble_sensor.SENSOR_DEFS
+        assert "balancer_status_bitmask" in ble_sensor.SENSOR_DEFS
         assert "detail_log_entry_count" in ble_sensor.SENSOR_DEFS
         assert "battery_type_id" in ble_sensor.SENSOR_DEFS
         assert len(ble_sensor.SENSOR_DEFS) == 27
@@ -159,7 +159,7 @@ class TestJkBmsBleButtonConstants:
 class TestJkBleTextSensorConstants:
     def test_text_sensors_list(self):
         assert ble_text_sensor.CONF_ERRORS in ble_text_sensor.TEXT_SENSORS
-        assert ble_text_sensor.CONF_OPERATION_STATUS in ble_text_sensor.TEXT_SENSORS
+        assert ble_text_sensor.CONF_BALANCER_STATUS in ble_text_sensor.TEXT_SENSORS
         assert ble_text_sensor.CONF_CHARGE_STATUS in ble_text_sensor.TEXT_SENSORS
         assert ble_text_sensor.CONF_BATTERY_TYPE in ble_text_sensor.TEXT_SENSORS
         assert len(ble_text_sensor.TEXT_SENSORS) == 8


### PR DESCRIPTION
## Problem

JK02 and JK04 exposed different sensors for the same physical information:

| | JK02 | JK04 |
|---|---|---|
| Raw bitmask | `sensor.balancer_status` ✓ | — |
| Human-readable | — | `text_sensor.operation_status` ✓ |

## Changes

Both protocols now expose the same pair of sensors:

| Sensor | Type | Values |
|---|---|---|
| `sensor.balancer_status_bitmask` | numeric | 0 / 1 / 2 |
| `text_sensor.balancer_status` | text | `"Balancing"` / `"Idle"` |
| `binary_sensor.balancing` | binary | unchanged |

## Deprecation / Migration

| Old key | Replacement | Mechanism |
|---|---|---|
| `sensor.balancer_status` | `sensor.balancer_status_bitmask` | `_RENAMED_SENSORS` warning |
| `text_sensor.operation_status` | `text_sensor.balancer_status` | `_RENAMED_SENSORS` warning |

Existing configs emit a deprecation warning and are auto-migrated — no manual changes required.

## Background

Protocol documentation names this field **"Balance Status"** (`equStatus`) with states OFF / ON / ON / ON (0–3).