### PR TITLE
Align capacity sensor names in JK-PB modbus example with jk_bms_ble

### DIFF
--- a/esp32-jk-pb-modbus-example.yaml
+++ b/esp32-jk-pb-modbus-example.yaml
@@ -1449,7 +1449,7 @@ sensor:
   # 0x12A8   168    INT32    2    R    SOCCapRemain    mAH
   - platform: modbus_controller
     modbus_controller_id: bms0
-    name: "capacity remaining derived"
+    name: "capacity remaining"
     address: 0x12A8
     register_type: holding
     value_type: U_DWORD
@@ -1465,7 +1465,7 @@ sensor:
   # 0x12AC   172   UINT32    4    R    SOCFullChargeCap    mAH
   - platform: modbus_controller
     modbus_controller_id: bms0
-    name: "actual battery capacity"
+    name: "full charge capacity"
     address: 0x12AC
     register_type: holding
     value_type: U_DWORD


### PR DESCRIPTION
## Summary

- Renames `"capacity remaining derived"` (`0x12A8` / `SOCCapRemain`) → `"capacity remaining"`
- Renames `"actual battery capacity"` (`0x12AC` / `SOCFullChargeCap`) → `"full charge capacity"`

The new names match the established naming in the `jk_bms_ble` component (`Capacity Remaining`, `Full Charge Capacity`) and eliminate the ambiguity reported in #1011: `"actual battery capacity"` incorrectly implied a real-time remaining value, while the register actually holds the full-charge / nominal capacity.

The `"state of charge"` sensor (`0x12A6` / `SOCStateOfcharge`) was already present and correctly named.

Fixes #1011