### PR TITLE
Remove dead charging_sensor_ and discharging_sensor_ from jk_bms

### DIFF
--- a/components/jk_bms/jk_bms.cpp
+++ b/components/jk_bms/jk_bms.cpp
@@ -467,7 +467,6 @@ void JkBms::publish_device_unavailable_() {
   this->publish_state_(discharging_undertemperature_protection_sensor_, NAN);
   this->publish_state_(discharging_undertemperature_recovery_sensor_, NAN);
   this->publish_state_(full_charge_capacity_sensor_, NAN);
-
   this->publish_state_(current_calibration_sensor_, NAN);
   this->publish_state_(device_address_sensor_, NAN);
   this->publish_state_(sleep_wait_time_sensor_, NAN);

--- a/components/jk_bms/jk_bms.cpp
+++ b/components/jk_bms/jk_bms.cpp
@@ -467,8 +467,7 @@ void JkBms::publish_device_unavailable_() {
   this->publish_state_(discharging_undertemperature_protection_sensor_, NAN);
   this->publish_state_(discharging_undertemperature_recovery_sensor_, NAN);
   this->publish_state_(full_charge_capacity_sensor_, NAN);
-  this->publish_state_(charging_sensor_, NAN);
-  this->publish_state_(discharging_sensor_, NAN);
+
   this->publish_state_(current_calibration_sensor_, NAN);
   this->publish_state_(device_address_sensor_, NAN);
   this->publish_state_(sleep_wait_time_sensor_, NAN);

--- a/components/jk_bms/jk_bms.h
+++ b/components/jk_bms/jk_bms.h
@@ -291,8 +291,6 @@ class JkBms : public PollingComponent, public jk_modbus::JkModbusDevice {
   sensor::Sensor *discharging_undertemperature_protection_sensor_{nullptr};
   sensor::Sensor *discharging_undertemperature_recovery_sensor_{nullptr};
   sensor::Sensor *full_charge_capacity_sensor_{nullptr};
-  sensor::Sensor *charging_sensor_{nullptr};
-  sensor::Sensor *discharging_sensor_{nullptr};
   sensor::Sensor *current_calibration_sensor_{nullptr};
   sensor::Sensor *device_address_sensor_{nullptr};
   sensor::Sensor *sleep_wait_time_sensor_{nullptr};


### PR DESCRIPTION
Both members were completely unused:

- No setter (`set_charging_sensor` / `set_discharging_sensor`)
- Not referenced in `sensor.py` — could never be configured
- Only appeared in the offline NaN-broadcast handler (pointless)

Removing 3 lines of dead code.