### PR TITLE
Fix load_config_preset: empty placeholder as persistent initial state

### DIFF
--- a/components/jk_bms_ble/select/__init__.py
+++ b/components/jk_bms_ble/select/__init__.py
@@ -194,7 +194,9 @@ async def to_code(config):
 
     if CONF_LOAD_CONFIG_PRESET in config:
         conf = config[CONF_LOAD_CONFIG_PRESET]
-        var = await select.new_select(conf, options=list(LOAD_CONFIG_PRESET_OPTIONS))
+        var = await select.new_select(
+            conf, options=[""] + list(LOAD_CONFIG_PRESET_OPTIONS)
+        )
         await cg.register_component(var, conf)
         cg.add(var.set_parent(hub))
         for opt, reg in LOAD_CONFIG_PRESET_OPTIONS.items():

--- a/components/jk_bms_ble/select/jk_select.cpp
+++ b/components/jk_bms_ble/select/jk_select.cpp
@@ -25,8 +25,7 @@ void JkPresetSelect::dump_config() { LOG_SELECT("", "JkBmsBle Preset Select", th
 void JkPresetSelect::control(const std::string &value) {
   for (const auto &[opt, reg] : this->option_registers_) {
     if (opt == value) {
-      if (this->parent_->write_register(reg, 0x00000000, 0x00))
-        this->publish_state(value);
+      this->parent_->write_register(reg, 0x00000000, 0x00);
       return;
     }
   }

--- a/components/jk_bms_ble/select/jk_select.h
+++ b/components/jk_bms_ble/select/jk_select.h
@@ -24,12 +24,15 @@ class JkSelect : public select::Select, public Component {
 };
 
 // Select where each option triggers a write to a distinct register with data_len=0.
+// State is pinned to "" on setup and never updated: the BMS provides no read-back
+// confirmation, so the empty placeholder stays selected across page reloads.
 class JkPresetSelect : public select::Select, public Component {
  public:
   void set_parent(JkBmsBle *parent) { this->parent_ = parent; }
   void add_option_register(const std::string &option, uint8_t holding_register) {
     this->option_registers_.emplace_back(option, holding_register);
   }
+  void setup() override { this->publish_state(""); }
   void dump_config() override;
 
  protected:


### PR DESCRIPTION
## Problem

The select entity had only three options (Li-Ion, LiFePO4, LTO). ESPHome pre-selects the first option, making it impossible to trigger that preset again without first switching away.

## Fix

- Prepend `""` (empty string) as the first option — always shown as the current state
- `setup()` publishes `""` on startup so the placeholder is the initial state
- `control()` resets state back to `""` after every write, since the BMS provides no read-back confirmation
- Selecting `""` is a no-op (nothing sent to the BMS)

## Result

The user always sees an empty selection. Choosing Li-Ion, LiFePO4, or LTO sends the command and the entity immediately returns to the empty placeholder — all three options remain re-selectable at any time.