### PR TITLE
Replace locally defined unit constants with esphome.const imports

### DIFF
--- a/components/heltec_balancer_ble/number/__init__.py
+++ b/components/heltec_balancer_ble/number/__init__.py
@@ -12,6 +12,7 @@ from esphome.const import (
     UNIT_AMPERE,
     UNIT_CELSIUS,
     UNIT_EMPTY,
+    UNIT_MILLISECOND,
     UNIT_SECOND,
     UNIT_VOLT,
 )
@@ -23,8 +24,6 @@ from .. import (
 )
 
 UNIT_MICROSECOND = "µs"
-UNIT_MILLISECOND = "ms"
-
 DEPENDENCIES = ["heltec_balancer_ble"]
 
 CODEOWNERS = ["@syssi"]

--- a/components/heltec_balancer_ble/sensor.py
+++ b/components/heltec_balancer_ble/sensor.py
@@ -16,7 +16,9 @@ from esphome.const import (
     UNIT_AMPERE,
     UNIT_CELSIUS,
     UNIT_EMPTY,
+    UNIT_OHM,
     UNIT_PERCENT,
+    UNIT_SECOND,
     UNIT_VOLT,
 )
 
@@ -49,9 +51,6 @@ CONF_CELL_POLARITY_ERROR_BITMASK = "cell_polarity_error_bitmask"
 CONF_CELL_EXCESSIVE_LINE_RESISTANCE_BITMASK = "cell_excessive_line_resistance_bitmask"
 
 UNIT_AMPERE_HOURS = "Ah"
-UNIT_OHM = "Ω"
-UNIT_SECONDS = "s"
-
 ICON_CURRENT_DC = "mdi:current-dc"
 ICON_CELL_RESISTANCE = "mdi:omega"
 
@@ -181,7 +180,7 @@ SENSOR_DEFS = {
         "state_class": STATE_CLASS_MEASUREMENT,
     },
     CONF_TOTAL_RUNTIME: {
-        "unit_of_measurement": UNIT_SECONDS,
+        "unit_of_measurement": UNIT_SECOND,
         "icon": ICON_TIMELAPSE,
         "accuracy_decimals": 0,
         "device_class": DEVICE_CLASS_EMPTY,

--- a/components/jk_balancer/number/__init__.py
+++ b/components/jk_balancer/number/__init__.py
@@ -11,6 +11,7 @@ from esphome.const import (
     ICON_EMPTY,
     UNIT_EMPTY,
     UNIT_MILLIAMP,
+    UNIT_MILLIVOLT,
 )
 
 from .. import CONF_JK_BALANCER_ID, JK_BALANCER_COMPONENT_SCHEMA, jk_balancer_ns
@@ -18,8 +19,6 @@ from .. import CONF_JK_BALANCER_ID, JK_BALANCER_COMPONENT_SCHEMA, jk_balancer_ns
 DEPENDENCIES = ["jk_balancer"]
 
 CODEOWNERS = ["@syssi"]
-
-UNIT_MILLIVOLT = "mV"
 
 CONF_CELL_COUNT = "cell_count"
 CONF_BALANCE_TRIGGER_VOLTAGE = "balance_trigger_voltage"

--- a/components/jk_balancer/sensor.py
+++ b/components/jk_balancer/sensor.py
@@ -49,8 +49,6 @@ ICON_CELL_COUNT_DETECTED = "mdi:car-battery"
 ICON_ERRORS_BITMASK = "mdi:alert-circle-outline"
 ICON_BALANCER_STATUS = "mdi:seesaw"
 
-UNIT_SECONDS = "s"
-UNIT_HOURS = "h"
 UNIT_AMPERE_HOURS = "Ah"
 
 CELLS = [f"cell_voltage_{i}" for i in range(1, 25)]

--- a/components/jk_bms/sensor.py
+++ b/components/jk_bms/sensor.py
@@ -19,7 +19,9 @@ from esphome.const import (
     UNIT_AMPERE,
     UNIT_CELSIUS,
     UNIT_EMPTY,
+    UNIT_HOUR,
     UNIT_PERCENT,
+    UNIT_SECOND,
     UNIT_VOLT,
     UNIT_WATT,
 )
@@ -121,8 +123,6 @@ ICON_OPERATION_MODE_BITMASK = "mdi:heart-pulse"
 ICON_CHARGING_CYCLES = "mdi:battery-sync"
 ICON_LOW_SOC_ALARM_THRESHOLD = "mdi:battery-alert"
 
-UNIT_SECONDS = "s"
-UNIT_HOURS = "h"
 UNIT_AMPERE_HOURS = "Ah"
 
 CELLS = [f"cell_voltage_{i}" for i in range(1, 25)]
@@ -318,7 +318,7 @@ SENSOR_DEFS = {
         "state_class": STATE_CLASS_MEASUREMENT,
     },
     CONF_CELL_VOLTAGE_OVERVOLTAGE_DELAY: {
-        "unit_of_measurement": UNIT_SECONDS,
+        "unit_of_measurement": UNIT_SECOND,
         "icon": ICON_TIMELAPSE,
         "accuracy_decimals": 0,
         "device_class": DEVICE_CLASS_EMPTY,
@@ -339,7 +339,7 @@ SENSOR_DEFS = {
         "state_class": STATE_CLASS_MEASUREMENT,
     },
     CONF_CELL_VOLTAGE_UNDERVOLTAGE_DELAY: {
-        "unit_of_measurement": UNIT_SECONDS,
+        "unit_of_measurement": UNIT_SECOND,
         "icon": ICON_TIMELAPSE,
         "accuracy_decimals": 0,
         "device_class": DEVICE_CLASS_EMPTY,
@@ -360,7 +360,7 @@ SENSOR_DEFS = {
         "state_class": STATE_CLASS_MEASUREMENT,
     },
     CONF_DISCHARGING_OVERCURRENT_DELAY: {
-        "unit_of_measurement": UNIT_SECONDS,
+        "unit_of_measurement": UNIT_SECOND,
         "icon": ICON_TIMELAPSE,
         "accuracy_decimals": 0,
         "device_class": DEVICE_CLASS_EMPTY,
@@ -374,7 +374,7 @@ SENSOR_DEFS = {
         "state_class": STATE_CLASS_MEASUREMENT,
     },
     CONF_CHARGING_OVERCURRENT_DELAY: {
-        "unit_of_measurement": UNIT_SECONDS,
+        "unit_of_measurement": UNIT_SECOND,
         "icon": ICON_TIMELAPSE,
         "accuracy_decimals": 0,
         "device_class": DEVICE_CLASS_EMPTY,
@@ -493,7 +493,7 @@ SENSOR_DEFS = {
         "state_class": STATE_CLASS_MEASUREMENT,
     },
     CONF_SLEEP_WAIT_TIME: {
-        "unit_of_measurement": UNIT_SECONDS,
+        "unit_of_measurement": UNIT_SECOND,
         "icon": ICON_TIMELAPSE,
         "accuracy_decimals": 0,
         "device_class": DEVICE_CLASS_EMPTY,
@@ -514,7 +514,7 @@ SENSOR_DEFS = {
         "state_class": STATE_CLASS_MEASUREMENT,
     },
     CONF_TOTAL_RUNTIME: {
-        "unit_of_measurement": UNIT_HOURS,
+        "unit_of_measurement": UNIT_HOUR,
         "icon": ICON_TIMELAPSE,
         "accuracy_decimals": 0,
         "device_class": DEVICE_CLASS_EMPTY,

--- a/components/jk_bms_ble/number/__init__.py
+++ b/components/jk_bms_ble/number/__init__.py
@@ -13,7 +13,9 @@ from esphome.const import (
     UNIT_CELSIUS,
     UNIT_EMPTY,
     UNIT_HOUR,
+    UNIT_MINUTE,
     UNIT_PERCENT,
+    UNIT_SECOND,
     UNIT_VOLT,
 )
 
@@ -198,9 +200,6 @@ CONF_SMART_SLEEP_DELAY = "smart_sleep_delay"
 CONF_EMERGENCY_DURATION = "emergency_duration"
 
 UNIT_AMPERE_HOUR = "Ah"
-UNIT_HOURS = "h"
-UNIT_MINUTES = "min"
-UNIT_SECONDS = "s"
 UNIT_MICROSECONDS = "μs"
 
 NUMBERS = {
@@ -486,7 +485,7 @@ _NUMBER_CONFIG_SCHEMA = JK_BMS_BLE_COMPONENT_SCHEMA.extend(
                 cv.Optional(CONF_MAX_VALUE, default=600): cv.float_,
                 cv.Optional(CONF_STEP, default=1.0): cv.float_,
                 cv.Optional(
-                    CONF_UNIT_OF_MEASUREMENT, default=UNIT_SECONDS
+                    CONF_UNIT_OF_MEASUREMENT, default=UNIT_SECOND
                 ): cv.string_strict,
             }
         ),
@@ -498,7 +497,7 @@ _NUMBER_CONFIG_SCHEMA = JK_BMS_BLE_COMPONENT_SCHEMA.extend(
                 cv.Optional(CONF_MAX_VALUE, default=600): cv.float_,
                 cv.Optional(CONF_STEP, default=1.0): cv.float_,
                 cv.Optional(
-                    CONF_UNIT_OF_MEASUREMENT, default=UNIT_SECONDS
+                    CONF_UNIT_OF_MEASUREMENT, default=UNIT_SECOND
                 ): cv.string_strict,
             }
         ),
@@ -510,7 +509,7 @@ _NUMBER_CONFIG_SCHEMA = JK_BMS_BLE_COMPONENT_SCHEMA.extend(
                 cv.Optional(CONF_MAX_VALUE, default=600): cv.float_,
                 cv.Optional(CONF_STEP, default=1.0): cv.float_,
                 cv.Optional(
-                    CONF_UNIT_OF_MEASUREMENT, default=UNIT_SECONDS
+                    CONF_UNIT_OF_MEASUREMENT, default=UNIT_SECOND
                 ): cv.string_strict,
             }
         ),
@@ -522,7 +521,7 @@ _NUMBER_CONFIG_SCHEMA = JK_BMS_BLE_COMPONENT_SCHEMA.extend(
                 cv.Optional(CONF_MAX_VALUE, default=600): cv.float_,
                 cv.Optional(CONF_STEP, default=1.0): cv.float_,
                 cv.Optional(
-                    CONF_UNIT_OF_MEASUREMENT, default=UNIT_SECONDS
+                    CONF_UNIT_OF_MEASUREMENT, default=UNIT_SECOND
                 ): cv.string_strict,
             }
         ),
@@ -544,7 +543,7 @@ _NUMBER_CONFIG_SCHEMA = JK_BMS_BLE_COMPONENT_SCHEMA.extend(
                 cv.Optional(CONF_MAX_VALUE, default=600): cv.float_,
                 cv.Optional(CONF_STEP, default=1.0): cv.float_,
                 cv.Optional(
-                    CONF_UNIT_OF_MEASUREMENT, default=UNIT_SECONDS
+                    CONF_UNIT_OF_MEASUREMENT, default=UNIT_SECOND
                 ): cv.string_strict,
             }
         ),
@@ -666,7 +665,7 @@ _NUMBER_CONFIG_SCHEMA = JK_BMS_BLE_COMPONENT_SCHEMA.extend(
                 cv.Optional(CONF_MAX_VALUE, default=255.0): cv.float_,
                 cv.Optional(CONF_STEP, default=1.0): cv.float_,
                 cv.Optional(
-                    CONF_UNIT_OF_MEASUREMENT, default=UNIT_SECONDS
+                    CONF_UNIT_OF_MEASUREMENT, default=UNIT_SECOND
                 ): cv.string_strict,
             }
         ),
@@ -696,7 +695,7 @@ _NUMBER_CONFIG_SCHEMA = JK_BMS_BLE_COMPONENT_SCHEMA.extend(
                 cv.Optional(CONF_MAX_VALUE, default=100): cv.float_,
                 cv.Optional(CONF_STEP, default=1.0): cv.float_,
                 cv.Optional(
-                    CONF_UNIT_OF_MEASUREMENT, default=UNIT_HOURS
+                    CONF_UNIT_OF_MEASUREMENT, default=UNIT_HOUR
                 ): cv.string_strict,
             }
         ),
@@ -706,7 +705,7 @@ _NUMBER_CONFIG_SCHEMA = JK_BMS_BLE_COMPONENT_SCHEMA.extend(
                 cv.Optional(CONF_MAX_VALUE, default=255): cv.float_,
                 cv.Optional(CONF_STEP, default=1.0): cv.float_,
                 cv.Optional(
-                    CONF_UNIT_OF_MEASUREMENT, default=UNIT_MINUTES
+                    CONF_UNIT_OF_MEASUREMENT, default=UNIT_MINUTE
                 ): cv.string_strict,
             }
         ),

--- a/components/jk_bms_ble/sensor.py
+++ b/components/jk_bms_ble/sensor.py
@@ -19,7 +19,9 @@ from esphome.const import (
     UNIT_AMPERE,
     UNIT_CELSIUS,
     UNIT_EMPTY,
+    UNIT_OHM,
     UNIT_PERCENT,
+    UNIT_SECOND,
     UNIT_VOLT,
     UNIT_WATT,
 )
@@ -66,9 +68,6 @@ CONF_UART3_PROTOCOLS_ENABLED_BITMASK = "uart3_protocols_enabled_bitmask"
 CONF_CAN_PROTOCOLS_ENABLED_BITMASK = "can_protocols_enabled_bitmask"
 
 UNIT_AMPERE_HOURS = "Ah"
-UNIT_OHM = "Ω"
-UNIT_SECONDS = "s"
-
 ICON_CURRENT_DC = "mdi:current-dc"
 ICON_CAPACITY = "mdi:battery-medium"
 ICON_MIN_VOLTAGE_CELL = "mdi:battery-minus-outline"
@@ -241,7 +240,7 @@ SENSOR_DEFS = {
         "state_class": STATE_CLASS_TOTAL_INCREASING,
     },
     CONF_TOTAL_RUNTIME: {
-        "unit_of_measurement": UNIT_SECONDS,
+        "unit_of_measurement": UNIT_SECOND,
         "icon": ICON_TIMELAPSE,
         "accuracy_decimals": 0,
         "device_class": DEVICE_CLASS_EMPTY,
@@ -255,13 +254,13 @@ SENSOR_DEFS = {
         "state_class": STATE_CLASS_MEASUREMENT,
     },
     CONF_EMERGENCY_TIME_COUNTDOWN: {
-        "unit_of_measurement": UNIT_SECONDS,
+        "unit_of_measurement": UNIT_SECOND,
         "icon": ICON_TIMELAPSE,
         "accuracy_decimals": 0,
         "device_class": DEVICE_CLASS_EMPTY,
     },
     CONF_SMART_SLEEP_COUNTDOWN: {
-        "unit_of_measurement": UNIT_SECONDS,
+        "unit_of_measurement": UNIT_SECOND,
         "icon": ICON_TIMELAPSE,
         "accuracy_decimals": 0,
         "device_class": DEVICE_CLASS_EMPTY,
@@ -280,7 +279,7 @@ SENSOR_DEFS = {
         "device_class": DEVICE_CLASS_EMPTY,
     },
     CONF_CHARGE_STATUS_TIME_ELAPSED: {
-        "unit_of_measurement": UNIT_SECONDS,
+        "unit_of_measurement": UNIT_SECOND,
         "icon": ICON_CHARGE_STATUS_TIME_ELAPSED,
         "accuracy_decimals": 0,
         "device_class": DEVICE_CLASS_EMPTY,


### PR DESCRIPTION
## Summary

Several components defined their own string constants for units that are already available in `esphome.const`. This PR removes the duplicates and imports the canonical names instead.

| Local definition | Replaced by |
|---|---|
| `UNIT_SECONDS = "s"` | `UNIT_SECOND` |
| `UNIT_HOURS = "h"` | `UNIT_HOUR` |
| `UNIT_MINUTES = "min"` | `UNIT_MINUTE` |
| `UNIT_OHM = "Ω"` | `UNIT_OHM` |
| `UNIT_MILLISECOND = "ms"` | `UNIT_MILLISECOND` |
| `UNIT_MILLIVOLT = "mV"` | `UNIT_MILLIVOLT` |

**Affected files:** `jk_bms_ble/number`, `jk_bms_ble/sensor`, `jk_bms/sensor`, `jk_balancer/number`, `jk_balancer/sensor`, `heltec_balancer_ble/number`, `heltec_balancer_ble/sensor`

No functional change — string values are identical.