### PR TITLE
Add shutdown, restart, factory_reset button entities

### DIFF
--- a/components/jk_bms_ble/button/__init__.py
+++ b/components/jk_bms_ble/button/__init__.py
@@ -1,6 +1,7 @@
 import esphome.codegen as cg
 from esphome.components import button
 import esphome.config_validation as cv
+from esphome.const import ENTITY_CATEGORY_CONFIG
 
 from .. import CONF_JK_BMS_BLE_ID, JK_BMS_BLE_COMPONENT_SCHEMA, jk_bms_ble_ns
 
@@ -11,16 +12,26 @@ CODEOWNERS = ["@syssi", "@txubelaxu"]
 CONF_RETRIEVE_SETTINGS = "retrieve_settings"
 CONF_RETRIEVE_DEVICE_INFO = "retrieve_device_info"
 CONF_RETRIEVE_LOGBOOK = "retrieve_logbook"
+CONF_SHUTDOWN = "shutdown"
+CONF_RESTART = "restart"
+CONF_FACTORY_RESET = "factory_reset"
 
 ICON_RETRIEVE_SETTINGS = "mdi:cog"
 ICON_RETRIEVE_DEVICE_INFO = "mdi:information-variant"
 ICON_RETRIEVE_LOGBOOK = "mdi:history"
+ICON_SHUTDOWN = "mdi:power"
+ICON_RESTART = "mdi:restart"
+ICON_FACTORY_RESET = "mdi:restore"
 
 BUTTONS = {
     # The BMS responds to the 0x96 request with a single settings frame and enables the notification stream
     CONF_RETRIEVE_SETTINGS: 0x96,
     CONF_RETRIEVE_DEVICE_INFO: 0x97,
     CONF_RETRIEVE_LOGBOOK: 0xA1,
+    # JK02_32S: data_len=0 commands
+    CONF_SHUTDOWN: 0x65,
+    CONF_RESTART: 0x66,
+    CONF_FACTORY_RESET: 0x9D,
 }
 
 JkButton = jk_bms_ble_ns.class_("JkButton", button.Button, cg.Component)
@@ -38,6 +49,21 @@ CONFIG_SCHEMA = JK_BMS_BLE_COMPONENT_SCHEMA.extend(
         cv.Optional(CONF_RETRIEVE_LOGBOOK): button.button_schema(
             JkButton,
             icon=ICON_RETRIEVE_LOGBOOK,
+        ),
+        cv.Optional(CONF_SHUTDOWN): button.button_schema(
+            JkButton,
+            icon=ICON_SHUTDOWN,
+            entity_category=ENTITY_CATEGORY_CONFIG,
+        ),
+        cv.Optional(CONF_RESTART): button.button_schema(
+            JkButton,
+            icon=ICON_RESTART,
+            entity_category=ENTITY_CATEGORY_CONFIG,
+        ),
+        cv.Optional(CONF_FACTORY_RESET): button.button_schema(
+            JkButton,
+            icon=ICON_FACTORY_RESET,
+            entity_category=ENTITY_CATEGORY_CONFIG,
         ),
     }
 )

--- a/components/jk_bms_ble/button/__init__.py
+++ b/components/jk_bms_ble/button/__init__.py
@@ -1,7 +1,7 @@
 import esphome.codegen as cg
 from esphome.components import button
 import esphome.config_validation as cv
-from esphome.const import ENTITY_CATEGORY_CONFIG
+from esphome.const import CONF_FACTORY_RESET, CONF_RESTART, ENTITY_CATEGORY_CONFIG
 
 from .. import CONF_JK_BMS_BLE_ID, JK_BMS_BLE_COMPONENT_SCHEMA, jk_bms_ble_ns
 
@@ -13,8 +13,6 @@ CONF_RETRIEVE_SETTINGS = "retrieve_settings"
 CONF_RETRIEVE_DEVICE_INFO = "retrieve_device_info"
 CONF_RETRIEVE_LOGBOOK = "retrieve_logbook"
 CONF_SHUTDOWN = "shutdown"
-CONF_RESTART = "restart"
-CONF_FACTORY_RESET = "factory_reset"
 
 ICON_RETRIEVE_SETTINGS = "mdi:cog"
 ICON_RETRIEVE_DEVICE_INFO = "mdi:information-variant"

--- a/esp32-ble-example-multiple-devices.yaml
+++ b/esp32-ble-example-multiple-devices.yaml
@@ -123,6 +123,15 @@ button:
     retrieve_logbook:
       name: "retrieve logbook"
       device_id: device0
+    shutdown:
+      name: "shutdown"
+      device_id: device0
+    restart:
+      name: "restart"
+      device_id: device0
+    factory_reset:
+      name: "factory reset"
+      device_id: device0
 
   - platform: jk_bms_ble
     jk_bms_ble_id: bms1
@@ -134,6 +143,15 @@ button:
       device_id: device1
     retrieve_logbook:
       name: "retrieve logbook"
+      device_id: device1
+    shutdown:
+      name: "shutdown"
+      device_id: device1
+    restart:
+      name: "restart"
+      device_id: device1
+    factory_reset:
+      name: "factory reset"
       device_id: device1
 
 number:

--- a/esp32-ble-uart-hybrid-example.yaml
+++ b/esp32-ble-uart-hybrid-example.yaml
@@ -112,6 +112,12 @@ button:
       name: "retrieve device info"
     retrieve_logbook:
       name: "retrieve logbook"
+    shutdown:
+      name: "shutdown"
+    restart:
+      name: "restart"
+    factory_reset:
+      name: "factory reset"
 
 number:
   - platform: jk_bms_ble

--- a/esp32-ble-v11-example.yaml
+++ b/esp32-ble-v11-example.yaml
@@ -86,6 +86,12 @@ button:
       name: "retrieve device info"
     retrieve_logbook:
       name: "retrieve logbook"
+    shutdown:
+      name: "shutdown"
+    restart:
+      name: "restart"
+    factory_reset:
+      name: "factory reset"
 
 number:
   - platform: jk_bms_ble

--- a/esp32-ble-v14-example-multiple-devices.yaml
+++ b/esp32-ble-v14-example-multiple-devices.yaml
@@ -129,6 +129,15 @@ button:
     retrieve_logbook:
       name: "retrieve logbook"
       device_id: device0
+    shutdown:
+      name: "shutdown"
+      device_id: device0
+    restart:
+      name: "restart"
+      device_id: device0
+    factory_reset:
+      name: "factory reset"
+      device_id: device0
 
   - platform: jk_bms_ble
     jk_bms_ble_id: bms1
@@ -140,6 +149,15 @@ button:
       device_id: device1
     retrieve_logbook:
       name: "retrieve logbook"
+      device_id: device1
+    shutdown:
+      name: "shutdown"
+      device_id: device1
+    restart:
+      name: "restart"
+      device_id: device1
+    factory_reset:
+      name: "factory reset"
       device_id: device1
 
 number:

--- a/esp32-ble-v14-example.yaml
+++ b/esp32-ble-v14-example.yaml
@@ -90,6 +90,12 @@ button:
       name: "retrieve device info"
     retrieve_logbook:
       name: "retrieve logbook"
+    shutdown:
+      name: "shutdown"
+    restart:
+      name: "restart"
+    factory_reset:
+      name: "factory reset"
 
 number:
   - platform: jk_bms_ble

--- a/esp32-ble-v15-example.yaml
+++ b/esp32-ble-v15-example.yaml
@@ -90,6 +90,12 @@ button:
       name: "retrieve device info"
     retrieve_logbook:
       name: "retrieve logbook"
+    shutdown:
+      name: "shutdown"
+    restart:
+      name: "restart"
+    factory_reset:
+      name: "factory reset"
 
 number:
   - platform: jk_bms_ble

--- a/esp32-ble-v19-3pack-olimex-poe-example.yaml
+++ b/esp32-ble-v19-3pack-olimex-poe-example.yaml
@@ -193,6 +193,15 @@ button:
     retrieve_logbook:
       name: "retrieve logbook"
       device_id: device0
+    shutdown:
+      name: "shutdown"
+      device_id: device0
+    restart:
+      name: "restart"
+      device_id: device0
+    factory_reset:
+      name: "factory reset"
+      device_id: device0
 
   - platform: jk_bms_ble
     jk_bms_ble_id: bms1
@@ -205,6 +214,15 @@ button:
     retrieve_logbook:
       name: "retrieve logbook"
       device_id: device1
+    shutdown:
+      name: "shutdown"
+      device_id: device1
+    restart:
+      name: "restart"
+      device_id: device1
+    factory_reset:
+      name: "factory reset"
+      device_id: device1
 
   - platform: jk_bms_ble
     jk_bms_ble_id: bms2
@@ -216,6 +234,15 @@ button:
       device_id: device2
     retrieve_logbook:
       name: "retrieve logbook"
+      device_id: device2
+    shutdown:
+      name: "shutdown"
+      device_id: device2
+    restart:
+      name: "restart"
+      device_id: device2
+    factory_reset:
+      name: "factory reset"
       device_id: device2
 
 number:

--- a/esp32-ble-v19-example.yaml
+++ b/esp32-ble-v19-example.yaml
@@ -90,6 +90,12 @@ button:
       name: "retrieve device info"
     retrieve_logbook:
       name: "retrieve logbook"
+    shutdown:
+      name: "shutdown"
+    restart:
+      name: "restart"
+    factory_reset:
+      name: "factory reset"
 
 number:
   - platform: jk_bms_ble

--- a/tests/test_component_schemas.py
+++ b/tests/test_component_schemas.py
@@ -195,11 +195,19 @@ class TestJkBmsBleButtonConstants:
         assert ble_button.CONF_RETRIEVE_SETTINGS in ble_button.BUTTONS
         assert ble_button.CONF_RETRIEVE_DEVICE_INFO in ble_button.BUTTONS
         assert ble_button.CONF_RETRIEVE_LOGBOOK in ble_button.BUTTONS
-        assert len(ble_button.BUTTONS) == 3
+        assert ble_button.CONF_SHUTDOWN in ble_button.BUTTONS
+        assert ble_button.CONF_RESTART in ble_button.BUTTONS
+        assert ble_button.CONF_FACTORY_RESET in ble_button.BUTTONS
+        assert len(ble_button.BUTTONS) == 6
 
     def test_button_addresses_are_unique(self):
         addresses = list(ble_button.BUTTONS.values())
         assert len(addresses) == len(set(addresses))
+
+    def test_button_addresses(self):
+        assert ble_button.BUTTONS[ble_button.CONF_SHUTDOWN] == 0x65
+        assert ble_button.BUTTONS[ble_button.CONF_RESTART] == 0x66
+        assert ble_button.BUTTONS[ble_button.CONF_FACTORY_RESET] == 0x9D
 
 
 class TestJkBleTextSensorConstants:


### PR DESCRIPTION
## Summary

- Adds three new button entities for JK02_32S BMS: **shutdown**, **restart**, **factory_reset**
- Each button sends `write_register(address, 0x00000000, 0x00)` — data_len=0, same mechanism as existing buttons
- Registers: shutdown=0x65, restart=0x66, factory_reset=0x9D (recorded from JK02_32S frames)
- No C++ changes required; purely additive Python extension to the existing `BUTTONS` dict

## Test plan

- [ ] All 41 schema tests pass
- [ ] `BUTTONS` dict has 6 entries with unique addresses
- [ ] Compile and flash to ESP32, verify each button triggers the expected BMS action