### PR TITLE
Expose device info fields as text sensors in heltec_balancer_ble

### DIFF
--- a/components/heltec_balancer_ble/heltec_balancer_ble.cpp
+++ b/components/heltec_balancer_ble/heltec_balancer_ble.cpp
@@ -174,6 +174,11 @@ void HeltecBalancerBle::dump_config() {  // NOLINT(google-readability-function-s
   LOG_TEXT_SENSOR("", "Total Runtime Formatted", this->total_runtime_formatted_text_sensor_);
   LOG_TEXT_SENSOR("", "Buzzer Mode", this->buzzer_mode_text_sensor_);
   LOG_TEXT_SENSOR("", "Battery Type", this->battery_type_text_sensor_);
+  LOG_TEXT_SENSOR("", "Device Model", this->device_model_text_sensor_);
+  LOG_TEXT_SENSOR("", "Hardware Version", this->hardware_version_text_sensor_);
+  LOG_TEXT_SENSOR("", "Software Version", this->software_version_text_sensor_);
+  LOG_TEXT_SENSOR("", "Protocol Version", this->protocol_version_text_sensor_);
+  LOG_TEXT_SENSOR("", "Manufacturing Date", this->manufacturing_date_text_sensor_);
 }
 
 std::array<uint8_t, 20> HeltecBalancerBle::build_command_frame_(uint8_t function, uint8_t command,
@@ -1100,15 +1105,29 @@ void HeltecBalancerBle::decode_device_info_(const std::vector<uint8_t> &data) {
   // 4     2   0x01 0x00              Command (device info)
   // 6     2   0x64 0x00              Length (100 bytes)
   // 8    16   0x47 0x57 0x2D 0x32 0x34 0x53 0x34 0x45 0x42 0x00 0x00 0x00 0x00 0x00 0x00 0x00    Model    GW-24S4EB
-  ESP_LOGI(TAG, "  Model: %s", std::string(data.begin() + 8, data.begin() + 8 + 16).c_str());
+  auto device_model_begin = data.begin() + 8;
+  this->publish_state_(this->device_model_text_sensor_,
+                        std::string(device_model_begin, std::find(device_model_begin, device_model_begin + 16, '\0')));
   // 24    8   0x48 0x57 0x2D 0x32 0x2E 0x38 0x2E 0x30    Hardware version           HW-2.8.0
-  ESP_LOGI(TAG, "  Hardware version: %s", std::string(data.begin() + 24, data.begin() + 24 + 8).c_str());
+  auto hardware_version_begin = data.begin() + 24;
+  this->publish_state_(
+      this->hardware_version_text_sensor_,
+      std::string(hardware_version_begin, std::find(hardware_version_begin, hardware_version_begin + 8, '\0')));
   // 32    8   0x5A 0x48 0x2D 0x31 0x2E 0x32 0x2E 0x33    Software version           ZH-1.2.3
-  ESP_LOGI(TAG, "  Software version: %s", std::string(data.begin() + 32, data.begin() + 32 + 8).c_str());
+  auto software_version_begin = data.begin() + 32;
+  this->publish_state_(
+      this->software_version_text_sensor_,
+      std::string(software_version_begin, std::find(software_version_begin, software_version_begin + 8, '\0')));
   // 40    8   0x56 0x31 0x2E 0x30 0x2E 0x30 0x00 0x00    Protocol version           V1.0.0
-  ESP_LOGI(TAG, "  Protocol version: %s", std::string(data.begin() + 40, data.begin() + 40 + 8).c_str());
+  auto protocol_version_begin = data.begin() + 40;
+  this->publish_state_(
+      this->protocol_version_text_sensor_,
+      std::string(protocol_version_begin, std::find(protocol_version_begin, protocol_version_begin + 8, '\0')));
   // 48    8   0x32 0x30 0x32 0x32 0x30 0x35 0x33 0x31    Production date            20220531
-  ESP_LOGI(TAG, "  Manufacturing date: %s", std::string(data.begin() + 48, data.begin() + 48 + 8).c_str());
+  auto manufacturing_date_begin = data.begin() + 48;
+  this->publish_state_(
+      this->manufacturing_date_text_sensor_,
+      std::string(manufacturing_date_begin, std::find(manufacturing_date_begin, manufacturing_date_begin + 8, '\0')));
   // 56    4   0x05 0x00 0x00 0x00    Power on count                                 5
   ESP_LOGI(TAG, "  Power on count: %d", heltec_get_16bit(56));
   // 60    4   0x01 0x91 0x0A 0x00    Total runtime                                  7D

--- a/components/heltec_balancer_ble/heltec_balancer_ble.cpp
+++ b/components/heltec_balancer_ble/heltec_balancer_ble.cpp
@@ -1107,7 +1107,7 @@ void HeltecBalancerBle::decode_device_info_(const std::vector<uint8_t> &data) {
   // 8    16   0x47 0x57 0x2D 0x32 0x34 0x53 0x34 0x45 0x42 0x00 0x00 0x00 0x00 0x00 0x00 0x00    Model    GW-24S4EB
   auto device_model_begin = data.begin() + 8;
   this->publish_state_(this->device_model_text_sensor_,
-                        std::string(device_model_begin, std::find(device_model_begin, device_model_begin + 16, '\0')));
+                       std::string(device_model_begin, std::find(device_model_begin, device_model_begin + 16, '\0')));
   // 24    8   0x48 0x57 0x2D 0x32 0x2E 0x38 0x2E 0x30    Hardware version           HW-2.8.0
   auto hardware_version_begin = data.begin() + 24;
   this->publish_state_(

--- a/components/heltec_balancer_ble/heltec_balancer_ble.h
+++ b/components/heltec_balancer_ble/heltec_balancer_ble.h
@@ -248,6 +248,21 @@ class HeltecBalancerBle :
   void set_battery_type_text_sensor(text_sensor::TextSensor *battery_type_text_sensor) {
     battery_type_text_sensor_ = battery_type_text_sensor;
   }
+  void set_device_model_text_sensor(text_sensor::TextSensor *device_model_text_sensor) {
+    device_model_text_sensor_ = device_model_text_sensor;
+  }
+  void set_hardware_version_text_sensor(text_sensor::TextSensor *hardware_version_text_sensor) {
+    hardware_version_text_sensor_ = hardware_version_text_sensor;
+  }
+  void set_software_version_text_sensor(text_sensor::TextSensor *software_version_text_sensor) {
+    software_version_text_sensor_ = software_version_text_sensor;
+  }
+  void set_protocol_version_text_sensor(text_sensor::TextSensor *protocol_version_text_sensor) {
+    protocol_version_text_sensor_ = protocol_version_text_sensor;
+  }
+  void set_manufacturing_date_text_sensor(text_sensor::TextSensor *manufacturing_date_text_sensor) {
+    manufacturing_date_text_sensor_ = manufacturing_date_text_sensor;
+  }
 
   void set_buzzer_mode_select(select::Select *buzzer_mode_select) { buzzer_mode_select_ = buzzer_mode_select; }
   void set_battery_type_select(select::Select *battery_type_select) { battery_type_select_ = battery_type_select; }
@@ -336,6 +351,11 @@ class HeltecBalancerBle :
   text_sensor::TextSensor *total_runtime_formatted_text_sensor_{nullptr};
   text_sensor::TextSensor *buzzer_mode_text_sensor_{nullptr};
   text_sensor::TextSensor *battery_type_text_sensor_{nullptr};
+  text_sensor::TextSensor *device_model_text_sensor_{nullptr};
+  text_sensor::TextSensor *hardware_version_text_sensor_{nullptr};
+  text_sensor::TextSensor *software_version_text_sensor_{nullptr};
+  text_sensor::TextSensor *protocol_version_text_sensor_{nullptr};
+  text_sensor::TextSensor *manufacturing_date_text_sensor_{nullptr};
 
   std::vector<uint8_t> frame_buffer_;
   InitState init_state_{InitState::NEED_DEVICE_INFO};

--- a/components/heltec_balancer_ble/text_sensor.py
+++ b/components/heltec_balancer_ble/text_sensor.py
@@ -1,7 +1,7 @@
 import esphome.codegen as cg
 from esphome.components import text_sensor
 import esphome.config_validation as cv
-from esphome.const import ENTITY_CATEGORY_DIAGNOSTIC, ICON_TIMELAPSE
+from esphome.const import ENTITY_CATEGORY_DIAGNOSTIC, ICON_EMPTY, ICON_TIMELAPSE
 
 from . import CONF_HELTEC_BALANCER_BLE_ID, HELTEC_BALANCER_BLE_COMPONENT_SCHEMA
 
@@ -14,9 +14,16 @@ CONF_OPERATION_STATUS = "operation_status"
 CONF_TOTAL_RUNTIME_FORMATTED = "total_runtime_formatted"
 CONF_BUZZER_MODE = "buzzer_mode"
 CONF_BATTERY_TYPE = "battery_type"
+CONF_DEVICE_MODEL = "device_model"
+CONF_HARDWARE_VERSION = "hardware_version"
+CONF_SOFTWARE_VERSION = "software_version"
+CONF_PROTOCOL_VERSION = "protocol_version"
+CONF_MANUFACTURING_DATE = "manufacturing_date"
 
 ICON_ERRORS = "mdi:alert-circle-outline"
 ICON_OPERATION_STATUS = "mdi:heart-pulse"
+ICON_DEVICE_MODEL = "mdi:chip"
+ICON_MANUFACTURING_DATE = "mdi:calendar"
 
 TEXT_SENSORS = [
     CONF_ERRORS,
@@ -24,6 +31,11 @@ TEXT_SENSORS = [
     CONF_TOTAL_RUNTIME_FORMATTED,
     CONF_BUZZER_MODE,
     CONF_BATTERY_TYPE,
+    CONF_DEVICE_MODEL,
+    CONF_HARDWARE_VERSION,
+    CONF_SOFTWARE_VERSION,
+    CONF_PROTOCOL_VERSION,
+    CONF_MANUFACTURING_DATE,
 ]
 
 CONFIG_SCHEMA = HELTEC_BALANCER_BLE_COMPONENT_SCHEMA.extend(
@@ -43,6 +55,26 @@ CONFIG_SCHEMA = HELTEC_BALANCER_BLE_COMPONENT_SCHEMA.extend(
         ),
         cv.Optional(CONF_BATTERY_TYPE): text_sensor.text_sensor_schema(
             icon=ICON_OPERATION_STATUS,
+            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+        ),
+        cv.Optional(CONF_DEVICE_MODEL): text_sensor.text_sensor_schema(
+            icon=ICON_DEVICE_MODEL,
+            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+        ),
+        cv.Optional(CONF_HARDWARE_VERSION): text_sensor.text_sensor_schema(
+            icon=ICON_EMPTY,
+            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+        ),
+        cv.Optional(CONF_SOFTWARE_VERSION): text_sensor.text_sensor_schema(
+            icon=ICON_EMPTY,
+            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+        ),
+        cv.Optional(CONF_PROTOCOL_VERSION): text_sensor.text_sensor_schema(
+            icon=ICON_EMPTY,
+            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+        ),
+        cv.Optional(CONF_MANUFACTURING_DATE): text_sensor.text_sensor_schema(
+            icon=ICON_MANUFACTURING_DATE,
             entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
         ),
     }

--- a/esp32-heltec-balancer-ble-ek-b24s8e200a-example.yaml
+++ b/esp32-heltec-balancer-ble-ek-b24s8e200a-example.yaml
@@ -318,6 +318,16 @@ text_sensor:
       name: "buzzer mode"
     battery_type:
       name: "battery type"
+    device_model:
+      name: "device model"
+    hardware_version:
+      name: "hardware version"
+    software_version:
+      name: "software version"
+    protocol_version:
+      name: "protocol version"
+    manufacturing_date:
+      name: "manufacturing date"
 
 interval:
   - interval: 30min

--- a/esp32-heltec-balancer-ble-example-multiple-devices.yaml
+++ b/esp32-heltec-balancer-ble-example-multiple-devices.yaml
@@ -601,6 +601,21 @@ text_sensor:
     battery_type:
       name: "battery type"
       device_id: device0
+    device_model:
+      name: "device model"
+      device_id: device0
+    hardware_version:
+      name: "hardware version"
+      device_id: device0
+    software_version:
+      name: "software version"
+      device_id: device0
+    protocol_version:
+      name: "protocol version"
+      device_id: device0
+    manufacturing_date:
+      name: "manufacturing date"
+      device_id: device0
 
   - platform: heltec_balancer_ble
     heltec_balancer_ble_id: balancer1
@@ -618,6 +633,21 @@ text_sensor:
       device_id: device1
     battery_type:
       name: "battery type"
+      device_id: device1
+    device_model:
+      name: "device model"
+      device_id: device1
+    hardware_version:
+      name: "hardware version"
+      device_id: device1
+    software_version:
+      name: "software version"
+      device_id: device1
+    protocol_version:
+      name: "protocol version"
+      device_id: device1
+    manufacturing_date:
+      name: "manufacturing date"
       device_id: device1
 
 interval:

--- a/esp32-heltec-balancer-ble-example.yaml
+++ b/esp32-heltec-balancer-ble-example.yaml
@@ -264,6 +264,16 @@ text_sensor:
       name: "buzzer mode"
     battery_type:
       name: "battery type"
+    device_model:
+      name: "device model"
+    hardware_version:
+      name: "hardware version"
+    software_version:
+      name: "software version"
+    protocol_version:
+      name: "protocol version"
+    manufacturing_date:
+      name: "manufacturing date"
 
 interval:
   - interval: 30min

--- a/tests/components/heltec_balancer_ble/ek-24s10eb_test.cpp
+++ b/tests/components/heltec_balancer_ble/ek-24s10eb_test.cpp
@@ -187,6 +187,56 @@ TEST(Ek24S10EbDeviceInfoTest, TotalRuntimeFormatted) {
   EXPECT_EQ(formatted.state, "21d 3h");
 }
 
+TEST(Ek24S10EbDeviceInfoTest, DeviceModel) {
+  TestableHeltecBalancerBle bms;
+  text_sensor::TextSensor device_model;
+  bms.set_device_model_text_sensor(&device_model);
+
+  bms.decode_device_info_(DEVICE_INFO_FRAME);
+
+  EXPECT_EQ(device_model.state, "EK-24S10EB");
+}
+
+TEST(Ek24S10EbDeviceInfoTest, HardwareVersion) {
+  TestableHeltecBalancerBle bms;
+  text_sensor::TextSensor hardware_version;
+  bms.set_hardware_version_text_sensor(&hardware_version);
+
+  bms.decode_device_info_(DEVICE_INFO_FRAME);
+
+  EXPECT_EQ(hardware_version.state, "HW-2.0.0");
+}
+
+TEST(Ek24S10EbDeviceInfoTest, SoftwareVersion) {
+  TestableHeltecBalancerBle bms;
+  text_sensor::TextSensor software_version;
+  bms.set_software_version_text_sensor(&software_version);
+
+  bms.decode_device_info_(DEVICE_INFO_FRAME);
+
+  EXPECT_EQ(software_version.state, "ZL-2.0.2");
+}
+
+TEST(Ek24S10EbDeviceInfoTest, ProtocolVersion) {
+  TestableHeltecBalancerBle bms;
+  text_sensor::TextSensor protocol_version;
+  bms.set_protocol_version_text_sensor(&protocol_version);
+
+  bms.decode_device_info_(DEVICE_INFO_FRAME);
+
+  EXPECT_EQ(protocol_version.state, "V0.1.73");
+}
+
+TEST(Ek24S10EbDeviceInfoTest, ManufacturingDate) {
+  TestableHeltecBalancerBle bms;
+  text_sensor::TextSensor manufacturing_date;
+  bms.set_manufacturing_date_text_sensor(&manufacturing_date);
+
+  bms.decode_device_info_(DEVICE_INFO_FRAME);
+
+  EXPECT_EQ(manufacturing_date.state, "20250901");
+}
+
 TEST(Ek24S10EbDeviceInfoTest, DispatchedViaFrameType) {
   TestableHeltecBalancerBle bms;
   sensor::Sensor runtime;

--- a/tests/components/heltec_balancer_ble/ek-24s4eb_test.cpp
+++ b/tests/components/heltec_balancer_ble/ek-24s4eb_test.cpp
@@ -189,6 +189,56 @@ TEST(EkDeviceInfoTest, TotalRuntimeFormatted) {
   EXPECT_EQ(formatted.state, "1d 11h");
 }
 
+TEST(EkDeviceInfoTest, DeviceModel) {
+  TestableHeltecBalancerBle bms;
+  text_sensor::TextSensor device_model;
+  bms.set_device_model_text_sensor(&device_model);
+
+  bms.decode_device_info_(DEVICE_INFO_FRAME);
+
+  EXPECT_EQ(device_model.state, "EK-24S4EB");
+}
+
+TEST(EkDeviceInfoTest, HardwareVersion) {
+  TestableHeltecBalancerBle bms;
+  text_sensor::TextSensor hardware_version;
+  bms.set_hardware_version_text_sensor(&hardware_version);
+
+  bms.decode_device_info_(DEVICE_INFO_FRAME);
+
+  EXPECT_EQ(hardware_version.state, "HW-3.2.0");
+}
+
+TEST(EkDeviceInfoTest, SoftwareVersion) {
+  TestableHeltecBalancerBle bms;
+  text_sensor::TextSensor software_version;
+  bms.set_software_version_text_sensor(&software_version);
+
+  bms.decode_device_info_(DEVICE_INFO_FRAME);
+
+  EXPECT_EQ(software_version.state, "ZH-2.1.1");
+}
+
+TEST(EkDeviceInfoTest, ProtocolVersion) {
+  TestableHeltecBalancerBle bms;
+  text_sensor::TextSensor protocol_version;
+  bms.set_protocol_version_text_sensor(&protocol_version);
+
+  bms.decode_device_info_(DEVICE_INFO_FRAME);
+
+  EXPECT_EQ(protocol_version.state, "V1.3.13");
+}
+
+TEST(EkDeviceInfoTest, ManufacturingDate) {
+  TestableHeltecBalancerBle bms;
+  text_sensor::TextSensor manufacturing_date;
+  bms.set_manufacturing_date_text_sensor(&manufacturing_date);
+
+  bms.decode_device_info_(DEVICE_INFO_FRAME);
+
+  EXPECT_EQ(manufacturing_date.state, "20260201");
+}
+
 TEST(EkDeviceInfoTest, DispatchedViaFrameType) {
   TestableHeltecBalancerBle bms;
   sensor::Sensor runtime;

--- a/tests/components/heltec_balancer_ble/ek-b24s8e200a_test.cpp
+++ b/tests/components/heltec_balancer_ble/ek-b24s8e200a_test.cpp
@@ -232,6 +232,56 @@ TEST(EkB24S8E200ADeviceInfoTest, TotalRuntimeFormatted) {
   EXPECT_EQ(formatted.state, "14h");
 }
 
+TEST(EkB24S8E200ADeviceInfoTest, DeviceModel) {
+  TestableHeltecBalancerBle bms;
+  text_sensor::TextSensor device_model;
+  bms.set_device_model_text_sensor(&device_model);
+
+  bms.decode_device_info_(DEVICE_INFO_FRAME);
+
+  EXPECT_EQ(device_model.state, "EK-B24S8E200A");
+}
+
+TEST(EkB24S8E200ADeviceInfoTest, HardwareVersion) {
+  TestableHeltecBalancerBle bms;
+  text_sensor::TextSensor hardware_version;
+  bms.set_hardware_version_text_sensor(&hardware_version);
+
+  bms.decode_device_info_(DEVICE_INFO_FRAME);
+
+  EXPECT_EQ(hardware_version.state, "HW-2.0.0");
+}
+
+TEST(EkB24S8E200ADeviceInfoTest, SoftwareVersion) {
+  TestableHeltecBalancerBle bms;
+  text_sensor::TextSensor software_version;
+  bms.set_software_version_text_sensor(&software_version);
+
+  bms.decode_device_info_(DEVICE_INFO_FRAME);
+
+  EXPECT_EQ(software_version.state, "SW-2.0.0");
+}
+
+TEST(EkB24S8E200ADeviceInfoTest, ProtocolVersion) {
+  TestableHeltecBalancerBle bms;
+  text_sensor::TextSensor protocol_version;
+  bms.set_protocol_version_text_sensor(&protocol_version);
+
+  bms.decode_device_info_(DEVICE_INFO_FRAME);
+
+  EXPECT_EQ(protocol_version.state, "V1.3.36");
+}
+
+TEST(EkB24S8E200ADeviceInfoTest, ManufacturingDate) {
+  TestableHeltecBalancerBle bms;
+  text_sensor::TextSensor manufacturing_date;
+  bms.set_manufacturing_date_text_sensor(&manufacturing_date);
+
+  bms.decode_device_info_(DEVICE_INFO_FRAME);
+
+  EXPECT_EQ(manufacturing_date.state, "20251015");
+}
+
 // ── Settings frame SW-2.0.0 (150 bytes) ──────────────────────────────────────
 
 TEST(EkB24S8E200ASettingsTest, CellCount) {

--- a/tests/components/heltec_balancer_ble/gw-24s4eb_test.cpp
+++ b/tests/components/heltec_balancer_ble/gw-24s4eb_test.cpp
@@ -183,6 +183,56 @@ TEST(GwDeviceInfoTest, TotalRuntimeFormatted) {
   EXPECT_EQ(formatted.state, "47d ");
 }
 
+TEST(GwDeviceInfoTest, DeviceModel) {
+  TestableHeltecBalancerBle bms;
+  text_sensor::TextSensor device_model;
+  bms.set_device_model_text_sensor(&device_model);
+
+  bms.decode_device_info_(DEVICE_INFO_FRAME);
+
+  EXPECT_EQ(device_model.state, "GW-24S4EB");
+}
+
+TEST(GwDeviceInfoTest, HardwareVersion) {
+  TestableHeltecBalancerBle bms;
+  text_sensor::TextSensor hardware_version;
+  bms.set_hardware_version_text_sensor(&hardware_version);
+
+  bms.decode_device_info_(DEVICE_INFO_FRAME);
+
+  EXPECT_EQ(hardware_version.state, "HW-2.8.0");
+}
+
+TEST(GwDeviceInfoTest, SoftwareVersion) {
+  TestableHeltecBalancerBle bms;
+  text_sensor::TextSensor software_version;
+  bms.set_software_version_text_sensor(&software_version);
+
+  bms.decode_device_info_(DEVICE_INFO_FRAME);
+
+  EXPECT_EQ(software_version.state, "SW-1.1.0");
+}
+
+TEST(GwDeviceInfoTest, ProtocolVersion) {
+  TestableHeltecBalancerBle bms;
+  text_sensor::TextSensor protocol_version;
+  bms.set_protocol_version_text_sensor(&protocol_version);
+
+  bms.decode_device_info_(DEVICE_INFO_FRAME);
+
+  EXPECT_EQ(protocol_version.state, "V1.0.0");
+}
+
+TEST(GwDeviceInfoTest, ManufacturingDate) {
+  TestableHeltecBalancerBle bms;
+  text_sensor::TextSensor manufacturing_date;
+  bms.set_manufacturing_date_text_sensor(&manufacturing_date);
+
+  bms.decode_device_info_(DEVICE_INFO_FRAME);
+
+  EXPECT_EQ(manufacturing_date.state, "20210915");
+}
+
 TEST(GwDeviceInfoTest, DispatchedViaFrameType) {
   TestableHeltecBalancerBle bms;
   sensor::Sensor runtime;

--- a/tests/test_component_schemas.py
+++ b/tests/test_component_schemas.py
@@ -280,7 +280,14 @@ class TestHeltecBalancerBleSensorLists:
     def test_text_sensors_list(self):
         assert heltec_text_sensor.CONF_ERRORS in heltec_text_sensor.TEXT_SENSORS
         assert heltec_text_sensor.CONF_BATTERY_TYPE in heltec_text_sensor.TEXT_SENSORS
-        assert len(heltec_text_sensor.TEXT_SENSORS) == 5
+        assert heltec_text_sensor.CONF_DEVICE_MODEL in heltec_text_sensor.TEXT_SENSORS
+        assert heltec_text_sensor.CONF_HARDWARE_VERSION in heltec_text_sensor.TEXT_SENSORS
+        assert heltec_text_sensor.CONF_SOFTWARE_VERSION in heltec_text_sensor.TEXT_SENSORS
+        assert heltec_text_sensor.CONF_PROTOCOL_VERSION in heltec_text_sensor.TEXT_SENSORS
+        assert (
+            heltec_text_sensor.CONF_MANUFACTURING_DATE in heltec_text_sensor.TEXT_SENSORS
+        )
+        assert len(heltec_text_sensor.TEXT_SENSORS) == 10
 
     def test_buttons_dict(self):
         assert heltec_button.CONF_RETRIEVE_SETTINGS in heltec_button.BUTTONS


### PR DESCRIPTION
## Summary
- The device info frame already parsed model, hardware version, software version, protocol version and manufacturing date but only logged them (`ESP_LOGI`)
- Publish them as new `text_sensor` entities: `device_model`, `hardware_version`, `software_version`, `protocol_version`, `manufacturing_date`
- Adds the new sensors to all affected example YAML configs

## Test plan
- [x] `./run-cpp-tests.sh heltec_balancer_ble` — 124/124 tests pass, including new decode tests for all five sensors (GW-24S4EB frame)
- [x] `pytest tests/test_component_schemas.py` — 43/43 pass
- [x] `esphome config` validated against all 3 touched example YAML files (using local component source)