### PR TITLE
Remove capacity_remaining from _RENAMED_SENSORS

### DIFF
--- a/components/jk_bms/sensor.py
+++ b/components/jk_bms/sensor.py
@@ -547,7 +547,6 @@ _RENAMED_SENSORS = {
     "cell_pressure_difference_protection": "cell_voltage_difference_protection",
     "balance_opening_pressure_difference": "balancing_delta_voltage",
     "alarm_low_volume": "low_soc_alarm_threshold",
-    "capacity_remaining": "state_of_charge",
     "capacity_remaining_derived": "capacity_remaining",
     "battery_strings": "cell_count",
     "temperature_sensors": "temperature_sensor_count",


### PR DESCRIPTION
## Breaking change fix

`capacity_remaining` was previously the v2 name for the state-of-charge sensor (%) and was added to `_RENAMED_SENSORS` pointing to `state_of_charge`. However, `capacity_remaining` is also the valid v3 name for the Ah-remaining sensor (previously `capacity_remaining_derived`).

Having `"capacity_remaining": "state_of_charge"` in `_RENAMED_SENSORS` is destructive for any user with both sensors configured: `deprecated_renames` would execute `config["state_of_charge"] = config.pop("capacity_remaining")`, overwriting the SOC sensor entry with the Ah sensor entry.

The rename from old `capacity_remaining` (SOC%) to `state_of_charge` is handled by the migration script (`migrate_v2_to_v3.py`), not the compat layer.