### PR TITLE
Expose power on count sensor in jk_bms_ble

### DIFF
--- a/components/jk_bms_ble/jk_bms_ble.cpp
+++ b/components/jk_bms_ble/jk_bms_ble.cpp
@@ -432,6 +432,7 @@ void JkBmsBle::dump_config() {  // NOLINT(google-readability-function-size,reada
   LOG_SENSOR("", "Charging Cycles", this->charging_cycles_sensor_);
   LOG_SENSOR("", "Total Charging Cycle Capacity", this->total_charging_cycle_capacity_sensor_);
   LOG_SENSOR("", "Total Runtime", this->total_runtime_sensor_);
+  LOG_SENSOR("", "Power On Count", this->power_on_count_sensor_);
   LOG_SENSOR("", "Heating Current", this->heating_current_sensor_);
   LOG_SENSOR("", "Balancing Current", this->balancing_current_sensor_);
   LOG_SENSOR("", "Emergency Time Countdown", this->emergency_time_countdown_sensor_);
@@ -1710,8 +1711,8 @@ void JkBmsBle::decode_device_info_(const std::vector<uint8_t> &data) {
   // 38    4   0x54 0xE6 0x01 0x00
   ESP_LOGI(TAG, "  Uptime: %lu s", (unsigned long) jk_get_32bit(38));
 
-  // 42    4   0x9C 0x00 0x00 0x00
-  ESP_LOGI(TAG, "  Power on count: %lu", (unsigned long) jk_get_32bit(42));
+  // 42    4   0x9C 0x00 0x00 0x00    Power on count
+  this->publish_state_(this->power_on_count_sensor_, (float) jk_get_32bit(42));
 
   // 46   16   0x4A 0x4B 0x5F 0x50 0x42 0x32 0x41 0x31 0x36 0x53 0x31 0x35 0x50 0x00 0x00 0x00
   ESP_LOGI(TAG, "  Device name: %s", std::string(data.begin() + 46, data.begin() + 46 + 16).c_str());

--- a/components/jk_bms_ble/jk_bms_ble.h
+++ b/components/jk_bms_ble/jk_bms_ble.h
@@ -267,6 +267,9 @@ class JkBmsBle :
     total_charging_cycle_capacity_sensor_ = total_charging_cycle_capacity_sensor;
   }
   void set_total_runtime_sensor(sensor::Sensor *total_runtime_sensor) { total_runtime_sensor_ = total_runtime_sensor; }
+  void set_power_on_count_sensor(sensor::Sensor *power_on_count_sensor) {
+    power_on_count_sensor_ = power_on_count_sensor;
+  }
   void set_balancing_current_sensor(sensor::Sensor *balancing_current_sensor) {
     balancing_current_sensor_ = balancing_current_sensor;
   }
@@ -495,6 +498,7 @@ class JkBmsBle :
   sensor::Sensor *charging_cycles_sensor_{nullptr};
   sensor::Sensor *total_charging_cycle_capacity_sensor_{nullptr};
   sensor::Sensor *total_runtime_sensor_{nullptr};
+  sensor::Sensor *power_on_count_sensor_{nullptr};
   sensor::Sensor *balancing_current_sensor_{nullptr};
   sensor::Sensor *emergency_time_countdown_sensor_{nullptr};
   sensor::Sensor *smart_sleep_countdown_sensor_{nullptr};

--- a/components/jk_bms_ble/sensor.py
+++ b/components/jk_bms_ble/sensor.py
@@ -53,6 +53,7 @@ CONF_FULL_CHARGE_CAPACITY = "full_charge_capacity"
 CONF_CHARGING_CYCLES = "charging_cycles"
 CONF_TOTAL_CHARGING_CYCLE_CAPACITY = "total_charging_cycle_capacity"
 CONF_TOTAL_RUNTIME = "total_runtime"
+CONF_POWER_ON_COUNT = "power_on_count"
 CONF_BALANCING_CURRENT = "balancing_current"
 CONF_EMERGENCY_TIME_COUNTDOWN = "emergency_time_countdown"
 CONF_SMART_SLEEP_COUNTDOWN = "smart_sleep_countdown"
@@ -74,6 +75,7 @@ ICON_MIN_VOLTAGE_CELL = "mdi:battery-minus-outline"
 ICON_MAX_VOLTAGE_CELL = "mdi:battery-plus-outline"
 ICON_CAPACITY_REMAINING = "mdi:battery-50"
 ICON_CHARGING_CYCLES = "mdi:battery-sync"
+ICON_POWER_ON_COUNT = "mdi:power-cycle"
 ICON_CELL_RESISTANCE = "mdi:omega"
 ICON_BALANCER = "mdi:seesaw"
 ICON_CHARGE_STATUS_ID = "mdi:battery-clock"
@@ -245,6 +247,14 @@ SENSOR_DEFS = {
         "accuracy_decimals": 0,
         "device_class": DEVICE_CLASS_EMPTY,
         "state_class": STATE_CLASS_TOTAL_INCREASING,
+    },
+    CONF_POWER_ON_COUNT: {
+        "unit_of_measurement": UNIT_EMPTY,
+        "icon": ICON_POWER_ON_COUNT,
+        "accuracy_decimals": 0,
+        "device_class": DEVICE_CLASS_EMPTY,
+        "state_class": STATE_CLASS_TOTAL_INCREASING,
+        "entity_category": ENTITY_CATEGORY_DIAGNOSTIC,
     },
     CONF_BALANCING_CURRENT: {
         "unit_of_measurement": UNIT_AMPERE,

--- a/esp32-ble-example.yaml
+++ b/esp32-ble-example.yaml
@@ -294,6 +294,8 @@ sensor:
       name: "total charging cycle capacity"
     total_runtime:
       name: "total runtime"
+    power_on_count:
+      name: "power on count"
     balancing_current:
       name: "balancing current"
 

--- a/esp32-ble-jk04-example.yaml
+++ b/esp32-ble-jk04-example.yaml
@@ -187,6 +187,8 @@ sensor:
       name: "total voltage"
     total_runtime:
       name: "total runtime"
+    power_on_count:
+      name: "power on count"
     balancing_current:
       name: "balancing current"
     balancer_status_bitmask:

--- a/esp32-ble-v11-example.yaml
+++ b/esp32-ble-v11-example.yaml
@@ -320,6 +320,8 @@ sensor:
       name: "total charging cycle capacity"
     total_runtime:
       name: "total runtime"
+    power_on_count:
+      name: "power on count"
     balancing_current:
       name: "balancing current"
     emergency_time_countdown:

--- a/esp32-ble-v14-example-multiple-devices.yaml
+++ b/esp32-ble-v14-example-multiple-devices.yaml
@@ -625,6 +625,9 @@ sensor:
     total_runtime:
       name: "total runtime"
       device_id: device0
+    power_on_count:
+      name: "power on count"
+      device_id: device0
     balancing_current:
       name: "balancing current"
       device_id: device0
@@ -859,6 +862,9 @@ sensor:
       device_id: device1
     total_runtime:
       name: "total runtime"
+      device_id: device1
+    power_on_count:
+      name: "power on count"
       device_id: device1
     balancing_current:
       name: "balancing current"

--- a/esp32-ble-v14-example.yaml
+++ b/esp32-ble-v14-example.yaml
@@ -332,6 +332,8 @@ sensor:
       name: "total charging cycle capacity"
     total_runtime:
       name: "total runtime"
+    power_on_count:
+      name: "power on count"
     balancing_current:
       name: "balancing current"
     emergency_time_countdown:

--- a/esp32-ble-v15-example.yaml
+++ b/esp32-ble-v15-example.yaml
@@ -336,6 +336,8 @@ sensor:
       name: "total charging cycle capacity"
     total_runtime:
       name: "total runtime"
+    power_on_count:
+      name: "power on count"
     balancing_current:
       name: "balancing current"
     emergency_time_countdown:

--- a/esp32-ble-v19-3pack-olimex-poe-example.yaml
+++ b/esp32-ble-v19-3pack-olimex-poe-example.yaml
@@ -1066,6 +1066,9 @@ sensor:
     total_runtime:
       name: "total runtime"
       device_id: device0
+    power_on_count:
+      name: "power on count"
+      device_id: device0
     balancing_current:
       name: "balancing current"
       device_id: device0
@@ -1283,6 +1286,9 @@ sensor:
     total_runtime:
       name: "total runtime"
       device_id: device1
+    power_on_count:
+      name: "power on count"
+      device_id: device1
     balancing_current:
       name: "balancing current"
       device_id: device1
@@ -1498,6 +1504,9 @@ sensor:
       device_id: device2
     total_runtime:
       name: "total runtime"
+      device_id: device2
+    power_on_count:
+      name: "power on count"
       device_id: device2
     balancing_current:
       name: "balancing current"

--- a/esp32-ble-v19-example.yaml
+++ b/esp32-ble-v19-example.yaml
@@ -338,6 +338,8 @@ sensor:
       name: "total charging cycle capacity"
     total_runtime:
       name: "total runtime"
+    power_on_count:
+      name: "power on count"
     balancing_current:
       name: "balancing current"
     emergency_time_countdown:

--- a/tests/components/jk_bms_ble/jk_bms_ble_jk02_24s_v10_test.cpp
+++ b/tests/components/jk_bms_ble/jk_bms_ble_jk02_24s_v10_test.cpp
@@ -20,6 +20,14 @@ TEST(JkBmsV10DeviceInfoTest, SoftwareVersion) {
   EXPECT_EQ(sw.state, "10.07");
 }
 
+TEST(JkBmsV10DeviceInfoTest, PowerOnCount) {
+  TestableJkBmsBle bms;
+  sensor::Sensor power_on_count;
+  bms.set_power_on_count_sensor(&power_on_count);
+  bms.decode_device_info_(DEVICE_INFO_JK02_24S_V10);
+  EXPECT_EQ(power_on_count.state, 1.0f);
+}
+
 TEST(JkBmsV10CellInfoTest, CellVoltages) {
   TestableJkBmsBle bms;
   sensor::Sensor cells[24];

--- a/tests/components/jk_bms_ble/jk_bms_ble_jk02_32s_v11_test.cpp
+++ b/tests/components/jk_bms_ble/jk_bms_ble_jk02_32s_v11_test.cpp
@@ -20,6 +20,14 @@ TEST(JkBmsV11DeviceInfoTest, SoftwareVersion) {
   EXPECT_EQ(sw.state, "14.20");
 }
 
+TEST(JkBmsV11DeviceInfoTest, PowerOnCount) {
+  TestableJkBmsBle bms;
+  sensor::Sensor power_on_count;
+  bms.set_power_on_count_sensor(&power_on_count);
+  bms.decode_device_info_(DEVICE_INFO_JK02_32S_V11);
+  EXPECT_EQ(power_on_count.state, 148.0f);
+}
+
 TEST(JkBmsV11CellInfoTest, CellVoltages) {
   TestableJkBmsBle bms;
   bms.set_protocol_version(PROTOCOL_VERSION_JK02_32S);

--- a/tests/components/jk_bms_ble/jk_bms_ble_jk02_32s_v14_test.cpp
+++ b/tests/components/jk_bms_ble/jk_bms_ble_jk02_32s_v14_test.cpp
@@ -20,6 +20,14 @@ TEST(JkBmsV14DeviceInfoTest, SoftwareVersion) {
   EXPECT_EQ(sw.state, "14.20");
 }
 
+TEST(JkBmsV14DeviceInfoTest, PowerOnCount) {
+  TestableJkBmsBle bms;
+  sensor::Sensor power_on_count;
+  bms.set_power_on_count_sensor(&power_on_count);
+  bms.decode_device_info_(DEVICE_INFO_JK02_32S_V14);
+  EXPECT_EQ(power_on_count.state, 156.0f);
+}
+
 TEST(JkBmsV14CellInfoTest, CellVoltages) {
   TestableJkBmsBle bms;
   bms.set_protocol_version(PROTOCOL_VERSION_JK02_32S);

--- a/tests/components/jk_bms_ble/jk_bms_ble_jk02_32s_v15_test.cpp
+++ b/tests/components/jk_bms_ble/jk_bms_ble_jk02_32s_v15_test.cpp
@@ -20,6 +20,14 @@ TEST(JkBmsV15DeviceInfoTest, SoftwareVersion) {
   EXPECT_EQ(sw.state, "15.38");
 }
 
+TEST(JkBmsV15DeviceInfoTest, PowerOnCount) {
+  TestableJkBmsBle bms;
+  sensor::Sensor power_on_count;
+  bms.set_power_on_count_sensor(&power_on_count);
+  bms.decode_device_info_(DEVICE_INFO_JK02_32S_V15);
+  EXPECT_EQ(power_on_count.state, 29.0f);
+}
+
 TEST(JkBmsV15CellInfoTest, CellVoltages) {
   TestableJkBmsBle bms;
   bms.set_protocol_version(PROTOCOL_VERSION_JK02_32S);

--- a/tests/components/jk_bms_ble/jk_bms_ble_jk02_32s_v19_test.cpp
+++ b/tests/components/jk_bms_ble/jk_bms_ble_jk02_32s_v19_test.cpp
@@ -20,6 +20,14 @@ TEST(JkBmsV19DeviceInfoTest, SoftwareVersion) {
   EXPECT_EQ(sw.state, "19.27");
 }
 
+TEST(JkBmsV19DeviceInfoTest, PowerOnCount) {
+  TestableJkBmsBle bms;
+  sensor::Sensor power_on_count;
+  bms.set_power_on_count_sensor(&power_on_count);
+  bms.decode_device_info_(DEVICE_INFO_JK02_32S_V19);
+  EXPECT_EQ(power_on_count.state, 16.0f);
+}
+
 TEST(JkBmsV19CellInfoTest, CellVoltages) {
   TestableJkBmsBle bms;
   bms.set_protocol_version(PROTOCOL_VERSION_JK02_32S);

--- a/tests/components/jk_bms_ble/jk_bms_ble_jk04_test.cpp
+++ b/tests/components/jk_bms_ble/jk_bms_ble_jk04_test.cpp
@@ -39,6 +39,14 @@ TEST(JkBmsJk04DeviceInfoTest, ManufacturingDateAndSerialNumberAreEmpty) {
   EXPECT_EQ(serial_number.state, "");
 }
 
+TEST(JkBmsJk04DeviceInfoTest, PowerOnCount) {
+  TestableJkBmsBle bms;
+  sensor::Sensor power_on_count;
+  bms.set_power_on_count_sensor(&power_on_count);
+  bms.decode_device_info_(DEVICE_INFO_JK04);
+  EXPECT_EQ(power_on_count.state, 19.0f);
+}
+
 TEST(JkBmsJk04CellInfoTest, CellVoltages) {
   TestableJkBmsBle bms;
   bms.set_protocol_version(PROTOCOL_VERSION_JK04);

--- a/tests/components/jk_bms_ble/jk_bms_ble_test.cpp
+++ b/tests/components/jk_bms_ble/jk_bms_ble_test.cpp
@@ -55,6 +55,16 @@ TEST(JkBmsBleDeviceInfoTest, SerialNumber) {
   EXPECT_EQ(serial_number.state, "2041803028");
 }
 
+TEST(JkBmsBleDeviceInfoTest, PowerOnCount) {
+  TestableJkBmsBle bms;
+  sensor::Sensor power_on_count;
+  bms.set_power_on_count_sensor(&power_on_count);
+
+  bms.decode_device_info_(DEVICE_INFO_JK02_24S_V10);
+
+  EXPECT_EQ(power_on_count.state, 1.0f);
+}
+
 TEST(JkBmsBleDeviceInfoTest, NullSensorsDoNotCrash) {
   TestableJkBmsBle bms;
   bms.decode_device_info_(DEVICE_INFO_JK02_24S_V10);

--- a/tests/test_component_schemas.py
+++ b/tests/test_component_schemas.py
@@ -119,7 +119,8 @@ class TestJkBmsBleSensorLists:
         assert "balancer_status_bitmask" in ble_sensor.SENSOR_DEFS
         assert "detail_log_entry_count" in ble_sensor.SENSOR_DEFS
         assert "battery_type_id" in ble_sensor.SENSOR_DEFS
-        assert len(ble_sensor.SENSOR_DEFS) == 32
+        assert ble_sensor.CONF_POWER_ON_COUNT in ble_sensor.SENSOR_DEFS
+        assert len(ble_sensor.SENSOR_DEFS) == 33
 
 
 class TestJkBmsBleBinarySensorConstants:


### PR DESCRIPTION
## Summary
- Publish the device info frame's power-on counter (offset 42) as a new `power_on_count` numeric sensor in `jk_bms_ble`, replacing the previous log-only output.
- Add the sensor to the relevant example YAMLs (single-device and multi-device/multi-pack configs).
- Add C++ unit tests decoding `power_on_count` for all supported device-info frame variants (JK04, JK02_24S, JK02_32S v11/v14/v15/v19).
- Extend the Python schema test to cover the new `SENSOR_DEFS` entry.

## Test plan
- [x] `python -m pytest tests/test_component_schemas.py` (43 passed)
- [x] `./run-cpp-tests.sh jk_bms_ble` (216 passed)
- [x] `esphome config` validated against a local component source (no schema errors, `power_on_count` resolves with `state_class: total_increasing`)