### PR TITLE
Expose device model, manufacturing date and serial number in jk_bms_ble

### DIFF
--- a/components/jk_bms_ble/jk_bms_ble.cpp
+++ b/components/jk_bms_ble/jk_bms_ble.cpp
@@ -447,6 +447,9 @@ void JkBmsBle::dump_config() {  // NOLINT(google-readability-function-size,reada
   LOG_TEXT_SENSOR("", "Software Version", this->software_version_text_sensor_);
   LOG_TEXT_SENSOR("", "Hardware Version", this->hardware_version_text_sensor_);
   LOG_TEXT_SENSOR("", "Battery Type", this->battery_type_text_sensor_);
+  LOG_TEXT_SENSOR("", "Device Model", this->device_model_text_sensor_);
+  LOG_TEXT_SENSOR("", "Manufacturing Date", this->manufacturing_date_text_sensor_);
+  LOG_TEXT_SENSOR("", "Serial Number", this->serial_number_text_sensor_);
 }
 
 #ifdef USE_ESP32
@@ -1687,8 +1690,10 @@ void JkBmsBle::decode_device_info_(const std::vector<uint8_t> &data) {
   // 0     4   0x55 0xAA 0xEB 0x90    Header
   // 4     1   0x03                   Frame type
   // 5     1   0xC9                   Frame counter
-  // 6    16   0x4A 0x4B 0x5F 0x50 0x42 0x32 0x41 0x31 0x36 0x53 0x31 0x35 0x50 0x00 0x00 0x00
-  ESP_LOGI(TAG, "  Vendor ID: %s", std::string(data.begin() + 6, data.begin() + 6 + 16).c_str());
+  // 6    16   0x4A 0x4B 0x5F 0x50 0x42 0x32 0x41 0x31 0x36 0x53 0x31 0x35 0x50 0x00 0x00 0x00    Vendor ID / model
+  auto device_model_begin = data.begin() + 6;
+  this->publish_state_(this->device_model_text_sensor_,
+                       std::string(device_model_begin, std::find(device_model_begin, device_model_begin + 16, '\0')));
 
   // 22    8   0x31 0x34 0x2E 0x58 0x41 0x00 0x00 0x00    Hardware version
   auto hardware_version_begin = data.begin() + 22;
@@ -1714,12 +1719,17 @@ void JkBmsBle::decode_device_info_(const std::vector<uint8_t> &data) {
   // 62   16   0x31 0x32 0x33 0x34 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00
   ESP_LOGI(TAG, "  Device passcode: %s", std::string(data.begin() + 62, data.begin() + 62 + 16).c_str());
 
-  // 78    8   0x32 0x33 0x31 0x31 0x31 0x38 0x00 0x00
-  ESP_LOGI(TAG, "  Manufacturing date: 20%.2s-%.2s-%.2s", (const char *) &data[78], (const char *) &data[80],
-           (const char *) &data[82]);
+  // 78    6   0x32 0x33 0x31 0x31 0x31 0x38    Manufacturing date (YYMMDD), empty on JK04
+  auto manufacturing_date_begin = data.begin() + 78;
+  this->publish_state_(
+      this->manufacturing_date_text_sensor_,
+      data[78] == '\0' ? "" : "20" + std::string(manufacturing_date_begin, manufacturing_date_begin + 6));
 
-  // 86    8   0x33 0x30 0x39 0x32 0x35 0x37 0x32 0x31 0x33 0x34 0x00
-  ESP_LOGI(TAG, "  Serial number: %s", std::string(data.begin() + 86, data.begin() + 86 + 11).c_str());
+  // 86    8   0x33 0x30 0x39 0x32 0x35 0x37 0x32 0x31 0x33 0x34 0x00    Serial number
+  auto serial_number_begin = data.begin() + 86;
+  this->publish_state_(
+      this->serial_number_text_sensor_,
+      std::string(serial_number_begin, std::find(serial_number_begin, serial_number_begin + 11, '\0')));
 
   // 97    5   0x30 0x30 0x30 0x30 0x00
   ESP_LOGI(TAG, "  Passcode: %s", std::string(data.begin() + 97, data.begin() + 97 + 5).c_str());

--- a/components/jk_bms_ble/jk_bms_ble.h
+++ b/components/jk_bms_ble/jk_bms_ble.h
@@ -326,6 +326,15 @@ class JkBmsBle :
   void set_battery_type_text_sensor(text_sensor::TextSensor *battery_type_text_sensor) {
     battery_type_text_sensor_ = battery_type_text_sensor;
   }
+  void set_device_model_text_sensor(text_sensor::TextSensor *device_model_text_sensor) {
+    device_model_text_sensor_ = device_model_text_sensor;
+  }
+  void set_manufacturing_date_text_sensor(text_sensor::TextSensor *manufacturing_date_text_sensor) {
+    manufacturing_date_text_sensor_ = manufacturing_date_text_sensor;
+  }
+  void set_serial_number_text_sensor(text_sensor::TextSensor *serial_number_text_sensor) {
+    serial_number_text_sensor_ = serial_number_text_sensor;
+  }
 
   void set_charging_switch(switch_::Switch *charging_switch) { charging_switch_ = charging_switch; }
   void set_discharging_switch(switch_::Switch *discharging_switch) { discharging_switch_ = discharging_switch; }
@@ -539,6 +548,9 @@ class JkBmsBle :
   text_sensor::TextSensor *software_version_text_sensor_{nullptr};
   text_sensor::TextSensor *hardware_version_text_sensor_{nullptr};
   text_sensor::TextSensor *battery_type_text_sensor_{nullptr};
+  text_sensor::TextSensor *device_model_text_sensor_{nullptr};
+  text_sensor::TextSensor *manufacturing_date_text_sensor_{nullptr};
+  text_sensor::TextSensor *serial_number_text_sensor_{nullptr};
 
   std::vector<uint8_t> frame_buffer_;
   bool status_notification_received_ = false;

--- a/components/jk_bms_ble/text_sensor.py
+++ b/components/jk_bms_ble/text_sensor.py
@@ -17,11 +17,17 @@ CONF_CHARGE_STATUS = "charge_status"
 CONF_SOFTWARE_VERSION = "software_version"
 CONF_HARDWARE_VERSION = "hardware_version"
 CONF_BATTERY_TYPE = "battery_type"
+CONF_DEVICE_MODEL = "device_model"
+CONF_MANUFACTURING_DATE = "manufacturing_date"
+CONF_SERIAL_NUMBER = "serial_number"
 
 ICON_ERRORS = "mdi:alert-circle-outline"
 ICON_BALANCER_STATUS = "mdi:heart-pulse"
 ICON_CHARGE_STATUS = "mdi:battery-clock"
 ICON_BATTERY_TYPE = "mdi:battery-heart-variant"
+ICON_DEVICE_MODEL = "mdi:chip"
+ICON_MANUFACTURING_DATE = "mdi:calendar"
+ICON_SERIAL_NUMBER = "mdi:identifier"
 
 TEXT_SENSORS = [
     CONF_ERRORS,
@@ -32,6 +38,9 @@ TEXT_SENSORS = [
     CONF_SOFTWARE_VERSION,
     CONF_HARDWARE_VERSION,
     CONF_BATTERY_TYPE,
+    CONF_DEVICE_MODEL,
+    CONF_MANUFACTURING_DATE,
+    CONF_SERIAL_NUMBER,
 ]
 
 _RENAMED_TEXT_SENSORS = {
@@ -68,6 +77,18 @@ CONFIG_SCHEMA = cv.All(
             ),
             cv.Optional(CONF_BATTERY_TYPE): text_sensor.text_sensor_schema(
                 icon=ICON_BATTERY_TYPE,
+                entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+            ),
+            cv.Optional(CONF_DEVICE_MODEL): text_sensor.text_sensor_schema(
+                icon=ICON_DEVICE_MODEL,
+                entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+            ),
+            cv.Optional(CONF_MANUFACTURING_DATE): text_sensor.text_sensor_schema(
+                icon=ICON_MANUFACTURING_DATE,
+                entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+            ),
+            cv.Optional(CONF_SERIAL_NUMBER): text_sensor.text_sensor_schema(
+                icon=ICON_SERIAL_NUMBER,
                 entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
             ),
         }

--- a/esp32-ble-example-multiple-devices.yaml
+++ b/esp32-ble-example-multiple-devices.yaml
@@ -292,6 +292,15 @@ text_sensor:
     hardware_version:
       name: "hardware version"
       device_id: device0
+    device_model:
+      name: "device model"
+      device_id: device0
+    manufacturing_date:
+      name: "manufacturing date"
+      device_id: device0
+    serial_number:
+      name: "serial number"
+      device_id: device0
 
   - platform: jk_bms_ble
     jk_bms_ble_id: bms1
@@ -309,4 +318,13 @@ text_sensor:
       device_id: device1
     hardware_version:
       name: "hardware version"
+      device_id: device1
+    device_model:
+      name: "device model"
+      device_id: device1
+    manufacturing_date:
+      name: "manufacturing date"
+      device_id: device1
+    serial_number:
+      name: "serial number"
       device_id: device1

--- a/esp32-ble-example.yaml
+++ b/esp32-ble-example.yaml
@@ -325,3 +325,9 @@ text_sensor:
       name: "software version"
     hardware_version:
       name: "hardware version"
+    device_model:
+      name: "device model"
+    manufacturing_date:
+      name: "manufacturing date"
+    serial_number:
+      name: "serial number"

--- a/esp32-ble-jk04-example.yaml
+++ b/esp32-ble-jk04-example.yaml
@@ -228,3 +228,5 @@ text_sensor:
       name: "software version"
     hardware_version:
       name: "hardware version"
+    device_model:
+      name: "device model"

--- a/esp32-ble-v11-example.yaml
+++ b/esp32-ble-v11-example.yaml
@@ -380,3 +380,9 @@ text_sensor:
       name: "software version"
     hardware_version:
       name: "hardware version"
+    device_model:
+      name: "device model"
+    manufacturing_date:
+      name: "manufacturing date"
+    serial_number:
+      name: "serial number"

--- a/esp32-ble-v14-example-multiple-devices.yaml
+++ b/esp32-ble-v14-example-multiple-devices.yaml
@@ -997,6 +997,15 @@ text_sensor:
     hardware_version:
       name: "hardware version"
       device_id: device0
+    device_model:
+      name: "device model"
+      device_id: device0
+    manufacturing_date:
+      name: "manufacturing date"
+      device_id: device0
+    serial_number:
+      name: "serial number"
+      device_id: device0
 
   - platform: jk_bms_ble
     jk_bms_ble_id: bms1
@@ -1017,4 +1026,13 @@ text_sensor:
       device_id: device1
     hardware_version:
       name: "hardware version"
+      device_id: device1
+    device_model:
+      name: "device model"
+      device_id: device1
+    manufacturing_date:
+      name: "manufacturing date"
+      device_id: device1
+    serial_number:
+      name: "serial number"
       device_id: device1

--- a/esp32-ble-v14-example.yaml
+++ b/esp32-ble-v14-example.yaml
@@ -401,3 +401,9 @@ text_sensor:
       name: "hardware version"
     battery_type:
       name: "battery type"
+    device_model:
+      name: "device model"
+    manufacturing_date:
+      name: "manufacturing date"
+    serial_number:
+      name: "serial number"

--- a/esp32-ble-v15-example.yaml
+++ b/esp32-ble-v15-example.yaml
@@ -411,3 +411,9 @@ text_sensor:
       name: "hardware version"
     battery_type:
       name: "battery type"
+    device_model:
+      name: "device model"
+    manufacturing_date:
+      name: "manufacturing date"
+    serial_number:
+      name: "serial number"

--- a/esp32-ble-v19-3pack-olimex-poe-example.yaml
+++ b/esp32-ble-v19-3pack-olimex-poe-example.yaml
@@ -1825,6 +1825,15 @@ text_sensor:
     hardware_version:
       name: "hardware version"
       device_id: device0
+    device_model:
+      name: "device model"
+      device_id: device0
+    manufacturing_date:
+      name: "manufacturing date"
+      device_id: device0
+    serial_number:
+      name: "serial number"
+      device_id: device0
 
   - platform: jk_bms_ble
     jk_bms_ble_id: bms1
@@ -1852,6 +1861,15 @@ text_sensor:
     hardware_version:
       name: "hardware version"
       device_id: device1
+    device_model:
+      name: "device model"
+      device_id: device1
+    manufacturing_date:
+      name: "manufacturing date"
+      device_id: device1
+    serial_number:
+      name: "serial number"
+      device_id: device1
 
   - platform: jk_bms_ble
     jk_bms_ble_id: bms2
@@ -1878,4 +1896,13 @@ text_sensor:
       device_id: device2
     hardware_version:
       name: "hardware version"
+      device_id: device2
+    device_model:
+      name: "device model"
+      device_id: device2
+    manufacturing_date:
+      name: "manufacturing date"
+      device_id: device2
+    serial_number:
+      name: "serial number"
       device_id: device2

--- a/esp32-ble-v19-example.yaml
+++ b/esp32-ble-v19-example.yaml
@@ -441,3 +441,9 @@ text_sensor:
       name: "hardware version"
     battery_type:
       name: "battery type"
+    device_model:
+      name: "device model"
+    manufacturing_date:
+      name: "manufacturing date"
+    serial_number:
+      name: "serial number"

--- a/tests/components/jk_bms_ble/jk_bms_ble_jk04_test.cpp
+++ b/tests/components/jk_bms_ble/jk_bms_ble_jk04_test.cpp
@@ -20,6 +20,25 @@ TEST(JkBmsJk04DeviceInfoTest, SoftwareVersion) {
   EXPECT_EQ(sw.state, "3.3.0");
 }
 
+TEST(JkBmsJk04DeviceInfoTest, DeviceModel) {
+  TestableJkBmsBle bms;
+  text_sensor::TextSensor device_model;
+  bms.set_device_model_text_sensor(&device_model);
+  bms.decode_device_info_(DEVICE_INFO_JK04);
+  EXPECT_EQ(device_model.state, "JK-B2A16S");
+}
+
+TEST(JkBmsJk04DeviceInfoTest, ManufacturingDateAndSerialNumberAreEmpty) {
+  TestableJkBmsBle bms;
+  text_sensor::TextSensor manufacturing_date;
+  text_sensor::TextSensor serial_number;
+  bms.set_manufacturing_date_text_sensor(&manufacturing_date);
+  bms.set_serial_number_text_sensor(&serial_number);
+  bms.decode_device_info_(DEVICE_INFO_JK04);
+  EXPECT_EQ(manufacturing_date.state, "");
+  EXPECT_EQ(serial_number.state, "");
+}
+
 TEST(JkBmsJk04CellInfoTest, CellVoltages) {
   TestableJkBmsBle bms;
   bms.set_protocol_version(PROTOCOL_VERSION_JK04);

--- a/tests/components/jk_bms_ble/jk_bms_ble_test.cpp
+++ b/tests/components/jk_bms_ble/jk_bms_ble_test.cpp
@@ -25,6 +25,36 @@ TEST(JkBmsBleDeviceInfoTest, SoftwareVersion) {
   EXPECT_EQ(sw.state, "10.07");
 }
 
+TEST(JkBmsBleDeviceInfoTest, DeviceModel) {
+  TestableJkBmsBle bms;
+  text_sensor::TextSensor device_model;
+  bms.set_device_model_text_sensor(&device_model);
+
+  bms.decode_device_info_(DEVICE_INFO_JK02_24S_V10);
+
+  EXPECT_EQ(device_model.state, "JK-B2A24S20P");
+}
+
+TEST(JkBmsBleDeviceInfoTest, ManufacturingDate) {
+  TestableJkBmsBle bms;
+  text_sensor::TextSensor manufacturing_date;
+  bms.set_manufacturing_date_text_sensor(&manufacturing_date);
+
+  bms.decode_device_info_(DEVICE_INFO_JK02_24S_V10);
+
+  EXPECT_EQ(manufacturing_date.state, "20220511");
+}
+
+TEST(JkBmsBleDeviceInfoTest, SerialNumber) {
+  TestableJkBmsBle bms;
+  text_sensor::TextSensor serial_number;
+  bms.set_serial_number_text_sensor(&serial_number);
+
+  bms.decode_device_info_(DEVICE_INFO_JK02_24S_V10);
+
+  EXPECT_EQ(serial_number.state, "2041803028");
+}
+
 TEST(JkBmsBleDeviceInfoTest, NullSensorsDoNotCrash) {
   TestableJkBmsBle bms;
   bms.decode_device_info_(DEVICE_INFO_JK02_24S_V10);

--- a/tests/test_component_schemas.py
+++ b/tests/test_component_schemas.py
@@ -224,7 +224,10 @@ class TestJkBleTextSensorConstants:
         assert ble_text_sensor.CONF_BALANCER_STATUS in ble_text_sensor.TEXT_SENSORS
         assert ble_text_sensor.CONF_CHARGE_STATUS in ble_text_sensor.TEXT_SENSORS
         assert ble_text_sensor.CONF_BATTERY_TYPE in ble_text_sensor.TEXT_SENSORS
-        assert len(ble_text_sensor.TEXT_SENSORS) == 8
+        assert ble_text_sensor.CONF_DEVICE_MODEL in ble_text_sensor.TEXT_SENSORS
+        assert ble_text_sensor.CONF_MANUFACTURING_DATE in ble_text_sensor.TEXT_SENSORS
+        assert ble_text_sensor.CONF_SERIAL_NUMBER in ble_text_sensor.TEXT_SENSORS
+        assert len(ble_text_sensor.TEXT_SENSORS) == 11
 
 
 class TestJkBmsDisplaySensorLists:


### PR DESCRIPTION
## Summary
- The BLE device info frame already parsed the vendor ID, manufacturing date and serial number fields but only logged them (`ESP_LOGI`)
- Publish them as new `text_sensor` entities: `device_model`, `manufacturing_date`, `serial_number`
- `manufacturing_date` is published as `YYYYMMDD` (e.g. `20220511`); empty on JK04, whose device info frame doesn't carry those fields
- Adds the new sensors to all affected example YAML configs
- Closes #1030

## Test plan
- [x] `./run-cpp-tests.sh jk_bms_ble` — 209/209 tests pass, including new decode tests for all three sensors (JK02 and JK04 frames)
- [x] `pytest tests/test_component_schemas.py` — 43/43 pass
- [x] `esphome config` validated against all 9 touched example YAML files (using local component source)