### PR TITLE
Add and align cell voltage sensors in JK-PB modbus example

### DIFF
--- a/esp32-jk-pb-modbus-example.yaml
+++ b/esp32-jk-pb-modbus-example.yaml
@@ -917,7 +917,7 @@ sensor:
   # 0x1200    0    UINT16*32    64   R    CellVol0..CellVol31    mV
   - platform: modbus_controller
     modbus_controller_id: bms0
-    name: "maximum cell voltage"
+    name: "Maximum Cell Voltage"
     address: 0x1200
     register_type: holding
     register_count: 32
@@ -936,7 +936,7 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: bms0
-    name: "minimum cell voltage"
+    name: "Minimum Cell Voltage"
     address: 0x1200
     register_type: holding
     register_count: 32
@@ -973,7 +973,7 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: bms0
-    name: "max voltage cell number"
+    name: "Maximum Voltage Cell"
     address: 0x1200
     register_type: holding
     register_count: 32
@@ -995,7 +995,7 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: bms0
-    name: "min voltage cell number"
+    name: "Minimum Voltage Cell"
     address: 0x1200
     register_type: holding
     register_count: 32

--- a/esp32-jk-pb-modbus-example.yaml
+++ b/esp32-jk-pb-modbus-example.yaml
@@ -914,6 +914,45 @@ sensor:
     filters:
       - multiply: 0.001
 
+  # 0x1200    0    UINT16*32    64   R    CellVol0..CellVol31    mV
+  - platform: modbus_controller
+    modbus_controller_id: bms0
+    name: "maximum cell voltage"
+    address: 0x1200
+    register_type: holding
+    register_count: 32
+    response_size: 64
+    unit_of_measurement: "V"
+    device_class: voltage
+    state_class: measurement
+    accuracy_decimals: 3
+    lambda: |-
+      uint16_t max_voltage = 0;
+      for (int i = 0; i < 32; i++) {
+        uint16_t cell_voltage = (data[i*2] << 8) | data[i*2+1];
+        if (cell_voltage > max_voltage) max_voltage = cell_voltage;
+      }
+      return max_voltage * 0.001f;
+
+  - platform: modbus_controller
+    modbus_controller_id: bms0
+    name: "minimum cell voltage"
+    address: 0x1200
+    register_type: holding
+    register_count: 32
+    response_size: 64
+    unit_of_measurement: "V"
+    device_class: voltage
+    state_class: measurement
+    accuracy_decimals: 3
+    lambda: |-
+      uint16_t min_voltage = 0xFFFF;
+      for (int i = 0; i < 32; i++) {
+        uint16_t cell_voltage = (data[i*2] << 8) | data[i*2+1];
+        if (cell_voltage > 500 && cell_voltage < min_voltage) min_voltage = cell_voltage;
+      }
+      return min_voltage * 0.001f;
+
   # 0x1240   64    UINT32    4    R    CellStatus    (each bit indicates a attached cell)
   # 0x1244   68    UINT16    2    R    CellVolAverage    mV
   # 0x1246   70    UINT16    2    R    CellVoltageDifferenceMax    mV
@@ -932,36 +971,49 @@ sensor:
     filters:
       - multiply: 0.001
 
-  # 0x1248   72    UINT8/UINT8 2  R    MaxVolCellNbr / MinVolCellNbr
   - platform: modbus_controller
     modbus_controller_id: bms0
     name: "max voltage cell number"
-    address: 0x1248
+    address: 0x1200
     register_type: holding
-    value_type: U_WORD
-    register_count: 44
-    response_size: 44
+    register_count: 32
+    response_size: 64
     unit_of_measurement: ""
     state_class: measurement
     accuracy_decimals: 0
-    bitmask: 0xFF00
-    filters:
-      - offset: 1.0
+    lambda: |-
+      uint16_t max_voltage = 0;
+      int max_cell = 0;
+      for (int i = 0; i < 32; i++) {
+        uint16_t cell_voltage = (data[i*2] << 8) | data[i*2+1];
+        if (cell_voltage > max_voltage) {
+          max_voltage = cell_voltage;
+          max_cell = i + 1;
+        }
+      }
+      return (float) max_cell;
 
   - platform: modbus_controller
     modbus_controller_id: bms0
     name: "min voltage cell number"
-    address: 0x1248
+    address: 0x1200
     register_type: holding
-    value_type: U_WORD
-    register_count: 2
-    response_size: 2
+    register_count: 32
+    response_size: 64
     unit_of_measurement: ""
     state_class: measurement
     accuracy_decimals: 0
-    bitmask: 0x00FF
-    filters:
-      - offset: 1.0
+    lambda: |-
+      uint16_t min_voltage = 0xFFFF;
+      int min_cell = 0;
+      for (int i = 0; i < 32; i++) {
+        uint16_t cell_voltage = (data[i*2] << 8) | data[i*2+1];
+        if (cell_voltage > 500 && cell_voltage < min_voltage) {
+          min_voltage = cell_voltage;
+          min_cell = i + 1;
+        }
+      }
+      return (float) min_cell;
 
 
   # Comment out following part if you don't want monitor wire resistance

--- a/esp32-jk-pb-modbus-example.yaml
+++ b/esp32-jk-pb-modbus-example.yaml
@@ -966,7 +966,7 @@ sensor:
     accuracy_decimals: 0
     lambda: |-
       uint16_t max_voltage = 0;
-      int max_cell = 0;
+      uint8_t max_cell = 0;
       for (int i = 0; i < 32; i++) {
         uint16_t cell_voltage = (data[i*2] << 8) | data[i*2+1];
         if (cell_voltage > max_voltage) {
@@ -988,7 +988,7 @@ sensor:
     accuracy_decimals: 0
     lambda: |-
       uint16_t min_voltage = 0xFFFF;
-      int min_cell = 0;
+      uint8_t min_cell = 0;
       for (int i = 0; i < 32; i++) {
         uint16_t cell_voltage = (data[i*2] << 8) | data[i*2+1];
         if (cell_voltage > 500 && cell_voltage < min_voltage) {

--- a/esp32-jk-pb-modbus-example.yaml
+++ b/esp32-jk-pb-modbus-example.yaml
@@ -1000,10 +1000,25 @@ sensor:
 
   # 0x1240   64    UINT32    4    R    CellStatus    (each bit indicates a attached cell)
   # 0x1244   68    UINT16    2    R    CellVolAverage    mV
+  - platform: modbus_controller
+    modbus_controller_id: bms0
+    name: "Average Cell Voltage"
+    address: 0x1244
+    register_type: holding
+    value_type: U_WORD
+    register_count: 2
+    response_size: 2
+    unit_of_measurement: "V"
+    device_class: voltage
+    state_class: measurement
+    accuracy_decimals: 3
+    filters:
+      - multiply: 0.001
+
   # 0x1246   70    UINT16    2    R    CellVoltageDifferenceMax    mV
   - platform: modbus_controller
     modbus_controller_id: bms0
-    name: "delta cell voltage"
+    name: "Delta Cell Voltage"
     address: 0x1246
     register_type: holding
     value_type: U_WORD

--- a/esp32-jk-pb-modbus-example.yaml
+++ b/esp32-jk-pb-modbus-example.yaml
@@ -917,7 +917,7 @@ sensor:
   # 0x1200    0    UINT16*32    64   R    CellVol0..CellVol31    mV
   - platform: modbus_controller
     modbus_controller_id: bms0
-    name: "Maximum Cell Voltage"
+    name: "max cell voltage"
     address: 0x1200
     register_type: holding
     register_count: 32
@@ -936,7 +936,7 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: bms0
-    name: "Minimum Cell Voltage"
+    name: "min cell voltage"
     address: 0x1200
     register_type: holding
     register_count: 32
@@ -956,7 +956,7 @@ sensor:
   # 0x1248   72    UINT8/UINT8 2  R    MaxVolCellNbr / MinVolCellNbr
   - platform: modbus_controller
     modbus_controller_id: bms0
-    name: "Maximum Voltage Cell"
+    name: "max voltage cell"
     address: 0x1200
     register_type: holding
     register_count: 32
@@ -978,7 +978,7 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: bms0
-    name: "Minimum Voltage Cell"
+    name: "min voltage cell"
     address: 0x1200
     register_type: holding
     register_count: 32
@@ -1002,7 +1002,7 @@ sensor:
   # 0x1244   68    UINT16    2    R    CellVolAverage    mV
   - platform: modbus_controller
     modbus_controller_id: bms0
-    name: "Average Cell Voltage"
+    name: "average cell voltage"
     address: 0x1244
     register_type: holding
     value_type: U_WORD
@@ -1018,7 +1018,7 @@ sensor:
   # 0x1246   70    UINT16    2    R    CellVoltageDifferenceMax    mV
   - platform: modbus_controller
     modbus_controller_id: bms0
-    name: "Delta Cell Voltage"
+    name: "delta cell voltage"
     address: 0x1246
     register_type: holding
     value_type: U_WORD

--- a/esp32-jk-pb-modbus-example.yaml
+++ b/esp32-jk-pb-modbus-example.yaml
@@ -953,24 +953,7 @@ sensor:
       }
       return min_voltage * 0.001f;
 
-  # 0x1240   64    UINT32    4    R    CellStatus    (each bit indicates a attached cell)
-  # 0x1244   68    UINT16    2    R    CellVolAverage    mV
-  # 0x1246   70    UINT16    2    R    CellVoltageDifferenceMax    mV
-  - platform: modbus_controller
-    modbus_controller_id: bms0
-    name: "delta cell voltage"
-    address: 0x1246
-    register_type: holding
-    value_type: U_WORD
-    register_count: 2
-    response_size: 2
-    unit_of_measurement: "V"
-    device_class: voltage
-    state_class: measurement
-    accuracy_decimals: 3
-    filters:
-      - multiply: 0.001
-
+  # 0x1248   72    UINT8/UINT8 2  R    MaxVolCellNbr / MinVolCellNbr
   - platform: modbus_controller
     modbus_controller_id: bms0
     name: "Maximum Voltage Cell"
@@ -1014,6 +997,24 @@ sensor:
         }
       }
       return (float) min_cell;
+
+  # 0x1240   64    UINT32    4    R    CellStatus    (each bit indicates a attached cell)
+  # 0x1244   68    UINT16    2    R    CellVolAverage    mV
+  # 0x1246   70    UINT16    2    R    CellVoltageDifferenceMax    mV
+  - platform: modbus_controller
+    modbus_controller_id: bms0
+    name: "delta cell voltage"
+    address: 0x1246
+    register_type: holding
+    value_type: U_WORD
+    register_count: 2
+    response_size: 2
+    unit_of_measurement: "V"
+    device_class: voltage
+    state_class: measurement
+    accuracy_decimals: 3
+    filters:
+      - multiply: 0.001
 
 
   # Comment out following part if you don't want monitor wire resistance


### PR DESCRIPTION
## Summary

- Adds `min cell voltage` and `max cell voltage` sensors derived from a single batch read of all 32 cell voltage registers (`0x1200`, 64 bytes) via a lambda loop
- Adds `max voltage cell` and `min voltage cell` sensors from the same batch read, replacing the previous `MaxVolCellNbr`/`MinVolCellNbr` register approach (`0x1248`) which could report incorrect values depending on firmware
- Adds missing `average cell voltage` sensor (`0x1244`)
- All sensor names aligned with the `jk_bms_ble` example YAML (lowercase)

Since all four lambda sensors share the same `address`/`register_count`, ESPHome's `modbus_controller` coalesces them into a single Modbus request.

Closes #939