### PR TITLE
Fix heltec_balancer_ble frame reassembly on small BLE MTU

### DIFF
--- a/components/heltec_balancer_ble/heltec_balancer_ble.cpp
+++ b/components/heltec_balancer_ble/heltec_balancer_ble.cpp
@@ -392,10 +392,6 @@ void HeltecBalancerBle::assemble(const uint8_t *data, uint16_t length) {
   if (this->frame_buffer_.size() < FRAME_HEADER_SIZE)
     return;
 
-  // Rely on the frame's own declared length (offset 6/7) instead of scanning for a trailing
-  // END_OF_FRAME byte: with a small BLE MTU a frame is split into many fragments, and any of
-  // them can end on a data byte that happens to equal 0xFF, which used to trigger a premature
-  // CRC check against a still-incomplete buffer (https://github.com/syssi/esphome-jk-bms/issues/1031).
   const uint16_t frame_size = (uint16_t(this->frame_buffer_[7]) << 8) | uint16_t(this->frame_buffer_[6]);
   if (frame_size < MIN_RESPONSE_SIZE || frame_size > MAX_RESPONSE_SIZE) {
     ESP_LOGW(TAG, "Frame dropped because of invalid length");

--- a/components/heltec_balancer_ble/heltec_balancer_ble.cpp
+++ b/components/heltec_balancer_ble/heltec_balancer_ble.cpp
@@ -38,6 +38,9 @@ static const uint8_t END_OF_FRAME = 0xFF;
 static const uint16_t MIN_RESPONSE_SIZE = 20;   // Write acknowledge frame
 static const uint16_t MAX_RESPONSE_SIZE = 300;  // Cell info frame
 
+// Preamble(2) + device address(1) + function(1) + command(2) + length(2)
+static const uint8_t FRAME_HEADER_SIZE = 8;
+
 static const uint8_t OPERATION_STATUS_SIZE = 13;
 static constexpr const char *const OPERATION_STATUS[OPERATION_STATUS_SIZE] = {
     "Unknown",                                   // 0x00
@@ -84,6 +87,11 @@ uint8_t crc(const uint8_t data[], const uint16_t len) {
     crc = crc + data[i];
   }
   return crc;
+}
+
+// Every response frame declares its own total size (header + payload + CRC + EOF) at offset 6/7.
+uint16_t declared_frame_size(const std::vector<uint8_t> &buffer) {
+  return (uint16_t(buffer[7]) << 8) | uint16_t(buffer[6]);
 }
 
 void HeltecBalancerBle::dump_config() {  // NOLINT(google-readability-function-size,readability-function-size)
@@ -386,23 +394,42 @@ void HeltecBalancerBle::assemble(const uint8_t *data, uint16_t length) {
 
   this->frame_buffer_.insert(this->frame_buffer_.end(), data, data + length);
 
-  if (this->frame_buffer_.size() >= MIN_RESPONSE_SIZE && this->frame_buffer_.back() == END_OF_FRAME) {
-    const uint8_t *raw = &this->frame_buffer_[0];
-    const uint16_t frame_size = this->frame_buffer_.size();
+  if (this->frame_buffer_.size() < FRAME_HEADER_SIZE)
+    return;
 
-    uint8_t computed_crc = crc(raw, frame_size - 2);
-    uint8_t remote_crc = raw[frame_size - 2];
-    if (computed_crc != remote_crc) {
-      ESP_LOGW(TAG, "CRC check failed! 0x%02X != 0x%02X", computed_crc, remote_crc);
-      this->frame_buffer_.clear();
-      return;
-    }
-
-    std::vector<uint8_t> data(this->frame_buffer_.begin(), this->frame_buffer_.end());
-
-    this->decode_(data);
+  // Rely on the frame's own declared length instead of scanning for a trailing END_OF_FRAME
+  // byte: with a small BLE MTU a frame is split into many fragments, and any of them can end
+  // on a data byte that happens to equal 0xFF, which used to trigger a premature CRC check
+  // against a still-incomplete buffer (https://github.com/syssi/esphome-jk-bms/issues/1031).
+  const uint16_t frame_size = declared_frame_size(this->frame_buffer_);
+  if (frame_size < MIN_RESPONSE_SIZE || frame_size > MAX_RESPONSE_SIZE) {
+    ESP_LOGW(TAG, "Frame dropped because of invalid length");
     this->frame_buffer_.clear();
+    return;
   }
+
+  if (this->frame_buffer_.size() < frame_size)
+    return;  // Wait for the remaining fragments
+
+  const uint8_t *raw = &this->frame_buffer_[0];
+  if (raw[frame_size - 1] != END_OF_FRAME) {
+    ESP_LOGW(TAG, "Frame dropped because of missing end of frame marker");
+    this->frame_buffer_.clear();
+    return;
+  }
+
+  uint8_t computed_crc = crc(raw, frame_size - 2);
+  uint8_t remote_crc = raw[frame_size - 2];
+  if (computed_crc != remote_crc) {
+    ESP_LOGW(TAG, "CRC check failed! 0x%02X != 0x%02X", computed_crc, remote_crc);
+    this->frame_buffer_.clear();
+    return;
+  }
+
+  std::vector<uint8_t> frame(this->frame_buffer_.begin(), this->frame_buffer_.begin() + frame_size);
+
+  this->decode_(frame);
+  this->frame_buffer_.clear();
 }
 
 void HeltecBalancerBle::decode_(const std::vector<uint8_t> &data) {

--- a/components/heltec_balancer_ble/heltec_balancer_ble.cpp
+++ b/components/heltec_balancer_ble/heltec_balancer_ble.cpp
@@ -40,6 +40,7 @@ static const uint16_t MAX_RESPONSE_SIZE = 300;  // Cell info frame
 
 // Preamble(2) + device address(1) + function(1) + command(2) + length(2)
 static const uint8_t FRAME_HEADER_SIZE = 8;
+static const uint8_t FRAME_LENGTH_OFFSET = 6;
 
 static const uint8_t OPERATION_STATUS_SIZE = 13;
 static constexpr const char *const OPERATION_STATUS[OPERATION_STATUS_SIZE] = {
@@ -377,11 +378,6 @@ void HeltecBalancerBle::update() {}
 
 // TODO: There is no need to assemble frames if the MTU can be increased to > MAX_RESPONSE_SIZE
 void HeltecBalancerBle::assemble(const uint8_t *data, uint16_t length) {
-  if (this->frame_buffer_.size() > MAX_RESPONSE_SIZE) {
-    ESP_LOGW(TAG, "Frame dropped because of invalid length");
-    this->frame_buffer_.clear();
-  }
-
   // Flush buffer on every preamble
   if (length >= 2 && data[0] == SOF_RESPONSE_BYTE1 && data[1] == SOF_RESPONSE_BYTE2) {
     this->frame_buffer_.clear();
@@ -392,7 +388,8 @@ void HeltecBalancerBle::assemble(const uint8_t *data, uint16_t length) {
   if (this->frame_buffer_.size() < FRAME_HEADER_SIZE)
     return;
 
-  const uint16_t frame_size = (uint16_t(this->frame_buffer_[7]) << 8) | uint16_t(this->frame_buffer_[6]);
+  const uint16_t frame_size = (uint16_t(this->frame_buffer_[FRAME_LENGTH_OFFSET + 1]) << 8) |
+                              uint16_t(this->frame_buffer_[FRAME_LENGTH_OFFSET]);
   if (frame_size < MIN_RESPONSE_SIZE || frame_size > MAX_RESPONSE_SIZE) {
     ESP_LOGW(TAG, "Frame dropped because of invalid length");
     this->frame_buffer_.clear();
@@ -417,10 +414,10 @@ void HeltecBalancerBle::assemble(const uint8_t *data, uint16_t length) {
     return;
   }
 
-  std::vector<uint8_t> frame(this->frame_buffer_.begin(), this->frame_buffer_.begin() + frame_size);
+  const std::vector<uint8_t> frame(this->frame_buffer_.begin(), this->frame_buffer_.begin() + frame_size);
+  this->frame_buffer_.erase(this->frame_buffer_.begin(), this->frame_buffer_.begin() + frame_size);
 
   this->decode_(frame);
-  this->frame_buffer_.clear();
 }
 
 void HeltecBalancerBle::decode_(const std::vector<uint8_t> &data) {

--- a/components/heltec_balancer_ble/heltec_balancer_ble.cpp
+++ b/components/heltec_balancer_ble/heltec_balancer_ble.cpp
@@ -89,11 +89,6 @@ uint8_t crc(const uint8_t data[], const uint16_t len) {
   return crc;
 }
 
-// Every response frame declares its own total size (header + payload + CRC + EOF) at offset 6/7.
-uint16_t declared_frame_size(const std::vector<uint8_t> &buffer) {
-  return (uint16_t(buffer[7]) << 8) | uint16_t(buffer[6]);
-}
-
 void HeltecBalancerBle::dump_config() {  // NOLINT(google-readability-function-size,readability-function-size)
   ESP_LOGCONFIG(TAG, "HeltecBalancerBle");
   LOG_BINARY_SENSOR("", "Balancing", this->balancing_binary_sensor_);
@@ -397,11 +392,11 @@ void HeltecBalancerBle::assemble(const uint8_t *data, uint16_t length) {
   if (this->frame_buffer_.size() < FRAME_HEADER_SIZE)
     return;
 
-  // Rely on the frame's own declared length instead of scanning for a trailing END_OF_FRAME
-  // byte: with a small BLE MTU a frame is split into many fragments, and any of them can end
-  // on a data byte that happens to equal 0xFF, which used to trigger a premature CRC check
-  // against a still-incomplete buffer (https://github.com/syssi/esphome-jk-bms/issues/1031).
-  const uint16_t frame_size = declared_frame_size(this->frame_buffer_);
+  // Rely on the frame's own declared length (offset 6/7) instead of scanning for a trailing
+  // END_OF_FRAME byte: with a small BLE MTU a frame is split into many fragments, and any of
+  // them can end on a data byte that happens to equal 0xFF, which used to trigger a premature
+  // CRC check against a still-incomplete buffer (https://github.com/syssi/esphome-jk-bms/issues/1031).
+  const uint16_t frame_size = (uint16_t(this->frame_buffer_[7]) << 8) | uint16_t(this->frame_buffer_[6]);
   if (frame_size < MIN_RESPONSE_SIZE || frame_size > MAX_RESPONSE_SIZE) {
     ESP_LOGW(TAG, "Frame dropped because of invalid length");
     this->frame_buffer_.clear();

--- a/tests/components/heltec_balancer_ble/assemble_test.cpp
+++ b/tests/components/heltec_balancer_ble/assemble_test.cpp
@@ -120,6 +120,78 @@ TEST(AssembleTest, OddSizedFragmentsReassembleCellInfo) {
   EXPECT_NEAR(total.state, 53.22f, 0.01f);
 }
 
+// ── Invalid length field ──────────────────────────────────────────────────────
+
+TEST(AssembleTest, LengthFieldBelowMinimumIsDropped) {
+  TestableHeltecBalancerBle bms;
+  sensor::Sensor total;
+  bms.set_total_voltage_sensor(&total);
+
+  std::vector<uint8_t> broken = ek::CELL_INFO_FRAME;
+  broken[6] = 0x05;
+  broken[7] = 0x00;
+
+  bms.assemble(broken.data(), broken.size());
+  EXPECT_TRUE(std::isnan(total.state));
+
+  bms.assemble(ek::CELL_INFO_FRAME.data(), ek::CELL_INFO_FRAME.size());
+  EXPECT_NEAR(total.state, 53.22f, 0.01f);
+}
+
+TEST(AssembleTest, LengthFieldAboveMaximumIsDropped) {
+  TestableHeltecBalancerBle bms;
+  sensor::Sensor total;
+  bms.set_total_voltage_sensor(&total);
+
+  std::vector<uint8_t> broken = ek::CELL_INFO_FRAME;
+  broken[6] = 0x00;
+  broken[7] = 0x04;
+
+  bms.assemble(broken.data(), broken.size());
+  EXPECT_TRUE(std::isnan(total.state));
+
+  bms.assemble(ek::CELL_INFO_FRAME.data(), ek::CELL_INFO_FRAME.size());
+  EXPECT_NEAR(total.state, 53.22f, 0.01f);
+}
+
+// ── Missing end of frame marker ───────────────────────────────────────────────
+
+TEST(AssembleTest, MissingEndOfFrameMarkerIsDropped) {
+  TestableHeltecBalancerBle bms;
+  sensor::Sensor total;
+  bms.set_total_voltage_sensor(&total);
+
+  std::vector<uint8_t> broken = ek::CELL_INFO_FRAME;
+  broken.back() = 0x00;
+
+  bms.assemble(broken.data(), broken.size());
+  EXPECT_TRUE(std::isnan(total.state));
+
+  bms.assemble(ek::CELL_INFO_FRAME.data(), ek::CELL_INFO_FRAME.size());
+  EXPECT_NEAR(total.state, 53.22f, 0.01f);
+}
+
+// ── Trailing bytes of the next frame are retained ─────────────────────────────
+
+TEST(AssembleTest, FragmentSpanningTwoFramesDecodesBoth) {
+  TestableHeltecBalancerBle bms;
+  sensor::Sensor runtime, total;
+  bms.set_total_runtime_sensor(&runtime);
+  bms.set_total_voltage_sensor(&total);
+
+  std::vector<uint8_t> stream = ek::DEVICE_INFO_FRAME;
+  stream.insert(stream.end(), ek::CELL_INFO_FRAME.begin(), ek::CELL_INFO_FRAME.end());
+
+  const size_t mtu_payload = 64;
+  for (size_t offset = 0; offset < stream.size(); offset += mtu_payload) {
+    size_t chunk = std::min(mtu_payload, stream.size() - offset);
+    bms.assemble(&stream[offset], chunk);
+  }
+
+  EXPECT_FLOAT_EQ(runtime.state, 127854.0f);
+  EXPECT_NEAR(total.state, 53.22f, 0.01f);
+}
+
 // ── Resync after a lost frame ─────────────────────────────────────────────────
 
 TEST(AssembleTest, FreshPreambleResyncsAfterAbandonedFrame) {

--- a/tests/components/heltec_balancer_ble/assemble_test.cpp
+++ b/tests/components/heltec_balancer_ble/assemble_test.cpp
@@ -1,0 +1,154 @@
+#include <gtest/gtest.h>
+#include <algorithm>
+#include <cmath>
+#include "common.h"
+#include "frames_ek-24s4eb.h"
+#include "frames_gw-24s4eb.h"
+
+namespace esphome::heltec_balancer_ble::testing {
+
+// ── Single fragment (MTU large enough for the whole frame) ────────────────────
+
+TEST(AssembleTest, SingleFragmentDecodesCellInfo) {
+  TestableHeltecBalancerBle bms;
+  sensor::Sensor total;
+  bms.set_total_voltage_sensor(&total);
+
+  bms.assemble(ek::CELL_INFO_FRAME.data(), ek::CELL_INFO_FRAME.size());
+
+  EXPECT_NEAR(total.state, 53.22f, 0.01f);
+}
+
+TEST(AssembleTest, CorruptedCrcIsRejected) {
+  TestableHeltecBalancerBle bms;
+  sensor::Sensor total;
+  bms.set_total_voltage_sensor(&total);
+
+  std::vector<uint8_t> corrupted = ek::CELL_INFO_FRAME;
+  corrupted[corrupted.size() - 2] ^= 0xFF;  // flip the CRC byte
+
+  bms.assemble(corrupted.data(), corrupted.size());
+
+  EXPECT_TRUE(std::isnan(total.state));  // never decoded, sensor keeps its unset state
+}
+
+// ── Small-MTU fragmentation ─────────────────────────────────────────────────
+//
+// Regression coverage for https://github.com/syssi/esphome-jk-bms/issues/1031: a poor BLE
+// connection can force the peripheral down to a tiny MTU, so a single 300-byte cell info
+// frame arrives as many short notifications. The old assemble() treated a frame as complete
+// as soon as the accumulated buffer happened to end on 0xFF (END_OF_FRAME) -- but 0xFF also
+// occurs as an ordinary data byte (byte 137 of this real EK-24S4EB capture sits inside a cell
+// resistance float), so a fragment boundary landing there produced a bogus "CRC check failed"
+// and silently dropped the whole frame.
+
+TEST(AssembleTest, StrayFFByteInsidePayloadDoesNotTerminateFrameEarly) {
+  ASSERT_EQ(ek::CELL_INFO_FRAME[137], 0xFF);  // the byte that used to trigger the bug
+
+  TestableHeltecBalancerBle bms;
+  sensor::Sensor total;
+  bms.set_total_voltage_sensor(&total);
+
+  // Deliver byte-by-byte: the buffer's last byte equals 0xFF the moment byte 137 arrives
+  // (buffer size 138), long before the real 300-byte frame is complete.
+  for (uint8_t b : ek::CELL_INFO_FRAME) {
+    bms.assemble(&b, 1);
+  }
+
+  EXPECT_NEAR(total.state, 53.22f, 0.01f);
+}
+
+TEST(AssembleTest, IncompleteFrameDoesNotDecodeYet) {
+  TestableHeltecBalancerBle bms;
+  sensor::Sensor total;
+  bms.set_total_voltage_sensor(&total);
+
+  bms.assemble(ek::CELL_INFO_FRAME.data(), 138);  // header + the stray 0xFF byte, nothing more
+  EXPECT_TRUE(std::isnan(total.state));           // still waiting for the remaining 162 bytes
+
+  bms.assemble(ek::CELL_INFO_FRAME.data() + 138, ek::CELL_INFO_FRAME.size() - 138);
+  EXPECT_NEAR(total.state, 53.22f, 0.01f);
+}
+
+TEST(AssembleTest, RealisticSmallMtuFragmentsReassembleEkCellInfo) {
+  TestableHeltecBalancerBle bms;
+  sensor::Sensor cell1, total, temp1;
+  bms.set_cell_voltage_sensor(0, &cell1);
+  bms.set_total_voltage_sensor(&total);
+  bms.set_temperature_sensor_1_sensor(&temp1);
+
+  const size_t mtu_payload = 20;  // matches the real GW-24S4EB btsnoop capture chunk size
+  const auto &frame = ek::CELL_INFO_FRAME;
+  for (size_t offset = 0; offset < frame.size(); offset += mtu_payload) {
+    size_t chunk = std::min(mtu_payload, frame.size() - offset);
+    bms.assemble(&frame[offset], chunk);
+  }
+
+  EXPECT_NEAR(cell1.state, 3.325f, 0.001f);
+  EXPECT_NEAR(total.state, 53.22f, 0.01f);
+  EXPECT_NEAR(temp1.state, 25.71f, 0.01f);
+}
+
+TEST(AssembleTest, RealisticSmallMtuFragmentsReassembleGwCellInfo) {
+  TestableHeltecBalancerBle bms;
+  sensor::Sensor total;
+  bms.set_total_voltage_sensor(&total);
+
+  const size_t mtu_payload = 20;
+  const auto &frame = gw::CELL_INFO_FRAME;
+  for (size_t offset = 0; offset < frame.size(); offset += mtu_payload) {
+    size_t chunk = std::min(mtu_payload, frame.size() - offset);
+    bms.assemble(&frame[offset], chunk);
+  }
+
+  EXPECT_NEAR(total.state, 53.16f, 0.01f);
+}
+
+TEST(AssembleTest, OddSizedFragmentsReassembleCellInfo) {
+  TestableHeltecBalancerBle bms;
+  sensor::Sensor total;
+  bms.set_total_voltage_sensor(&total);
+
+  // Fragment sizes that don't evenly divide the frame and don't align with byte 137.
+  const size_t mtu_payload = 23;
+  const auto &frame = ek::CELL_INFO_FRAME;
+  for (size_t offset = 0; offset < frame.size(); offset += mtu_payload) {
+    size_t chunk = std::min(mtu_payload, frame.size() - offset);
+    bms.assemble(&frame[offset], chunk);
+  }
+
+  EXPECT_NEAR(total.state, 53.22f, 0.01f);
+}
+
+// ── Resync after a lost frame ─────────────────────────────────────────────────
+
+TEST(AssembleTest, FreshPreambleResyncsAfterAbandonedFrame) {
+  TestableHeltecBalancerBle bms;
+  sensor::Sensor total;
+  bms.set_total_voltage_sensor(&total);
+
+  // Half of a cell info frame is lost mid-transmission (e.g. a BLE disconnect glitch)...
+  bms.assemble(ek::CELL_INFO_FRAME.data(), 100);
+  // ...then a new, unrelated frame starts. The stale half must be discarded, not prepended.
+  bms.assemble(ek::DEVICE_INFO_FRAME.data(), ek::DEVICE_INFO_FRAME.size());
+  bms.assemble(ek::CELL_INFO_FRAME.data(), ek::CELL_INFO_FRAME.size());
+
+  EXPECT_NEAR(total.state, 53.22f, 0.01f);
+}
+
+// ── Multiple frames in sequence (as dispatched on ESP32) ──────────────────────
+
+TEST(AssembleTest, DeviceInfoThenCellInfoBothDecode) {
+  TestableHeltecBalancerBle bms;
+  sensor::Sensor runtime, total;
+  bms.set_total_runtime_sensor(&runtime);
+  bms.set_total_voltage_sensor(&total);
+
+  bms.assemble(ek::DEVICE_INFO_FRAME.data(), ek::DEVICE_INFO_FRAME.size());
+  bms.assemble(ek::CELL_INFO_FRAME.data(), ek::CELL_INFO_FRAME.size());
+
+  EXPECT_FLOAT_EQ(runtime.state, 127854.0f);
+  EXPECT_NEAR(total.state, 53.22f, 0.01f);
+}
+
+}  // namespace esphome::heltec_balancer_ble::testing


### PR DESCRIPTION
## Summary

- `assemble()` treated a frame as complete as soon as the accumulated buffer happened to end on `0xFF` (`END_OF_FRAME`). That byte also occurs as an ordinary data byte inside the payload (e.g. byte 137 of the real EK-24S4EB cell info capture used in the tests, which sits inside a cell resistance float).
- Once a poor BLE connection forces the peripheral down to a small MTU, a 300-byte cell info frame is split into many short notifications, and a fragment boundary landing on such a byte triggered a CRC check against a still-incomplete buffer and dropped the frame — matching the constant `CRC check failed!` spam reported in #1031.
- Fix: use the frame's own declared length field (offset 6/7, present in every response frame but previously unused) to decide when a frame is actually complete, instead of relying on a coincidental trailing `0xFF`. This mirrors what `jk_bms_ble` already does for its fixed-size frames.
- Renamed a local variable that was shadowing the `data` parameter (pre-existing, surfaced by the refactor).

## Test plan

- [x] Added `tests/components/heltec_balancer_ble/assemble_test.cpp`: single-fragment happy path, corrupted CRC still rejected, byte-by-byte reassembly across the real stray `0xFF` byte (direct regression test for #1031), realistic small-MTU (20-byte) fragment reassembly for both EK and GW captures, odd-sized fragments, resync after an abandoned frame, and multi-frame dispatch sequencing.
- [x] `python3 script/cpp_unit_test.py heltec_balancer_ble` — 115/115 tests pass.
- [x] `esphome compile esp32-heltec-balancer-ble-example-faker-ek-24s4eb.yaml` — builds successfully.
- [x] `clang-format --dry-run --Werror` clean.