### PR TITLE
Add emergency_duration number entity (JK02_32S)

### DIFF
--- a/components/jk_bms_ble/jk_bms_ble.cpp
+++ b/components/jk_bms_ble/jk_bms_ble.cpp
@@ -1857,6 +1857,9 @@ void JkBmsBle::decode_device_info_(const std::vector<uint8_t> &data) {
   // 271  4    0x00 0x00 0x00 0x00   UART3 Protocol enable (lower 32 of 56 bits)
   this->publish_state_(this->uart3_protocols_enabled_bitmask_sensor_, (float) jk_get_32bit(271));
   // 275  3    0x00 0x00 0x00       UART3 Protocol enable (upper 24 bits, reserved)
+  // 269  0x00                  Emergency duration  min
+  this->publish_state_(this->emergency_duration_number_, (float) data[269]);
+
   // 278  0x00  Re-Bulk SOC  %
   ESP_LOGI(TAG, "  Re-Bulk SOC: %d %%", data[278]);
   this->publish_state_(this->re_bulk_soc_number_, (float) data[278]);

--- a/components/jk_bms_ble/jk_bms_ble.h
+++ b/components/jk_bms_ble/jk_bms_ble.h
@@ -175,6 +175,9 @@ class JkBmsBle :
   void set_smart_sleep_delay_number(number::Number *smart_sleep_delay_number) {
     smart_sleep_delay_number_ = smart_sleep_delay_number;
   }
+  void set_emergency_duration_number(number::Number *emergency_duration_number) {
+    emergency_duration_number_ = emergency_duration_number;
+  }
   void set_re_bulk_soc_number(number::Number *re_bulk_soc_number) { re_bulk_soc_number_ = re_bulk_soc_number; }
 
   void set_balancing_binary_sensor(binary_sensor::BinarySensor *balancing_binary_sensor) {
@@ -460,6 +463,7 @@ class JkBmsBle :
   number::Number *heating_start_temperature_number_{nullptr};
   number::Number *heating_stop_temperature_number_{nullptr};
   number::Number *smart_sleep_delay_number_{nullptr};
+  number::Number *emergency_duration_number_{nullptr};
   number::Number *re_bulk_soc_number_{nullptr};
 
   sensor::Sensor *balancer_status_bitmask_sensor_{nullptr};

--- a/components/jk_bms_ble/number/__init__.py
+++ b/components/jk_bms_ble/number/__init__.py
@@ -195,9 +195,11 @@ CONF_DISCHARGE_PRECHARGE_TIME = "discharge_precharge_time"
 CONF_HEATING_START_TEMPERATURE = "heating_start_temperature"
 CONF_HEATING_STOP_TEMPERATURE = "heating_stop_temperature"
 CONF_SMART_SLEEP_DELAY = "smart_sleep_delay"
+CONF_EMERGENCY_DURATION = "emergency_duration"
 
 UNIT_AMPERE_HOUR = "Ah"
 UNIT_HOURS = "h"
+UNIT_MINUTES = "min"
 UNIT_SECONDS = "s"
 UNIT_MICROSECONDS = "μs"
 
@@ -266,6 +268,7 @@ NUMBERS = {
     CONF_HEATING_START_TEMPERATURE: [0x00, 0x00, 0x37, 1.0, 1, 0],
     CONF_HEATING_STOP_TEMPERATURE: [0x00, 0x00, 0x38, 1.0, 1, 0],
     CONF_SMART_SLEEP_DELAY: [0x00, 0x00, 0x39, 1.0, 1, 0],
+    CONF_EMERGENCY_DURATION: [0x00, 0x00, 0xB5, 1.0, 1, 0],
 }
 
 JkNumber = jk_bms_ble_ns.class_("JkNumber", number.Number, cg.Component)
@@ -694,6 +697,16 @@ _NUMBER_CONFIG_SCHEMA = JK_BMS_BLE_COMPONENT_SCHEMA.extend(
                 cv.Optional(CONF_STEP, default=1.0): cv.float_,
                 cv.Optional(
                     CONF_UNIT_OF_MEASUREMENT, default=UNIT_HOURS
+                ): cv.string_strict,
+            }
+        ),
+        cv.Optional(CONF_EMERGENCY_DURATION): JK_NUMBER_SCHEMA.extend(
+            {
+                cv.Optional(CONF_MIN_VALUE, default=1): cv.float_,
+                cv.Optional(CONF_MAX_VALUE, default=255): cv.float_,
+                cv.Optional(CONF_STEP, default=1.0): cv.float_,
+                cv.Optional(
+                    CONF_UNIT_OF_MEASUREMENT, default=UNIT_MINUTES
                 ): cv.string_strict,
             }
         ),

--- a/esp32-ble-v11-example.yaml
+++ b/esp32-ble-v11-example.yaml
@@ -128,6 +128,8 @@ number:
       name: "smart sleep voltage"
     smart_sleep_delay:
       name: "smart sleep delay"
+    emergency_duration:
+      name: "emergency duration"
     cell_soc100_voltage:
       name: "cell soc100 voltage"
     cell_soc0_voltage:

--- a/esp32-ble-v14-example-multiple-devices.yaml
+++ b/esp32-ble-v14-example-multiple-devices.yaml
@@ -211,6 +211,9 @@ number:
     smart_sleep_delay:
       name: "smart sleep delay"
       device_id: device0
+    emergency_duration:
+      name: "emergency duration"
+      device_id: device0
     cell_soc100_voltage:
       name: "cell soc100 voltage"
       device_id: device0
@@ -328,6 +331,9 @@ number:
       device_id: device1
     smart_sleep_delay:
       name: "smart sleep delay"
+      device_id: device1
+    emergency_duration:
+      name: "emergency duration"
       device_id: device1
     cell_soc100_voltage:
       name: "cell soc100 voltage"

--- a/esp32-ble-v14-example.yaml
+++ b/esp32-ble-v14-example.yaml
@@ -132,6 +132,8 @@ number:
       name: "smart sleep voltage"
     smart_sleep_delay:
       name: "smart sleep delay"
+    emergency_duration:
+      name: "emergency duration"
     cell_soc100_voltage:
       name: "cell soc100 voltage"
     cell_soc0_voltage:

--- a/esp32-ble-v15-example.yaml
+++ b/esp32-ble-v15-example.yaml
@@ -132,6 +132,8 @@ number:
       name: "smart sleep voltage"
     smart_sleep_delay:
       name: "smart sleep delay"
+    emergency_duration:
+      name: "emergency duration"
     cell_soc100_voltage:
       name: "cell soc100 voltage"
     cell_soc0_voltage:

--- a/esp32-ble-v19-3pack-olimex-poe-example.yaml
+++ b/esp32-ble-v19-3pack-olimex-poe-example.yaml
@@ -375,6 +375,9 @@ number:
     smart_sleep_delay:
       name: "smart sleep delay"
       device_id: device0
+    emergency_duration:
+      name: "emergency duration"
+      device_id: device0
 
   - platform: jk_bms_ble
     jk_bms_ble_id: bms1
@@ -505,6 +508,9 @@ number:
     smart_sleep_delay:
       name: "smart sleep delay"
       device_id: device1
+    emergency_duration:
+      name: "emergency duration"
+      device_id: device1
 
   - platform: jk_bms_ble
     jk_bms_ble_id: bms2
@@ -634,6 +640,9 @@ number:
       device_id: device2
     smart_sleep_delay:
       name: "smart sleep delay"
+      device_id: device2
+    emergency_duration:
+      name: "emergency duration"
       device_id: device2
 
 sensor:

--- a/esp32-ble-v19-example.yaml
+++ b/esp32-ble-v19-example.yaml
@@ -132,6 +132,8 @@ number:
       name: "smart sleep voltage"
     smart_sleep_delay:
       name: "smart sleep delay"
+    emergency_duration:
+      name: "emergency duration"
     cell_soc100_voltage:
       name: "cell soc100 voltage"
     cell_soc0_voltage:

--- a/tests/components/jk_bms_ble/jk_bms_ble_write_command_test.cpp
+++ b/tests/components/jk_bms_ble/jk_bms_ble_write_command_test.cpp
@@ -384,6 +384,67 @@ TEST(JkBmsWriteCommandTest, SmartSleepDelay23hFullFrame) {
   EXPECT_EQ(JkBmsBle::build_frame(0x39, 0x00000017, 0x01), expected);
 }
 
+// ── Emergency Duration (register 0xB5, 1-byte write) ─────────────────────────
+//
+// Captures recorded from a JK02_32S BMS:
+//
+//   Emergency 31 min: AA.55.90.EB.B5.01.1F.B5.C4.8C.DD.6C.11.32.3D.E2.B4.B4.59.C0
+//   Emergency 32 min: AA.55.90.EB.B5.01.20.CF.CE.23.3D.27.DF.A7.F9.96.FC.1E.E0.83
+//   Emergency 33 min: AA.55.90.EB.B5.01.21.66.2C.0E.7B.8C.CA.30.42.8F.BC.9F.7B.99
+//
+// Length byte is 0x01 (1-byte payload).  Bytes 7–18 are stale BLE-TX-buffer
+// data; build_frame() zero-initialises them — only register (byte 4), length
+// (byte 5), and value (byte 6) match the captures exactly.
+//
+// CRC = sum8(bytes[0..18]) = (AA+55+90+EB+B5+01+value) & 0xFF
+//                           = (0x330 + value) & 0xFF
+
+TEST(JkBmsWriteCommandTest, EmergencyDuration31min) {
+  // Captured: AA 55 90 EB B5 01 1F ...
+  auto f = JkBmsBle::build_frame(0xB5, 0x0000001F, 0x01);
+
+  EXPECT_EQ(f[4], 0xB5);  // register
+  EXPECT_EQ(f[5], 0x01);  // length: 1 byte
+  EXPECT_EQ(f[6], 0x1F);  // value: 31 minutes
+  EXPECT_EQ(f[7], 0x00);
+  EXPECT_EQ(f[8], 0x00);
+  EXPECT_EQ(f[9], 0x00);
+  EXPECT_EQ(f[19], 0x4F);  // CRC = (AA+55+90+EB+B5+01+1F) & FF
+}
+
+TEST(JkBmsWriteCommandTest, EmergencyDuration32min) {
+  // Captured: AA 55 90 EB B5 01 20 ...
+  auto f = JkBmsBle::build_frame(0xB5, 0x00000020, 0x01);
+
+  EXPECT_EQ(f[4], 0xB5);
+  EXPECT_EQ(f[5], 0x01);
+  EXPECT_EQ(f[6], 0x20);  // value: 32 minutes
+  EXPECT_EQ(f[19], 0x50);
+}
+
+TEST(JkBmsWriteCommandTest, EmergencyDuration33min) {
+  // Captured: AA 55 90 EB B5 01 21 ...
+  auto f = JkBmsBle::build_frame(0xB5, 0x00000021, 0x01);
+
+  EXPECT_EQ(f[4], 0xB5);
+  EXPECT_EQ(f[5], 0x01);
+  EXPECT_EQ(f[6], 0x21);  // value: 33 minutes
+  EXPECT_EQ(f[19], 0x51);
+}
+
+TEST(JkBmsWriteCommandTest, EmergencyDuration31minFullFrame) {
+  // Captured register/length/value match (bytes 7–18 differ, see file header):
+  //   AA 55 90 EB B5 01 1F B5 C4 8C DD 6C 11 32 3D E2 B4 B4 59 C0
+  // clang-format off
+  const std::array<uint8_t, 20> expected = {
+      0xAA, 0x55, 0x90, 0xEB, 0xB5, 0x01, 0x1F, 0x00,
+      0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+      0x00, 0x00, 0x00, 0x4F,
+  };
+  // clang-format on
+  EXPECT_EQ(JkBmsBle::build_frame(0xB5, 0x0000001F, 0x01), expected);
+}
+
 // ── Register uniqueness ───────────────────────────────────────────────────────
 
 TEST(JkBmsWriteCommandTest, RegistersAreDistinct) {


### PR DESCRIPTION
## Summary

- Adds `emergency_duration` number entity for JK02_32S devices (register `0xB5`, 1-byte write, unit minutes, range 1–255)
- Configures the maximum duration of an emergency override period — after this time the BMS returns to its normal fault state
- Decoded from the JK02_32S settings frame at offset 269 (`emergencyTime`)
- C++ frame tests verify three captured BLE frames (31 / 32 / 33 min) against `build_frame()`
- YAML examples updated for v11, v14, v14-multiple-devices, v15, v19, v19-3pack