### PR TITLE
Expose power on count sensor in heltec_balancer_ble

### DIFF
--- a/components/heltec_balancer_ble/heltec_balancer_ble.cpp
+++ b/components/heltec_balancer_ble/heltec_balancer_ble.cpp
@@ -157,6 +157,7 @@ void HeltecBalancerBle::dump_config() {  // NOLINT(google-readability-function-s
   LOG_SENSOR("", "Capacity Remaining", this->capacity_remaining_sensor_);
   LOG_SENSOR("", "State of Charge", this->state_of_charge_sensor_);
   LOG_SENSOR("", "Total Runtime", this->total_runtime_sensor_);
+  LOG_SENSOR("", "Power On Count", this->power_on_count_sensor_);
   LOG_SENSOR("", "Balancing Current", this->balancing_current_sensor_);
   LOG_SENSOR("", "Errors Bitmask", this->errors_bitmask_sensor_);
   LOG_SENSOR("", "Cell Detection Failed Bitmask", this->cell_detection_failed_bitmask_sensor_);
@@ -1104,39 +1105,46 @@ void HeltecBalancerBle::decode_device_info_(const std::vector<uint8_t> &data) {
   // 3     1   0x01                   Function (read)
   // 4     2   0x01 0x00              Command (device info)
   // 6     2   0x64 0x00              Length (100 bytes)
+
   // 8    16   0x47 0x57 0x2D 0x32 0x34 0x53 0x34 0x45 0x42 0x00 0x00 0x00 0x00 0x00 0x00 0x00    Model    GW-24S4EB
   auto device_model_begin = data.begin() + 8;
   this->publish_state_(this->device_model_text_sensor_,
                        std::string(device_model_begin, std::find(device_model_begin, device_model_begin + 16, '\0')));
+
   // 24    8   0x48 0x57 0x2D 0x32 0x2E 0x38 0x2E 0x30    Hardware version           HW-2.8.0
   auto hardware_version_begin = data.begin() + 24;
   this->publish_state_(
       this->hardware_version_text_sensor_,
       std::string(hardware_version_begin, std::find(hardware_version_begin, hardware_version_begin + 8, '\0')));
+
   // 32    8   0x5A 0x48 0x2D 0x31 0x2E 0x32 0x2E 0x33    Software version           ZH-1.2.3
   auto software_version_begin = data.begin() + 32;
   this->publish_state_(
       this->software_version_text_sensor_,
       std::string(software_version_begin, std::find(software_version_begin, software_version_begin + 8, '\0')));
+
   // 40    8   0x56 0x31 0x2E 0x30 0x2E 0x30 0x00 0x00    Protocol version           V1.0.0
   auto protocol_version_begin = data.begin() + 40;
   this->publish_state_(
       this->protocol_version_text_sensor_,
       std::string(protocol_version_begin, std::find(protocol_version_begin, protocol_version_begin + 8, '\0')));
+
   // 48    8   0x32 0x30 0x32 0x32 0x30 0x35 0x33 0x31    Production date            20220531
   auto manufacturing_date_begin = data.begin() + 48;
   this->publish_state_(
       this->manufacturing_date_text_sensor_,
       std::string(manufacturing_date_begin, std::find(manufacturing_date_begin, manufacturing_date_begin + 8, '\0')));
+
   // 56    4   0x05 0x00 0x00 0x00    Power on count                                 5
-  ESP_LOGI(TAG, "  Power on count: %d", heltec_get_16bit(56));
+  this->publish_state_(this->power_on_count_sensor_, (float) heltec_get_16bit(56));
+
   // 60    4   0x01 0x91 0x0A 0x00    Total runtime                                  7D
+  //                                  (0x0A9101 = 692481 / 3600 = 192.35h = 8.01d)
   ESP_LOGI(TAG, "  Total runtime: %s (%lus)", format_total_runtime_(heltec_get_32bit(60)).c_str(),
            (unsigned long) heltec_get_32bit(60));
   this->publish_state_(this->total_runtime_sensor_, (float) heltec_get_32bit(60));
   this->publish_state_(this->total_runtime_formatted_text_sensor_, format_total_runtime_(heltec_get_32bit(60)));
 
-  //                                  (0x0A9101 = 692481 / 3600 = 192.35h = 8.01d)
   // 64   34   0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00
   //           0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00
   // 98    1   0xAB                    CRC
@@ -1177,6 +1185,7 @@ void HeltecBalancerBle::publish_device_unavailable_() {
   this->publish_state_(capacity_remaining_sensor_, NAN);
   this->publish_state_(state_of_charge_sensor_, NAN);
   this->publish_state_(total_runtime_sensor_, NAN);
+  this->publish_state_(power_on_count_sensor_, NAN);
   this->publish_state_(balancing_current_sensor_, NAN);
   this->publish_state_(errors_bitmask_sensor_, NAN);
   this->publish_state_(cell_detection_failed_bitmask_sensor_, NAN);

--- a/components/heltec_balancer_ble/heltec_balancer_ble.h
+++ b/components/heltec_balancer_ble/heltec_balancer_ble.h
@@ -212,6 +212,9 @@ class HeltecBalancerBle :
     state_of_charge_sensor_ = state_of_charge_sensor;
   }
   void set_total_runtime_sensor(sensor::Sensor *total_runtime_sensor) { total_runtime_sensor_ = total_runtime_sensor; }
+  void set_power_on_count_sensor(sensor::Sensor *power_on_count_sensor) {
+    power_on_count_sensor_ = power_on_count_sensor;
+  }
   void set_balancing_current_sensor(sensor::Sensor *balancing_current_sensor) {
     balancing_current_sensor_ = balancing_current_sensor;
   }
@@ -334,6 +337,7 @@ class HeltecBalancerBle :
   sensor::Sensor *capacity_remaining_sensor_{nullptr};
   sensor::Sensor *state_of_charge_sensor_{nullptr};
   sensor::Sensor *total_runtime_sensor_{nullptr};
+  sensor::Sensor *power_on_count_sensor_{nullptr};
   sensor::Sensor *balancing_current_sensor_{nullptr};
   sensor::Sensor *errors_bitmask_sensor_{nullptr};
   sensor::Sensor *cell_detection_failed_bitmask_sensor_{nullptr};

--- a/components/heltec_balancer_ble/sensor.py
+++ b/components/heltec_balancer_ble/sensor.py
@@ -42,6 +42,7 @@ CONF_NOMINAL_CAPACITY = "nominal_capacity"
 CONF_CAPACITY_REMAINING = "capacity_remaining"
 CONF_STATE_OF_CHARGE = "state_of_charge"
 CONF_TOTAL_RUNTIME = "total_runtime"
+CONF_POWER_ON_COUNT = "power_on_count"
 CONF_BALANCING_CURRENT = "balancing_current"
 CONF_ERRORS_BITMASK = "errors_bitmask"
 CONF_CELL_DETECTION_FAILED_BITMASK = "cell_detection_failed_bitmask"
@@ -53,6 +54,7 @@ CONF_CELL_EXCESSIVE_LINE_RESISTANCE_BITMASK = "cell_excessive_line_resistance_bi
 UNIT_AMPERE_HOURS = "Ah"
 ICON_CURRENT_DC = "mdi:current-dc"
 ICON_CELL_RESISTANCE = "mdi:omega"
+ICON_POWER_ON_COUNT = "mdi:power-cycle"
 
 CELL_VOLTAGES = [f"cell_voltage_{i}" for i in range(1, 25)]
 CELL_RESISTANCES = [f"cell_resistance_{i}" for i in range(1, 25)]
@@ -182,6 +184,13 @@ SENSOR_DEFS = {
     CONF_TOTAL_RUNTIME: {
         "unit_of_measurement": UNIT_SECOND,
         "icon": ICON_TIMELAPSE,
+        "accuracy_decimals": 0,
+        "device_class": DEVICE_CLASS_EMPTY,
+        "state_class": STATE_CLASS_TOTAL_INCREASING,
+    },
+    CONF_POWER_ON_COUNT: {
+        "unit_of_measurement": UNIT_EMPTY,
+        "icon": ICON_POWER_ON_COUNT,
         "accuracy_decimals": 0,
         "device_class": DEVICE_CLASS_EMPTY,
         "state_class": STATE_CLASS_TOTAL_INCREASING,

--- a/esp32-heltec-balancer-ble-ek-b24s8e200a-example.yaml
+++ b/esp32-heltec-balancer-ble-ek-b24s8e200a-example.yaml
@@ -277,6 +277,8 @@ sensor:
       name: "state of charge"
     total_runtime:
       name: "total runtime"
+    power_on_count:
+      name: "power on count"
     balancing_current:
       name: "balancing current"
     cell_detection_failed_bitmask:

--- a/esp32-heltec-balancer-ble-example-multiple-devices.yaml
+++ b/esp32-heltec-balancer-ble-example-multiple-devices.yaml
@@ -338,6 +338,9 @@ sensor:
     total_runtime:
       name: "total runtime"
       device_id: device0
+    power_on_count:
+      name: "power on count"
+      device_id: device0
     balancing_current:
       name: "balancing current"
       device_id: device0
@@ -535,6 +538,9 @@ sensor:
       device_id: device1
     total_runtime:
       name: "total runtime"
+      device_id: device1
+    power_on_count:
+      name: "power on count"
       device_id: device1
     balancing_current:
       name: "balancing current"

--- a/esp32-heltec-balancer-ble-example.yaml
+++ b/esp32-heltec-balancer-ble-example.yaml
@@ -215,6 +215,8 @@ sensor:
       name: "temperature sensor 2"
     total_runtime:
       name: "total runtime"
+    power_on_count:
+      name: "power on count"
     balancing_current:
       name: "balancing current"
     # Not implemented

--- a/tests/components/heltec_balancer_ble/ek-24s10eb_test.cpp
+++ b/tests/components/heltec_balancer_ble/ek-24s10eb_test.cpp
@@ -177,6 +177,16 @@ TEST(Ek24S10EbDeviceInfoTest, TotalRuntime) {
   EXPECT_FLOAT_EQ(runtime.state, 1827398.0f);
 }
 
+TEST(Ek24S10EbDeviceInfoTest, PowerOnCount) {
+  TestableHeltecBalancerBle bms;
+  sensor::Sensor power_on_count;
+  bms.set_power_on_count_sensor(&power_on_count);
+
+  bms.decode_device_info_(DEVICE_INFO_FRAME);
+
+  EXPECT_FLOAT_EQ(power_on_count.state, 7.0f);
+}
+
 TEST(Ek24S10EbDeviceInfoTest, TotalRuntimeFormatted) {
   TestableHeltecBalancerBle bms;
   text_sensor::TextSensor formatted;

--- a/tests/components/heltec_balancer_ble/ek-24s4eb_test.cpp
+++ b/tests/components/heltec_balancer_ble/ek-24s4eb_test.cpp
@@ -179,6 +179,16 @@ TEST(EkDeviceInfoTest, TotalRuntime) {
   EXPECT_FLOAT_EQ(runtime.state, 127854.0f);
 }
 
+TEST(EkDeviceInfoTest, PowerOnCount) {
+  TestableHeltecBalancerBle bms;
+  sensor::Sensor power_on_count;
+  bms.set_power_on_count_sensor(&power_on_count);
+
+  bms.decode_device_info_(DEVICE_INFO_FRAME);
+
+  EXPECT_FLOAT_EQ(power_on_count.state, 6.0f);
+}
+
 TEST(EkDeviceInfoTest, TotalRuntimeFormatted) {
   TestableHeltecBalancerBle bms;
   text_sensor::TextSensor formatted;

--- a/tests/components/heltec_balancer_ble/ek-b24s8e200a_test.cpp
+++ b/tests/components/heltec_balancer_ble/ek-b24s8e200a_test.cpp
@@ -222,6 +222,16 @@ TEST(EkB24S8E200ADeviceInfoTest, TotalRuntime) {
   EXPECT_FLOAT_EQ(runtime.state, 53081.0f);
 }
 
+TEST(EkB24S8E200ADeviceInfoTest, PowerOnCount) {
+  TestableHeltecBalancerBle bms;
+  sensor::Sensor power_on_count;
+  bms.set_power_on_count_sensor(&power_on_count);
+
+  bms.decode_device_info_(DEVICE_INFO_FRAME);
+
+  EXPECT_FLOAT_EQ(power_on_count.state, 16.0f);
+}
+
 TEST(EkB24S8E200ADeviceInfoTest, TotalRuntimeFormatted) {
   TestableHeltecBalancerBle bms;
   text_sensor::TextSensor formatted;

--- a/tests/components/heltec_balancer_ble/gw-24s4eb_test.cpp
+++ b/tests/components/heltec_balancer_ble/gw-24s4eb_test.cpp
@@ -173,6 +173,16 @@ TEST(GwDeviceInfoTest, TotalRuntime) {
   EXPECT_FLOAT_EQ(runtime.state, 4064370.0f);
 }
 
+TEST(GwDeviceInfoTest, PowerOnCount) {
+  TestableHeltecBalancerBle bms;
+  sensor::Sensor power_on_count;
+  bms.set_power_on_count_sensor(&power_on_count);
+
+  bms.decode_device_info_(DEVICE_INFO_FRAME);
+
+  EXPECT_FLOAT_EQ(power_on_count.state, 33.0f);
+}
+
 TEST(GwDeviceInfoTest, TotalRuntimeFormatted) {
   TestableHeltecBalancerBle bms;
   text_sensor::TextSensor formatted;

--- a/tests/test_component_schemas.py
+++ b/tests/test_component_schemas.py
@@ -265,7 +265,9 @@ class TestJkBalancerSensorLists:
 
 class TestHeltecBalancerBleSensorLists:
     def test_sensor_defs_completeness(self):
-        assert len(heltec_sensor.SENSOR_DEFS) == 23
+        assert heltec_sensor.CONF_TOTAL_RUNTIME in heltec_sensor.SENSOR_DEFS
+        assert heltec_sensor.CONF_POWER_ON_COUNT in heltec_sensor.SENSOR_DEFS
+        assert len(heltec_sensor.SENSOR_DEFS) == 24
 
     def test_binary_sensor_defs_dict(self):
         assert (
@@ -282,11 +284,18 @@ class TestHeltecBalancerBleSensorLists:
         assert heltec_text_sensor.CONF_ERRORS in heltec_text_sensor.TEXT_SENSORS
         assert heltec_text_sensor.CONF_BATTERY_TYPE in heltec_text_sensor.TEXT_SENSORS
         assert heltec_text_sensor.CONF_DEVICE_MODEL in heltec_text_sensor.TEXT_SENSORS
-        assert heltec_text_sensor.CONF_HARDWARE_VERSION in heltec_text_sensor.TEXT_SENSORS
-        assert heltec_text_sensor.CONF_SOFTWARE_VERSION in heltec_text_sensor.TEXT_SENSORS
-        assert heltec_text_sensor.CONF_PROTOCOL_VERSION in heltec_text_sensor.TEXT_SENSORS
         assert (
-            heltec_text_sensor.CONF_MANUFACTURING_DATE in heltec_text_sensor.TEXT_SENSORS
+            heltec_text_sensor.CONF_HARDWARE_VERSION in heltec_text_sensor.TEXT_SENSORS
+        )
+        assert (
+            heltec_text_sensor.CONF_SOFTWARE_VERSION in heltec_text_sensor.TEXT_SENSORS
+        )
+        assert (
+            heltec_text_sensor.CONF_PROTOCOL_VERSION in heltec_text_sensor.TEXT_SENSORS
+        )
+        assert (
+            heltec_text_sensor.CONF_MANUFACTURING_DATE
+            in heltec_text_sensor.TEXT_SENSORS
         )
         assert len(heltec_text_sensor.TEXT_SENSORS) == 10
 


### PR DESCRIPTION
## Summary
- The device info frame already contained the power-on counter (byte offset 56) but it was only logged via `ESP_LOGI`, never published to a sensor.
- Adds a `power_on_count` sensor (unit-less, total-increasing count) following the same pattern as `charging_cycles` in `jk_bms_ble`.
- Wires the sensor into `dump_config`, `decode_device_info_`, and `publish_device_unavailable_`, and adds it to the example configs.

## Test plan
- [x] `pytest tests/test_component_schemas.py` passes
- [x] Added `PowerOnCount` unit tests for all four device variants (gw-24s4eb, ek-24s4eb, ek-24s10eb, ek-b24s8e200a), values derived from the existing test frame bytes