### PR TITLE
Fix misleading errors_bitmask warning for UART-only configs

### DIFF
--- a/migrate_v2_to_v3.py
+++ b/migrate_v2_to_v3.py
@@ -116,9 +116,9 @@ def migrate(path):
         if key_match and indent > 0:
             key = key_match.group(2)
 
-            if section == "sensor" and key in SENSOR_REMOVED:
+            if section == "sensor" and has_ble and key in SENSOR_REMOVED:
                 print(
-                    f"  line {lineno}: ACTION REQUIRED: {key} — {SENSOR_REMOVED[key]}"
+                    f"  line {lineno}: ACTION REQUIRED: {key} - {SENSOR_REMOVED[key]}"
                 )
 
             elif section == "sensor" and key in sensor_renames:

--- a/migrate_v2_to_v3.py
+++ b/migrate_v2_to_v3.py
@@ -118,7 +118,7 @@ def migrate(path):
 
             if section == "sensor" and has_ble and key in SENSOR_REMOVED:
                 print(
-                    f"  line {lineno}: ACTION REQUIRED: {key} - {SENSOR_REMOVED[key]}"
+                    f"  line {lineno}: ACTION REQUIRED: {key} — {SENSOR_REMOVED[key]}"
                 )
 
             elif section == "sensor" and key in sensor_renames:


### PR DESCRIPTION
The `ACTION REQUIRED: errors_bitmask` message was shown for `jk_bms` (UART) configs too, even though `sensor.errors_bitmask` was only removed from `jk_bms_ble`. In the UART component it is still a valid sensor key.

The check now only fires when `has_ble` is true.