### PR TITLE
CI: Remove pio warmup step for esp32-idf-tidy

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -370,13 +370,6 @@ jobs:
           echo "::add-matcher::.github/workflows/matchers/gcc.json"
           echo "::add-matcher::.github/workflows/matchers/clang-tidy.json"
 
-      - name: Run 'pio run --list-targets -e esp32-idf-tidy'
-        if: matrix.name == 'Run script/clang-tidy for ESP32 IDF'
-        run: |
-          . venv/bin/activate
-          mkdir -p .temp
-          pio run --list-targets -e esp32-idf-tidy
-
       - name: Install clang-tidy
         run: |
           . venv/bin/activate


### PR DESCRIPTION
## Summary

- `esphome/esphome@8aa4157` added a conditional `fastled/FastLED` rule in `idf_component.yml` that requires the `ESPHOME_ARDUINO` environment variable to be set
- The ESP-IDF component manager evaluates this rule during cmake configure — which the `pio run --list-targets -e esp32-idf-tidy` warmup step triggers **without** `ESPHOME_ARDUINO` being set, causing the build to fail with `ERROR: Environment variable "ESPHOME_ARDUINO" is not set`
- `script/clang-tidy` itself sets this variable correctly via `clang_tidy.py`, so the warmup step is not needed
- The upstream esphome CI already removed this step in `esphome/esphome@351b986`