### PR TITLE
Add smart_sleep_delay number and smart_sleep_countdown sensor (JK02_32S)

### DIFF
--- a/components/jk_bms_ble/jk_bms_ble.cpp
+++ b/components/jk_bms_ble/jk_bms_ble.cpp
@@ -944,7 +944,6 @@ void JkBmsBle::decode_jk02_cell_info_(const std::vector<uint8_t> &data) {
   ESP_LOGD(TAG, "Temperature sensor 3: %.1f °C", (float) jk_get_16bit(222 + offset) * 0.1f);
   ESP_LOGD(TAG, "Temperature sensor 4: %.1f °C", (float) jk_get_16bit(224 + offset) * 0.1f);
   ESP_LOGD(TAG, "Temperature sensor 5: %.1f °C", (float) jk_get_16bit(226 + offset) * 0.1f);
-  ESP_LOGD(TAG, "Time enter sleep: %lu s", (unsigned long) jk_get_32bit(238 + offset));
   this->publish_state_(this->smart_sleep_countdown_sensor_, (float) jk_get_32bit(238 + offset));
   ESP_LOGD(TAG, "PCL Module State: %s", ONOFF((bool) data[242 + offset]));
 
@@ -1458,7 +1457,6 @@ void JkBmsBle::decode_jk02_settings_(const std::vector<uint8_t> &data) {
     this->publish_state_(this->heating_stop_temperature_number_, (float) ((int8_t) data[285]));
 
     // 286   1   0x00                   Smart sleep delay
-    ESP_LOGI(TAG, "  Smart sleep delay: %d h", data[286]);
     this->publish_state_(this->smart_sleep_delay_number_, (float) data[286]);
     // 287   1   0x00
     ESP_LOGI(TAG, "  Data field enable control 0: %d", data[287]);

--- a/components/jk_bms_ble/jk_bms_ble.cpp
+++ b/components/jk_bms_ble/jk_bms_ble.cpp
@@ -945,6 +945,7 @@ void JkBmsBle::decode_jk02_cell_info_(const std::vector<uint8_t> &data) {
   ESP_LOGD(TAG, "Temperature sensor 4: %.1f °C", (float) jk_get_16bit(224 + offset) * 0.1f);
   ESP_LOGD(TAG, "Temperature sensor 5: %.1f °C", (float) jk_get_16bit(226 + offset) * 0.1f);
   ESP_LOGD(TAG, "Time enter sleep: %lu s", (unsigned long) jk_get_32bit(238 + offset));
+  this->publish_state_(this->smart_sleep_countdown_sensor_, (float) jk_get_32bit(238 + offset));
   ESP_LOGD(TAG, "PCL Module State: %s", ONOFF((bool) data[242 + offset]));
 
   if (frame_version == FRAME_VERSION_JK02_32S) {
@@ -1456,8 +1457,9 @@ void JkBmsBle::decode_jk02_settings_(const std::vector<uint8_t> &data) {
     // 285   1   0x00                   Heating stop temperature
     this->publish_state_(this->heating_stop_temperature_number_, (float) ((int8_t) data[285]));
 
-    // 286   1   0x00
-    ESP_LOGI(TAG, "  Smart sleep: %d h", data[286]);
+    // 286   1   0x00                   Smart sleep delay
+    ESP_LOGI(TAG, "  Smart sleep delay: %d h", data[286]);
+    this->publish_state_(this->smart_sleep_delay_number_, (float) data[286]);
     // 287   1   0x00
     ESP_LOGI(TAG, "  Data field enable control 0: %d", data[287]);
     // 288   2   0x00 0x00

--- a/components/jk_bms_ble/jk_bms_ble.h
+++ b/components/jk_bms_ble/jk_bms_ble.h
@@ -172,6 +172,9 @@ class JkBmsBle :
   void set_heating_stop_temperature_number(number::Number *heating_stop_temperature_number) {
     heating_stop_temperature_number_ = heating_stop_temperature_number;
   }
+  void set_smart_sleep_delay_number(number::Number *smart_sleep_delay_number) {
+    smart_sleep_delay_number_ = smart_sleep_delay_number;
+  }
   void set_re_bulk_soc_number(number::Number *re_bulk_soc_number) { re_bulk_soc_number_ = re_bulk_soc_number; }
 
   void set_balancing_binary_sensor(binary_sensor::BinarySensor *balancing_binary_sensor) {
@@ -266,6 +269,9 @@ class JkBmsBle :
   }
   void set_emergency_time_countdown_sensor(sensor::Sensor *emergency_time_countdown_sensor) {
     emergency_time_countdown_sensor_ = emergency_time_countdown_sensor;
+  }
+  void set_smart_sleep_countdown_sensor(sensor::Sensor *smart_sleep_countdown_sensor) {
+    smart_sleep_countdown_sensor_ = smart_sleep_countdown_sensor;
   }
   void set_heating_current_sensor(sensor::Sensor *heating_current_sensor) {
     heating_current_sensor_ = heating_current_sensor;
@@ -453,6 +459,7 @@ class JkBmsBle :
   number::Number *discharge_precharge_time_number_{nullptr};
   number::Number *heating_start_temperature_number_{nullptr};
   number::Number *heating_stop_temperature_number_{nullptr};
+  number::Number *smart_sleep_delay_number_{nullptr};
   number::Number *re_bulk_soc_number_{nullptr};
 
   sensor::Sensor *balancer_status_bitmask_sensor_{nullptr};
@@ -477,6 +484,7 @@ class JkBmsBle :
   sensor::Sensor *total_runtime_sensor_{nullptr};
   sensor::Sensor *balancing_current_sensor_{nullptr};
   sensor::Sensor *emergency_time_countdown_sensor_{nullptr};
+  sensor::Sensor *smart_sleep_countdown_sensor_{nullptr};
   sensor::Sensor *heating_current_sensor_{nullptr};
   sensor::Sensor *charge_status_id_sensor_{nullptr};
   sensor::Sensor *charge_status_time_elapsed_sensor_{nullptr};

--- a/components/jk_bms_ble/number/__init__.py
+++ b/components/jk_bms_ble/number/__init__.py
@@ -194,8 +194,10 @@ CONF_MOSFET_OVERTEMPERATURE_PROTECTION_RECOVERY = (
 CONF_DISCHARGE_PRECHARGE_TIME = "discharge_precharge_time"
 CONF_HEATING_START_TEMPERATURE = "heating_start_temperature"
 CONF_HEATING_STOP_TEMPERATURE = "heating_stop_temperature"
+CONF_SMART_SLEEP_DELAY = "smart_sleep_delay"
 
 UNIT_AMPERE_HOUR = "Ah"
+UNIT_HOURS = "h"
 UNIT_SECONDS = "s"
 UNIT_MICROSECONDS = "μs"
 
@@ -263,6 +265,7 @@ NUMBERS = {
     CONF_DISCHARGE_PRECHARGE_TIME: [0x00, 0x00, 0x25, 1.0, 4, 0],
     CONF_HEATING_START_TEMPERATURE: [0x00, 0x00, 0x37, 1.0, 1, 0],
     CONF_HEATING_STOP_TEMPERATURE: [0x00, 0x00, 0x38, 1.0, 1, 0],
+    CONF_SMART_SLEEP_DELAY: [0x00, 0x00, 0x39, 1.0, 1, 0],
 }
 
 JkNumber = jk_bms_ble_ns.class_("JkNumber", number.Number, cg.Component)
@@ -681,6 +684,16 @@ _NUMBER_CONFIG_SCHEMA = JK_BMS_BLE_COMPONENT_SCHEMA.extend(
                 cv.Optional(CONF_STEP, default=1.0): cv.float_,
                 cv.Optional(
                     CONF_UNIT_OF_MEASUREMENT, default=UNIT_CELSIUS
+                ): cv.string_strict,
+            }
+        ),
+        cv.Optional(CONF_SMART_SLEEP_DELAY): JK_NUMBER_SCHEMA.extend(
+            {
+                cv.Optional(CONF_MIN_VALUE, default=1): cv.float_,
+                cv.Optional(CONF_MAX_VALUE, default=100): cv.float_,
+                cv.Optional(CONF_STEP, default=1.0): cv.float_,
+                cv.Optional(
+                    CONF_UNIT_OF_MEASUREMENT, default=UNIT_HOURS
                 ): cv.string_strict,
             }
         ),

--- a/components/jk_bms_ble/sensor.py
+++ b/components/jk_bms_ble/sensor.py
@@ -53,6 +53,7 @@ CONF_TOTAL_CHARGING_CYCLE_CAPACITY = "total_charging_cycle_capacity"
 CONF_TOTAL_RUNTIME = "total_runtime"
 CONF_BALANCING_CURRENT = "balancing_current"
 CONF_EMERGENCY_TIME_COUNTDOWN = "emergency_time_countdown"
+CONF_SMART_SLEEP_COUNTDOWN = "smart_sleep_countdown"
 CONF_HEATING_CURRENT = "heating_current"
 CONF_CHARGE_STATUS_ID = "charge_status_id"
 CONF_CHARGE_STATUS_TIME_ELAPSED = "charge_status_time_elapsed"
@@ -254,6 +255,12 @@ SENSOR_DEFS = {
         "state_class": STATE_CLASS_MEASUREMENT,
     },
     CONF_EMERGENCY_TIME_COUNTDOWN: {
+        "unit_of_measurement": UNIT_SECONDS,
+        "icon": ICON_TIMELAPSE,
+        "accuracy_decimals": 0,
+        "device_class": DEVICE_CLASS_EMPTY,
+    },
+    CONF_SMART_SLEEP_COUNTDOWN: {
         "unit_of_measurement": UNIT_SECONDS,
         "icon": ICON_TIMELAPSE,
         "accuracy_decimals": 0,

--- a/esp32-ble-v11-example.yaml
+++ b/esp32-ble-v11-example.yaml
@@ -126,6 +126,8 @@ number:
       name: "max discharge current"
     smart_sleep_voltage:
       name: "smart sleep voltage"
+    smart_sleep_delay:
+      name: "smart sleep delay"
     cell_soc100_voltage:
       name: "cell soc100 voltage"
     cell_soc0_voltage:
@@ -320,6 +322,8 @@ sensor:
       name: "balancing current"
     emergency_time_countdown:
       name: "emergency time countdown"
+    smart_sleep_countdown:
+      name: "smart sleep countdown"
     detail_log_entry_count:
       name: "detail log entry count"
 

--- a/esp32-ble-v14-example-multiple-devices.yaml
+++ b/esp32-ble-v14-example-multiple-devices.yaml
@@ -207,6 +207,8 @@ number:
       device_id: device0
     smart_sleep_voltage:
       name: "smart sleep voltage"
+    smart_sleep_delay:
+      name: "smart sleep delay"
       device_id: device0
     cell_soc100_voltage:
       name: "cell soc100 voltage"
@@ -322,6 +324,8 @@ number:
       device_id: device1
     smart_sleep_voltage:
       name: "smart sleep voltage"
+    smart_sleep_delay:
+      name: "smart sleep delay"
       device_id: device1
     cell_soc100_voltage:
       name: "cell soc100 voltage"
@@ -619,6 +623,9 @@ sensor:
     emergency_time_countdown:
       name: "emergency time countdown"
       device_id: device0
+    smart_sleep_countdown:
+      name: "smart sleep countdown"
+      device_id: device0
     detail_log_entry_count:
       name: "detail log entry count"
       device_id: device0
@@ -850,6 +857,9 @@ sensor:
       device_id: device1
     emergency_time_countdown:
       name: "emergency time countdown"
+      device_id: device1
+    smart_sleep_countdown:
+      name: "smart sleep countdown"
       device_id: device1
     detail_log_entry_count:
       name: "detail log entry count"

--- a/esp32-ble-v14-example-multiple-devices.yaml
+++ b/esp32-ble-v14-example-multiple-devices.yaml
@@ -207,6 +207,7 @@ number:
       device_id: device0
     smart_sleep_voltage:
       name: "smart sleep voltage"
+      device_id: device0
     smart_sleep_delay:
       name: "smart sleep delay"
       device_id: device0
@@ -324,6 +325,7 @@ number:
       device_id: device1
     smart_sleep_voltage:
       name: "smart sleep voltage"
+      device_id: device1
     smart_sleep_delay:
       name: "smart sleep delay"
       device_id: device1

--- a/esp32-ble-v14-example.yaml
+++ b/esp32-ble-v14-example.yaml
@@ -130,6 +130,8 @@ number:
       name: "max discharge current"
     smart_sleep_voltage:
       name: "smart sleep voltage"
+    smart_sleep_delay:
+      name: "smart sleep delay"
     cell_soc100_voltage:
       name: "cell soc100 voltage"
     cell_soc0_voltage:
@@ -332,6 +334,8 @@ sensor:
       name: "balancing current"
     emergency_time_countdown:
       name: "emergency time countdown"
+    smart_sleep_countdown:
+      name: "smart sleep countdown"
     charge_status_id:
       name: "charge status id"
     charge_status_time_elapsed:

--- a/esp32-ble-v15-example.yaml
+++ b/esp32-ble-v15-example.yaml
@@ -130,6 +130,8 @@ number:
       name: "max discharge current"
     smart_sleep_voltage:
       name: "smart sleep voltage"
+    smart_sleep_delay:
+      name: "smart sleep delay"
     cell_soc100_voltage:
       name: "cell soc100 voltage"
     cell_soc0_voltage:
@@ -336,6 +338,8 @@ sensor:
       name: "balancing current"
     emergency_time_countdown:
       name: "emergency time countdown"
+    smart_sleep_countdown:
+      name: "smart sleep countdown"
     charge_status_id:
       name: "charge status id"
     charge_status_time_elapsed:

--- a/esp32-ble-v19-3pack-olimex-poe-example.yaml
+++ b/esp32-ble-v19-3pack-olimex-poe-example.yaml
@@ -371,6 +371,8 @@ number:
       device_id: device0
     smart_sleep_voltage:
       name: "smart sleep voltage"
+    smart_sleep_delay:
+      name: "smart sleep delay"
       device_id: device0
 
   - platform: jk_bms_ble
@@ -498,6 +500,8 @@ number:
       device_id: device1
     smart_sleep_voltage:
       name: "smart sleep voltage"
+    smart_sleep_delay:
+      name: "smart sleep delay"
       device_id: device1
 
   - platform: jk_bms_ble
@@ -625,6 +629,8 @@ number:
       device_id: device2
     smart_sleep_voltage:
       name: "smart sleep voltage"
+    smart_sleep_delay:
+      name: "smart sleep delay"
       device_id: device2
 
 sensor:
@@ -1072,6 +1078,9 @@ sensor:
     emergency_time_countdown:
       name: "emergency time countdown"
       device_id: device0
+    smart_sleep_countdown:
+      name: "smart sleep countdown"
+      device_id: device0
     detail_log_entry_count:
       name: "detail log entry count"
       device_id: device0
@@ -1286,6 +1295,9 @@ sensor:
     emergency_time_countdown:
       name: "emergency time countdown"
       device_id: device1
+    smart_sleep_countdown:
+      name: "smart sleep countdown"
+      device_id: device1
     detail_log_entry_count:
       name: "detail log entry count"
       device_id: device1
@@ -1498,6 +1510,9 @@ sensor:
       device_id: device2
     emergency_time_countdown:
       name: "emergency time countdown"
+      device_id: device2
+    smart_sleep_countdown:
+      name: "smart sleep countdown"
       device_id: device2
     detail_log_entry_count:
       name: "detail log entry count"

--- a/esp32-ble-v19-3pack-olimex-poe-example.yaml
+++ b/esp32-ble-v19-3pack-olimex-poe-example.yaml
@@ -371,6 +371,7 @@ number:
       device_id: device0
     smart_sleep_voltage:
       name: "smart sleep voltage"
+      device_id: device0
     smart_sleep_delay:
       name: "smart sleep delay"
       device_id: device0
@@ -500,6 +501,7 @@ number:
       device_id: device1
     smart_sleep_voltage:
       name: "smart sleep voltage"
+      device_id: device1
     smart_sleep_delay:
       name: "smart sleep delay"
       device_id: device1
@@ -629,6 +631,7 @@ number:
       device_id: device2
     smart_sleep_voltage:
       name: "smart sleep voltage"
+      device_id: device2
     smart_sleep_delay:
       name: "smart sleep delay"
       device_id: device2

--- a/esp32-ble-v19-example.yaml
+++ b/esp32-ble-v19-example.yaml
@@ -130,6 +130,8 @@ number:
       name: "max discharge current"
     smart_sleep_voltage:
       name: "smart sleep voltage"
+    smart_sleep_delay:
+      name: "smart sleep delay"
     cell_soc100_voltage:
       name: "cell soc100 voltage"
     cell_soc0_voltage:
@@ -338,6 +340,8 @@ sensor:
       name: "balancing current"
     emergency_time_countdown:
       name: "emergency time countdown"
+    smart_sleep_countdown:
+      name: "smart sleep countdown"
     charge_status_id:
       name: "charge status id"
     charge_status_time_elapsed:

--- a/tests/components/jk_bms_ble/jk_bms_ble_write_command_test.cpp
+++ b/tests/components/jk_bms_ble/jk_bms_ble_write_command_test.cpp
@@ -301,7 +301,7 @@ TEST(JkBmsWriteCommandTest, MultiplexedPortModeRs485) {
   EXPECT_EQ(f[19], 0xA9);
 }
 
-TEST(JkBmsWriteCommandTest, ProtocolModeCanFullFrame) {
+TEST(JkBmsWriteCommandTest, MultiplexedPortModeCanFullFrame) {
   // Captured register/length/value match (bytes 10–18 differ, see file header):
   //   aa 55 90 eb 2a 04 00 00 00 00 11 9d 1b c4 c1 a5 85 91 a9 5a
   // clang-format off
@@ -325,6 +325,63 @@ TEST(JkBmsWriteCommandTest, MultiplexedPortModeRs485FullFrame) {
   };
   // clang-format on
   EXPECT_EQ(JkBmsBle::build_frame(0x2A, 0x00000001, 0x04), expected);
+}
+
+// ── Smart Sleep Delay (register 0x39, 1-byte write) ──────────────────────────
+//
+// Capture recorded from a JK02_32S BMS (issue #421), value = 23 hours:
+//
+//   AA.55.90.EB.39.01.17.BB.2E.15.63.0E.3C.DC.A4.3A.7A.06.20.D0
+//
+// Length byte is 0x01 (1-byte payload).  Bytes 7–18 are stale BLE-TX-buffer
+// data; build_frame() zero-initialises them — only register (byte 4), length
+// (byte 5), and value (byte 6) match the capture exactly.
+//
+// CRC = sum8(bytes[0..18]) = (AA+55+90+EB+39+01+value) & 0xFF
+//                           = (0x274 + value) & 0xFF → 0xCB (23 h)
+
+TEST(JkBmsWriteCommandTest, SmartSleepDelay23h) {
+  // Captured: AA 55 90 EB 39 01 17 ...
+  auto f = JkBmsBle::build_frame(0x39, 0x00000017, 0x01);
+
+  EXPECT_EQ(f[4], 0x39);  // register
+  EXPECT_EQ(f[5], 0x01);  // length: 1 byte
+  EXPECT_EQ(f[6], 0x17);  // value: 23 hours
+  EXPECT_EQ(f[7], 0x00);
+  EXPECT_EQ(f[8], 0x00);
+  EXPECT_EQ(f[9], 0x00);
+  EXPECT_EQ(f[19], 0xCB);  // CRC = (AA+55+90+EB+39+01+17) & FF
+}
+
+TEST(JkBmsWriteCommandTest, SmartSleepDelay1h) {
+  auto f = JkBmsBle::build_frame(0x39, 0x00000001, 0x01);
+
+  EXPECT_EQ(f[4], 0x39);
+  EXPECT_EQ(f[5], 0x01);
+  EXPECT_EQ(f[6], 0x01);  // value: 1 hour (minimum)
+  EXPECT_EQ(f[19], 0xB5);
+}
+
+TEST(JkBmsWriteCommandTest, SmartSleepDelay100h) {
+  auto f = JkBmsBle::build_frame(0x39, 0x00000064, 0x01);
+
+  EXPECT_EQ(f[4], 0x39);
+  EXPECT_EQ(f[5], 0x01);
+  EXPECT_EQ(f[6], 0x64);  // value: 100 hours (maximum)
+  EXPECT_EQ(f[19], 0x18);
+}
+
+TEST(JkBmsWriteCommandTest, SmartSleepDelay23hFullFrame) {
+  // Captured register/length/value match (bytes 7–18 differ, see file header):
+  //   AA 55 90 EB 39 01 17 BB 2E 15 63 0E 3C DC A4 3A 7A 06 20 D0
+  // clang-format off
+  const std::array<uint8_t, 20> expected = {
+      0xAA, 0x55, 0x90, 0xEB, 0x39, 0x01, 0x17, 0x00,
+      0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+      0x00, 0x00, 0x00, 0xCB,
+  };
+  // clang-format on
+  EXPECT_EQ(JkBmsBle::build_frame(0x39, 0x00000017, 0x01), expected);
 }
 
 // ── Register uniqueness ───────────────────────────────────────────────────────

--- a/tests/test_component_schemas.py
+++ b/tests/test_component_schemas.py
@@ -119,7 +119,7 @@ class TestJkBmsBleSensorLists:
         assert "balancer_status_bitmask" in ble_sensor.SENSOR_DEFS
         assert "detail_log_entry_count" in ble_sensor.SENSOR_DEFS
         assert "battery_type_id" in ble_sensor.SENSOR_DEFS
-        assert len(ble_sensor.SENSOR_DEFS) == 31
+        assert len(ble_sensor.SENSOR_DEFS) == 32
 
 
 class TestJkBmsBleBinarySensorConstants:


### PR DESCRIPTION
## Summary

- Adds `smart_sleep_delay` number entity (register `0x39`, 1-byte write, 1–100 h): configures how many hours the cell voltage must remain below `smart_sleep_voltage` before smart sleep activates
- Adds `smart_sleep_countdown` sensor (read-only, seconds): live countdown to sleep onset decoded from the cell info frame at offset `238 + frame_offset` — works for both JK02_24S and JK02_32S
- C++ frame tests verify `smart_sleep_delay` against a captured BLE frame (23 h = `0x17`) from a real JK02_32S BMS
- YAML examples updated for v11, v14, v14-multiple-devices, v15, v19, v19-3pack

Closes #421