### PR TITLE
jk_bms_ble: make JK02 error labels configurable via error_overrides

### DIFF
--- a/components/jk_bms_ble/__init__.py
+++ b/components/jk_bms_ble/__init__.py
@@ -39,6 +39,47 @@ def deprecated_renames(renames: dict[str, str]):
 
 CONF_JK_BMS_BLE_ID = "jk_bms_ble_id"
 CONF_PROTOCOL_VERSION = "protocol_version"
+CONF_ERROR_OVERRIDES = "error_overrides"
+
+# Single source of truth for the JK02 error bitmask labels (bits 0-31).
+# The manufacturer has changed the meaning of some bits across firmware
+# generations (e.g. bit 4 used to mean "Cell Overvoltage", newer firmware
+# reports "Battery is fully charged" there instead) - `error_overrides` lets
+# a user override individual entries without patching the component.
+DEFAULT_ERRORS_JK02 = [
+    "Wire resistance",  # bit 0
+    "MOSFET overtemperature",  # bit 1
+    "Cell count is not equal to settings",  # bit 2
+    "",  # bit 3 (Previously: "Current sensor anomaly")
+    "Battery is fully charged",  # bit 4
+    "Battery pack overvoltage",  # bit 5
+    "Charge overcurrent",  # bit 6
+    "Charge short circuit",  # bit 7
+    "Charge overtemperature",  # bit 8
+    "Charge undertemperature",  # bit 9
+    "Coprocessor communication error",  # bit 10
+    "Cell undervoltage",  # bit 11
+    "Battery pack undervoltage",  # bit 12
+    "Discharge overcurrent",  # bit 13
+    "Discharge short circuit",  # bit 14
+    "Discharge overtemperature",  # bit 15
+    "Charging MOSFET abnormal",  # bit 16
+    "Discharging MOSFET abnormal",  # bit 17
+    "GPS disconnected",  # bit 18
+    "Modify password in time",  # bit 19
+    "Discharge on failed",  # bit 20
+    "Battery overtemperature",  # bit 21
+    "Temperature sensor anomaly",  # bit 22
+    "PL module anomaly",  # bit 23
+    "SCP release failed",  # bit 24
+    "Discharge OCP II",  # bit 25
+    "Discharge OCP III",  # bit 26
+    "Discharge undertemperature alarm",  # bit 27
+    "GPS remote lock",  # bit 28
+    "",  # bit 29
+    "",  # bit 30
+    "",  # bit 31
+]
 
 jk_bms_ble_ns = cg.esphome_ns.namespace("jk_bms_ble")
 JkBmsBle = jk_bms_ble_ns.class_(
@@ -69,6 +110,9 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(
                 CONF_THROTTLE, default="2s"
             ): cv.positive_time_period_milliseconds,
+            cv.Optional(CONF_ERROR_OVERRIDES): cv.Schema(
+                {cv.int_range(0, len(DEFAULT_ERRORS_JK02) - 1): cv.string_strict}
+            ),
         }
     )
     .extend(ble_client.BLE_CLIENT_SCHEMA)
@@ -83,3 +127,19 @@ async def to_code(config):
 
     cg.add(var.set_throttle(config[CONF_THROTTLE]))
     cg.add(var.set_protocol_version(config[CONF_PROTOCOL_VERSION]))
+
+    errors_jk02 = DEFAULT_ERRORS_JK02.copy()
+    for bit, label in config.get(CONF_ERROR_OVERRIDES, {}).items():
+        errors_jk02[bit] = label
+
+    # Emit a static constexpr lookup table in flash and hand a pointer to the hub.
+    # This keeps the error labels (and any error_overrides) as the single source
+    # of truth in Python - jk_bms_ble.cpp holds no error-label data of its own.
+    arr_name = f"{config[CONF_ID]}_ERRORS_JK02"
+    entries = ", ".join(str(cg.safe_exp(label)) for label in errors_jk02)
+    cg.add_global(
+        cg.RawStatement(
+            f"static constexpr const char *const {arr_name}[] = {{{entries}}};"
+        )
+    )
+    cg.add(var.set_errors_jk02_table(cg.RawExpression(arr_name), len(errors_jk02)))

--- a/components/jk_bms_ble/__init__.py
+++ b/components/jk_bms_ble/__init__.py
@@ -41,11 +41,6 @@ CONF_JK_BMS_BLE_ID = "jk_bms_ble_id"
 CONF_PROTOCOL_VERSION = "protocol_version"
 CONF_ERROR_OVERRIDES = "error_overrides"
 
-# Single source of truth for the JK02 error bitmask labels (bits 0-31).
-# The manufacturer has changed the meaning of some bits across firmware
-# generations (e.g. bit 4 used to mean "Cell Overvoltage", newer firmware
-# reports "Battery is fully charged" there instead) - `error_overrides` lets
-# a user override individual entries without patching the component.
 DEFAULT_ERRORS_JK02 = [
     "Wire resistance",  # bit 0
     "MOSFET overtemperature",  # bit 1
@@ -143,10 +138,6 @@ async def to_code(config):
 
     errors_jk02 = apply_error_overrides(config.get(CONF_ERROR_OVERRIDES, {}))
 
-    # Emit a static constexpr lookup table in flash and hand a pointer to the hub.
-    # This keeps the error labels (and any error_overrides) as the single source of
-    # truth in Python - jk_bms_ble.cpp holds no error-label data of its own. The
-    # docs/protocol-design-ble.md bit layout table mirrors DEFAULT_ERRORS_JK02.
     arr_name = f"{config[CONF_ID]}_ERRORS_JK02"
     entries = ", ".join(str(cg.safe_exp(label)) for label in errors_jk02)
     cg.add_global(

--- a/components/jk_bms_ble/__init__.py
+++ b/components/jk_bms_ble/__init__.py
@@ -75,6 +75,32 @@ DEFAULT_ERRORS_JK02 = (
     "",  # bit 30
     "",  # bit 31
 )
+MAX_ERROR_BIT = len(DEFAULT_ERRORS_JK02) - 1
+
+
+def error_overrides(value):
+    # A plain {cv.int_range(...): cv.string_strict} schema rejects an out of range
+    # bit with voluptuous' "extra keys not allowed", which tells the user nothing.
+    value = cv.Schema({cv.string: cv.string_strict})(value)
+
+    overrides = {}
+    for key, label in value.items():
+        try:
+            bit = cv.int_(key)
+        except cv.Invalid:
+            raise cv.Invalid(
+                f"'{key}' is not a valid error bit, expected a number between 0 and {MAX_ERROR_BIT}",
+                path=[key],
+            ) from None
+        if not 0 <= bit <= MAX_ERROR_BIT:
+            raise cv.Invalid(
+                f"Error bit {bit} is out of range, must be between 0 and {MAX_ERROR_BIT}",
+                path=[key],
+            )
+        overrides[bit] = label
+
+    return overrides
+
 
 jk_bms_ble_ns = cg.esphome_ns.namespace("jk_bms_ble")
 JkBmsBle = jk_bms_ble_ns.class_(
@@ -105,9 +131,7 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(
                 CONF_THROTTLE, default="2s"
             ): cv.positive_time_period_milliseconds,
-            cv.Optional(CONF_ERROR_OVERRIDES): cv.Schema(
-                {cv.int_range(0, len(DEFAULT_ERRORS_JK02) - 1): cv.string_strict}
-            ),
+            cv.Optional(CONF_ERROR_OVERRIDES): error_overrides,
         }
     )
     .extend(ble_client.BLE_CLIENT_SCHEMA)

--- a/components/jk_bms_ble/__init__.py
+++ b/components/jk_bms_ble/__init__.py
@@ -81,6 +81,21 @@ DEFAULT_ERRORS_JK02 = [
     "",  # bit 31
 ]
 
+# Maps a bit position to the label replacing the DEFAULT_ERRORS_JK02 entry. An empty
+# label suppresses the bit, so it shows up in the raw bitmask sensor only.
+ERROR_OVERRIDES_SCHEMA = cv.Schema(
+    {cv.int_range(0, len(DEFAULT_ERRORS_JK02) - 1): cv.string_strict}
+)
+
+
+def apply_error_overrides(overrides):
+    """Return the JK02 error labels with the given {bit: label} overrides applied."""
+    errors = DEFAULT_ERRORS_JK02.copy()
+    for bit, label in overrides.items():
+        errors[bit] = label
+    return errors
+
+
 jk_bms_ble_ns = cg.esphome_ns.namespace("jk_bms_ble")
 JkBmsBle = jk_bms_ble_ns.class_(
     "JkBmsBle", ble_client.BLEClientNode, cg.PollingComponent
@@ -110,9 +125,7 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(
                 CONF_THROTTLE, default="2s"
             ): cv.positive_time_period_milliseconds,
-            cv.Optional(CONF_ERROR_OVERRIDES): cv.Schema(
-                {cv.int_range(0, len(DEFAULT_ERRORS_JK02) - 1): cv.string_strict}
-            ),
+            cv.Optional(CONF_ERROR_OVERRIDES): ERROR_OVERRIDES_SCHEMA,
         }
     )
     .extend(ble_client.BLE_CLIENT_SCHEMA)
@@ -128,13 +141,12 @@ async def to_code(config):
     cg.add(var.set_throttle(config[CONF_THROTTLE]))
     cg.add(var.set_protocol_version(config[CONF_PROTOCOL_VERSION]))
 
-    errors_jk02 = DEFAULT_ERRORS_JK02.copy()
-    for bit, label in config.get(CONF_ERROR_OVERRIDES, {}).items():
-        errors_jk02[bit] = label
+    errors_jk02 = apply_error_overrides(config.get(CONF_ERROR_OVERRIDES, {}))
 
     # Emit a static constexpr lookup table in flash and hand a pointer to the hub.
-    # This keeps the error labels (and any error_overrides) as the single source
-    # of truth in Python - jk_bms_ble.cpp holds no error-label data of its own.
+    # This keeps the error labels (and any error_overrides) as the single source of
+    # truth in Python - jk_bms_ble.cpp holds no error-label data of its own. The
+    # docs/protocol-design-ble.md bit layout table mirrors DEFAULT_ERRORS_JK02.
     arr_name = f"{config[CONF_ID]}_ERRORS_JK02"
     entries = ", ".join(str(cg.safe_exp(label)) for label in errors_jk02)
     cg.add_global(

--- a/components/jk_bms_ble/__init__.py
+++ b/components/jk_bms_ble/__init__.py
@@ -41,40 +41,42 @@ CONF_JK_BMS_BLE_ID = "jk_bms_ble_id"
 CONF_PROTOCOL_VERSION = "protocol_version"
 CONF_ERROR_OVERRIDES = "error_overrides"
 
+# fmt: off
 DEFAULT_ERRORS_JK02 = (
-    "Wire resistance",  # bit 0
-    "MOSFET overtemperature",  # bit 1
+    "Wire resistance",                      # bit 0
+    "MOSFET overtemperature",               # bit 1
     "Cell count is not equal to settings",  # bit 2
-    "",  # bit 3 (Previously: "Current sensor anomaly")
-    "Battery is fully charged",  # bit 4
-    "Battery pack overvoltage",  # bit 5
-    "Charge overcurrent",  # bit 6
-    "Charge short circuit",  # bit 7
-    "Charge overtemperature",  # bit 8
-    "Charge undertemperature",  # bit 9
-    "Coprocessor communication error",  # bit 10
-    "Cell undervoltage",  # bit 11
-    "Battery pack undervoltage",  # bit 12
-    "Discharge overcurrent",  # bit 13
-    "Discharge short circuit",  # bit 14
-    "Discharge overtemperature",  # bit 15
-    "Charging MOSFET abnormal",  # bit 16
-    "Discharging MOSFET abnormal",  # bit 17
-    "GPS disconnected",  # bit 18
-    "Modify password in time",  # bit 19
-    "Discharge on failed",  # bit 20
-    "Battery overtemperature",  # bit 21
-    "Temperature sensor anomaly",  # bit 22
-    "PL module anomaly",  # bit 23
-    "SCP release failed",  # bit 24
-    "Discharge OCP II",  # bit 25
-    "Discharge OCP III",  # bit 26
-    "Discharge undertemperature alarm",  # bit 27
-    "GPS remote lock",  # bit 28
-    "",  # bit 29
-    "",  # bit 30
-    "",  # bit 31
+    "",                                     # bit 3 (Previously: "Current sensor anomaly")
+    "Battery is fully charged",             # bit 4
+    "Battery pack overvoltage",             # bit 5
+    "Charge overcurrent",                   # bit 6
+    "Charge short circuit",                 # bit 7
+    "Charge overtemperature",               # bit 8
+    "Charge undertemperature",              # bit 9
+    "Coprocessor communication error",      # bit 10
+    "Cell undervoltage",                    # bit 11
+    "Battery pack undervoltage",            # bit 12
+    "Discharge overcurrent",                # bit 13
+    "Discharge short circuit",              # bit 14
+    "Discharge overtemperature",            # bit 15
+    "Charging MOSFET abnormal",             # bit 16
+    "Discharging MOSFET abnormal",          # bit 17
+    "GPS disconnected",                     # bit 18
+    "Modify password in time",              # bit 19
+    "Discharge on failed",                  # bit 20
+    "Battery overtemperature",              # bit 21
+    "Temperature sensor anomaly",           # bit 22
+    "PL module anomaly",                    # bit 23
+    "SCP release failed",                   # bit 24
+    "Discharge OCP II",                     # bit 25
+    "Discharge OCP III",                    # bit 26
+    "Discharge undertemperature alarm",     # bit 27
+    "GPS remote lock",                      # bit 28
+    "",                                     # bit 29
+    "",                                     # bit 30
+    "",                                     # bit 31
 )
+# fmt: on
 MAX_ERROR_BIT = len(DEFAULT_ERRORS_JK02) - 1
 
 

--- a/components/jk_bms_ble/__init__.py
+++ b/components/jk_bms_ble/__init__.py
@@ -41,7 +41,7 @@ CONF_JK_BMS_BLE_ID = "jk_bms_ble_id"
 CONF_PROTOCOL_VERSION = "protocol_version"
 CONF_ERROR_OVERRIDES = "error_overrides"
 
-DEFAULT_ERRORS_JK02 = [
+DEFAULT_ERRORS_JK02 = (
     "Wire resistance",  # bit 0
     "MOSFET overtemperature",  # bit 1
     "Cell count is not equal to settings",  # bit 2
@@ -74,22 +74,7 @@ DEFAULT_ERRORS_JK02 = [
     "",  # bit 29
     "",  # bit 30
     "",  # bit 31
-]
-
-# Maps a bit position to the label replacing the DEFAULT_ERRORS_JK02 entry. An empty
-# label suppresses the bit, so it shows up in the raw bitmask sensor only.
-ERROR_OVERRIDES_SCHEMA = cv.Schema(
-    {cv.int_range(0, len(DEFAULT_ERRORS_JK02) - 1): cv.string_strict}
 )
-
-
-def apply_error_overrides(overrides):
-    """Return the JK02 error labels with the given {bit: label} overrides applied."""
-    errors = DEFAULT_ERRORS_JK02.copy()
-    for bit, label in overrides.items():
-        errors[bit] = label
-    return errors
-
 
 jk_bms_ble_ns = cg.esphome_ns.namespace("jk_bms_ble")
 JkBmsBle = jk_bms_ble_ns.class_(
@@ -120,7 +105,9 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(
                 CONF_THROTTLE, default="2s"
             ): cv.positive_time_period_milliseconds,
-            cv.Optional(CONF_ERROR_OVERRIDES): ERROR_OVERRIDES_SCHEMA,
+            cv.Optional(CONF_ERROR_OVERRIDES): cv.Schema(
+                {cv.int_range(0, len(DEFAULT_ERRORS_JK02) - 1): cv.string_strict}
+            ),
         }
     )
     .extend(ble_client.BLE_CLIENT_SCHEMA)
@@ -136,7 +123,9 @@ async def to_code(config):
     cg.add(var.set_throttle(config[CONF_THROTTLE]))
     cg.add(var.set_protocol_version(config[CONF_PROTOCOL_VERSION]))
 
-    errors_jk02 = apply_error_overrides(config.get(CONF_ERROR_OVERRIDES, {}))
+    errors_jk02 = list(DEFAULT_ERRORS_JK02)
+    for bit, label in config.get(CONF_ERROR_OVERRIDES, {}).items():
+        errors_jk02[bit] = label
 
     arr_name = f"{config[CONF_ID]}_ERRORS_JK02"
     entries = ", ".join(str(cg.safe_exp(label)) for label in errors_jk02)

--- a/components/jk_bms_ble/jk_bms_ble.cpp
+++ b/components/jk_bms_ble/jk_bms_ble.cpp
@@ -818,7 +818,7 @@ void JkBmsBle::decode_jk02_cell_info_(const std::vector<uint8_t> &data) {
     uint32_t raw_errors_bitmask = jk_get_32bit(134 + offset);
     this->publish_state_(this->errors_bitmask_hex_text_sensor_, this->to_hex_string_(raw_errors_bitmask));
     this->publish_state_(this->errors_text_sensor_,
-                         this->error_bits_to_string_(raw_errors_bitmask, this->errors_jk02_table_.entries, 32));
+                         this->error_bits_to_string_(raw_errors_bitmask, this->errors_jk02_table_, 32));
   } else {
     this->publish_state_(this->mosfet_temperature_sensor_, (float) ((int16_t) jk_get_16bit(134 + offset)) * 0.1f);
   }
@@ -829,7 +829,7 @@ void JkBmsBle::decode_jk02_cell_info_(const std::vector<uint8_t> &data) {
     uint32_t raw_errors_bitmask = jk_get_16bit(136 + offset);
     this->publish_state_(this->errors_bitmask_hex_text_sensor_, this->to_hex_string_(raw_errors_bitmask));
     this->publish_state_(this->errors_text_sensor_,
-                         this->error_bits_to_string_(raw_errors_bitmask, this->errors_jk02_table_.entries, 16));
+                         this->error_bits_to_string_(raw_errors_bitmask, this->errors_jk02_table_, 16));
   }
 
   // 138   2   0x00 0x00              Balance current      0.001         A
@@ -1963,19 +1963,22 @@ std::string JkBmsBle::to_hex_string_(const uint32_t mask) {
   return std::string(buf);
 }
 
-std::string JkBmsBle::error_bits_to_string_(const uint32_t mask, const char *const *errors, const uint8_t errors_size) {
-  bool first = true;
+std::string JkBmsBle::error_bits_to_string_(const uint32_t mask, const LookupTable &errors, const uint8_t bits) {
   std::string errors_list;
 
-  if (mask) {
-    for (int i = 0; i < errors_size; i++) {
-      if ((mask & (1 << i)) && errors[i][0] != '\0') {
-        if (!first)
-          errors_list.append(";");
-        first = false;
-        errors_list.append(errors[i]);
-      }
-    }
+  for (uint8_t i = 0; i < bits; i++) {
+    if ((mask & (1UL << i)) == 0)
+      continue;
+
+    // Bits without a label (unused or suppressed via `error_overrides`) and bits beyond
+    // the configured table are reported by the raw bitmask sensor only.
+    const char *label = errors.get(i);
+    if (label == nullptr || label[0] == '\0')
+      continue;
+
+    if (!errors_list.empty())
+      errors_list.append(";");
+    errors_list.append(label);
   }
 
   return errors_list;

--- a/components/jk_bms_ble/jk_bms_ble.cpp
+++ b/components/jk_bms_ble/jk_bms_ble.cpp
@@ -29,41 +29,6 @@ static const uint8_t COMMAND_LOGBOOK = 0xA1;
 static const uint16_t MIN_RESPONSE_SIZE = 300;
 static const uint16_t MAX_RESPONSE_SIZE = 384 + 16;
 
-static constexpr const char *const ERRORS_JK02[] = {
-    "Wire resistance",                      // bit 0
-    "MOSFET overtemperature",               // bit 1
-    "Cell count is not equal to settings",  // bit 2
-    "",                                     // bit 3 (Previously: "Current sensor anomaly")
-    "Battery is fully charged",             // bit 4
-    "Battery pack overvoltage",             // bit 5
-    "Charge overcurrent",                   // bit 6
-    "Charge short circuit",                 // bit 7
-    "Charge overtemperature",               // bit 8
-    "Charge undertemperature",              // bit 9
-    "Coprocessor communication error",      // bit 10
-    "Cell undervoltage",                    // bit 11
-    "Battery pack undervoltage",            // bit 12
-    "Discharge overcurrent",                // bit 13
-    "Discharge short circuit",              // bit 14
-    "Discharge overtemperature",            // bit 15
-    "Charging MOSFET abnormal",             // bit 16
-    "Discharging MOSFET abnormal",          // bit 17
-    "GPS disconnected",                     // bit 18
-    "Modify password in time",              // bit 19
-    "Discharge on failed",                  // bit 20
-    "Battery overtemperature",              // bit 21
-    "Temperature sensor anomaly",           // bit 22
-    "PL module anomaly",                    // bit 23
-    "SCP release failed",                   // bit 24
-    "Discharge OCP II",                     // bit 25
-    "Discharge OCP III",                    // bit 26
-    "Discharge undertemperature alarm",     // bit 27
-    "GPS remote lock",                      // bit 28
-    "",                                     // bit 29
-    "",                                     // bit 30
-    "",                                     // bit 31
-};
-
 static constexpr const char *const LOGBOOK_CODES[] = {
     "",                                                    // 0x00
     "Boot",                                                // 0x01
@@ -852,7 +817,8 @@ void JkBmsBle::decode_jk02_cell_info_(const std::vector<uint8_t> &data) {
     // 166-169: errors bitmask, little-endian 32-bit
     uint32_t raw_errors_bitmask = jk_get_32bit(134 + offset);
     this->publish_state_(this->errors_bitmask_hex_text_sensor_, this->to_hex_string_(raw_errors_bitmask));
-    this->publish_state_(this->errors_text_sensor_, this->error_bits_to_string_(raw_errors_bitmask, ERRORS_JK02, 32));
+    this->publish_state_(this->errors_text_sensor_,
+                         this->error_bits_to_string_(raw_errors_bitmask, this->errors_jk02_table_.entries, 32));
   } else {
     this->publish_state_(this->mosfet_temperature_sensor_, (float) ((int16_t) jk_get_16bit(134 + offset)) * 0.1f);
   }
@@ -862,7 +828,8 @@ void JkBmsBle::decode_jk02_cell_info_(const std::vector<uint8_t> &data) {
   if (frame_version != FRAME_VERSION_JK02_32S) {
     uint32_t raw_errors_bitmask = jk_get_16bit(136 + offset);
     this->publish_state_(this->errors_bitmask_hex_text_sensor_, this->to_hex_string_(raw_errors_bitmask));
-    this->publish_state_(this->errors_text_sensor_, this->error_bits_to_string_(raw_errors_bitmask, ERRORS_JK02, 16));
+    this->publish_state_(this->errors_text_sensor_,
+                         this->error_bits_to_string_(raw_errors_bitmask, this->errors_jk02_table_.entries, 16));
   }
 
   // 138   2   0x00 0x00              Balance current      0.001         A

--- a/components/jk_bms_ble/jk_bms_ble.h
+++ b/components/jk_bms_ble/jk_bms_ble.h
@@ -585,7 +585,7 @@ class JkBmsBle :
   void reset_online_status_tracker_();
   void track_online_status_();
   std::string to_hex_string_(uint32_t mask);
-  std::string error_bits_to_string_(uint32_t bitmask, const char *const *errors, uint8_t errors_size);
+  std::string error_bits_to_string_(uint32_t bitmask, const LookupTable &errors, uint8_t bits);
   std::string charge_status_id_to_string_(uint8_t status);
   std::string battery_type_id_to_string_(uint8_t code);
 

--- a/components/jk_bms_ble/jk_bms_ble.h
+++ b/components/jk_bms_ble/jk_bms_ble.h
@@ -404,6 +404,7 @@ class JkBmsBle :
   void set_multiplexed_port_mode_table(const char *const *entries, size_t count) {
     multiplexed_port_mode_table_ = {entries, count};
   }
+  void set_errors_jk02_table(const char *const *entries, size_t count) { errors_jk02_table_ = {entries, count}; }
 
   void assemble(const uint8_t *data, uint16_t length);
   void set_protocol_version(ProtocolVersion protocol_version) { protocol_version_ = protocol_version; }
@@ -543,6 +544,7 @@ class JkBmsBle :
   LookupTable can_protocol_table_;
   LookupTable lcd_buzzer_trigger_table_;
   LookupTable multiplexed_port_mode_table_;
+  LookupTable errors_jk02_table_;
 
   text_sensor::TextSensor *errors_bitmask_hex_text_sensor_{nullptr};
   text_sensor::TextSensor *errors_text_sensor_{nullptr};

--- a/esp32-ble-example-multiple-devices.yaml
+++ b/esp32-ble-example-multiple-devices.yaml
@@ -75,6 +75,12 @@ jk_bms_ble:
     protocol_version: ${bms0_protocol_version}
     throttle: 5s
     id: bms0
+    # Override the label of one or more error bits (bit 0-31, JK02 only). JK
+    # reassigned some bits across firmware generations: bit 4 used to mean
+    # "Cell overvoltage" while newer firmware reports "Battery is fully charged"
+    # there. An empty label suppresses the bit entirely.
+    # error_overrides:
+    #   4: Cell overvoltage
   - ble_client_id: client1
     protocol_version: ${bms1_protocol_version}
     throttle: 5s

--- a/esp32-ble-example-multiple-devices.yaml
+++ b/esp32-ble-example-multiple-devices.yaml
@@ -75,12 +75,11 @@ jk_bms_ble:
     protocol_version: ${bms0_protocol_version}
     throttle: 5s
     id: bms0
-    # Override the label of one or more error bits (bit 0-31, JK02 only). JK
-    # reassigned some bits across firmware generations: bit 4 used to mean
-    # "Cell overvoltage" while newer firmware reports "Battery is fully charged"
-    # there. An empty label suppresses the bit entirely.
+    # Override the label of one or more error bits (bit 0-31, JK02 only).
+    # An empty label suppresses the bit entirely.
+    #
     # error_overrides:
-    #   4: Cell overvoltage
+    #   4: "Cell overvoltage"
   - ble_client_id: client1
     protocol_version: ${bms1_protocol_version}
     throttle: 5s

--- a/esp32-ble-example.yaml
+++ b/esp32-ble-example.yaml
@@ -64,6 +64,12 @@ jk_bms_ble:
     protocol_version: ${protocol_version}
     throttle: 5s
     id: bms0
+    # Override the label of one or more error bits (bit 0-31, JK02 only). JK
+    # reassigned some bits across firmware generations: bit 4 used to mean
+    # "Cell overvoltage" while newer firmware reports "Battery is fully charged"
+    # there. An empty label suppresses the bit entirely.
+    # error_overrides:
+    #   4: Cell overvoltage
 
 binary_sensor:
   - platform: jk_bms_ble

--- a/esp32-ble-example.yaml
+++ b/esp32-ble-example.yaml
@@ -64,12 +64,11 @@ jk_bms_ble:
     protocol_version: ${protocol_version}
     throttle: 5s
     id: bms0
-    # Override the label of one or more error bits (bit 0-31, JK02 only). JK
-    # reassigned some bits across firmware generations: bit 4 used to mean
-    # "Cell overvoltage" while newer firmware reports "Battery is fully charged"
-    # there. An empty label suppresses the bit entirely.
+    # Override the label of one or more error bits (bit 0-31, JK02 only).
+    # An empty label suppresses the bit entirely.
+    #
     # error_overrides:
-    #   4: Cell overvoltage
+    #   4: "Cell overvoltage"
 
 binary_sensor:
   - platform: jk_bms_ble

--- a/esp32-ble-jk04-example.yaml
+++ b/esp32-ble-jk04-example.yaml
@@ -64,6 +64,12 @@ jk_bms_ble:
     protocol_version: ${protocol_version}
     throttle: 5s
     id: bms0
+    # Override the label of one or more error bits (bit 0-31, JK02 only). JK
+    # reassigned some bits across firmware generations: bit 4 used to mean
+    # "Cell overvoltage" while newer firmware reports "Battery is fully charged"
+    # there. An empty label suppresses the bit entirely.
+    # error_overrides:
+    #   4: Cell overvoltage
 
 binary_sensor:
   - platform: jk_bms_ble

--- a/esp32-ble-jk04-example.yaml
+++ b/esp32-ble-jk04-example.yaml
@@ -64,12 +64,11 @@ jk_bms_ble:
     protocol_version: ${protocol_version}
     throttle: 5s
     id: bms0
-    # Override the label of one or more error bits (bit 0-31, JK02 only). JK
-    # reassigned some bits across firmware generations: bit 4 used to mean
-    # "Cell overvoltage" while newer firmware reports "Battery is fully charged"
-    # there. An empty label suppresses the bit entirely.
+    # Override the label of one or more error bits (bit 0-31, JK02 only).
+    # An empty label suppresses the bit entirely.
+    #
     # error_overrides:
-    #   4: Cell overvoltage
+    #   4: "Cell overvoltage"
 
 binary_sensor:
   - platform: jk_bms_ble

--- a/esp32-ble-uart-hybrid-example.yaml
+++ b/esp32-ble-uart-hybrid-example.yaml
@@ -71,6 +71,12 @@ jk_bms_ble:
     protocol_version: ${protocol_version}
     throttle: 10s
     id: bmsble0
+    # Override the label of one or more error bits (bit 0-31, JK02 only). JK
+    # reassigned some bits across firmware generations: bit 4 used to mean
+    # "Cell overvoltage" while newer firmware reports "Battery is fully charged"
+    # there. An empty label suppresses the bit entirely.
+    # error_overrides:
+    #   4: Cell overvoltage
 
 uart:
   - id: uart_0

--- a/esp32-ble-uart-hybrid-example.yaml
+++ b/esp32-ble-uart-hybrid-example.yaml
@@ -71,12 +71,11 @@ jk_bms_ble:
     protocol_version: ${protocol_version}
     throttle: 10s
     id: bmsble0
-    # Override the label of one or more error bits (bit 0-31, JK02 only). JK
-    # reassigned some bits across firmware generations: bit 4 used to mean
-    # "Cell overvoltage" while newer firmware reports "Battery is fully charged"
-    # there. An empty label suppresses the bit entirely.
+    # Override the label of one or more error bits (bit 0-31, JK02 only).
+    # An empty label suppresses the bit entirely.
+    #
     # error_overrides:
-    #   4: Cell overvoltage
+    #   4: "Cell overvoltage"
 
 uart:
   - id: uart_0

--- a/esp32-ble-v11-example.yaml
+++ b/esp32-ble-v11-example.yaml
@@ -64,6 +64,12 @@ jk_bms_ble:
     protocol_version: ${protocol_version}
     throttle: 5s
     id: bms0
+    # Override the label of one or more error bits (bit 0-31, JK02 only). JK
+    # reassigned some bits across firmware generations: bit 4 used to mean
+    # "Cell overvoltage" while newer firmware reports "Battery is fully charged"
+    # there. An empty label suppresses the bit entirely.
+    # error_overrides:
+    #   4: Cell overvoltage
 
 binary_sensor:
   - platform: jk_bms_ble

--- a/esp32-ble-v11-example.yaml
+++ b/esp32-ble-v11-example.yaml
@@ -64,12 +64,11 @@ jk_bms_ble:
     protocol_version: ${protocol_version}
     throttle: 5s
     id: bms0
-    # Override the label of one or more error bits (bit 0-31, JK02 only). JK
-    # reassigned some bits across firmware generations: bit 4 used to mean
-    # "Cell overvoltage" while newer firmware reports "Battery is fully charged"
-    # there. An empty label suppresses the bit entirely.
+    # Override the label of one or more error bits (bit 0-31, JK02 only).
+    # An empty label suppresses the bit entirely.
+    #
     # error_overrides:
-    #   4: Cell overvoltage
+    #   4: "Cell overvoltage"
 
 binary_sensor:
   - platform: jk_bms_ble

--- a/esp32-ble-v14-example-multiple-devices.yaml
+++ b/esp32-ble-v14-example-multiple-devices.yaml
@@ -75,6 +75,12 @@ jk_bms_ble:
     protocol_version: ${bms0_protocol_version}
     throttle: 5s
     id: bms0
+    # Override the label of one or more error bits (bit 0-31, JK02 only). JK
+    # reassigned some bits across firmware generations: bit 4 used to mean
+    # "Cell overvoltage" while newer firmware reports "Battery is fully charged"
+    # there. An empty label suppresses the bit entirely.
+    # error_overrides:
+    #   4: Cell overvoltage
   - ble_client_id: client1
     protocol_version: ${bms1_protocol_version}
     throttle: 5s

--- a/esp32-ble-v14-example-multiple-devices.yaml
+++ b/esp32-ble-v14-example-multiple-devices.yaml
@@ -75,12 +75,11 @@ jk_bms_ble:
     protocol_version: ${bms0_protocol_version}
     throttle: 5s
     id: bms0
-    # Override the label of one or more error bits (bit 0-31, JK02 only). JK
-    # reassigned some bits across firmware generations: bit 4 used to mean
-    # "Cell overvoltage" while newer firmware reports "Battery is fully charged"
-    # there. An empty label suppresses the bit entirely.
+    # Override the label of one or more error bits (bit 0-31, JK02 only).
+    # An empty label suppresses the bit entirely.
+    #
     # error_overrides:
-    #   4: Cell overvoltage
+    #   4: "Cell overvoltage"
   - ble_client_id: client1
     protocol_version: ${bms1_protocol_version}
     throttle: 5s

--- a/esp32-ble-v14-example.yaml
+++ b/esp32-ble-v14-example.yaml
@@ -64,6 +64,12 @@ jk_bms_ble:
     protocol_version: ${protocol_version}
     throttle: 5s
     id: bms0
+    # Override the label of one or more error bits (bit 0-31, JK02 only). JK
+    # reassigned some bits across firmware generations: bit 4 used to mean
+    # "Cell overvoltage" while newer firmware reports "Battery is fully charged"
+    # there. An empty label suppresses the bit entirely.
+    # error_overrides:
+    #   4: Cell overvoltage
 
 binary_sensor:
   - platform: jk_bms_ble

--- a/esp32-ble-v14-example.yaml
+++ b/esp32-ble-v14-example.yaml
@@ -64,12 +64,11 @@ jk_bms_ble:
     protocol_version: ${protocol_version}
     throttle: 5s
     id: bms0
-    # Override the label of one or more error bits (bit 0-31, JK02 only). JK
-    # reassigned some bits across firmware generations: bit 4 used to mean
-    # "Cell overvoltage" while newer firmware reports "Battery is fully charged"
-    # there. An empty label suppresses the bit entirely.
+    # Override the label of one or more error bits (bit 0-31, JK02 only).
+    # An empty label suppresses the bit entirely.
+    #
     # error_overrides:
-    #   4: Cell overvoltage
+    #   4: "Cell overvoltage"
 
 binary_sensor:
   - platform: jk_bms_ble

--- a/esp32-ble-v15-example.yaml
+++ b/esp32-ble-v15-example.yaml
@@ -64,6 +64,12 @@ jk_bms_ble:
     protocol_version: ${protocol_version}
     throttle: 5s
     id: bms0
+    # Override the label of one or more error bits (bit 0-31, JK02 only). JK
+    # reassigned some bits across firmware generations: bit 4 used to mean
+    # "Cell overvoltage" while newer firmware reports "Battery is fully charged"
+    # there. An empty label suppresses the bit entirely.
+    # error_overrides:
+    #   4: Cell overvoltage
 
 binary_sensor:
   - platform: jk_bms_ble

--- a/esp32-ble-v15-example.yaml
+++ b/esp32-ble-v15-example.yaml
@@ -64,12 +64,11 @@ jk_bms_ble:
     protocol_version: ${protocol_version}
     throttle: 5s
     id: bms0
-    # Override the label of one or more error bits (bit 0-31, JK02 only). JK
-    # reassigned some bits across firmware generations: bit 4 used to mean
-    # "Cell overvoltage" while newer firmware reports "Battery is fully charged"
-    # there. An empty label suppresses the bit entirely.
+    # Override the label of one or more error bits (bit 0-31, JK02 only).
+    # An empty label suppresses the bit entirely.
+    #
     # error_overrides:
-    #   4: Cell overvoltage
+    #   4: "Cell overvoltage"
 
 binary_sensor:
   - platform: jk_bms_ble

--- a/esp32-ble-v19-3pack-olimex-poe-example.yaml
+++ b/esp32-ble-v19-3pack-olimex-poe-example.yaml
@@ -99,12 +99,11 @@ jk_bms_ble:
     protocol_version: ${bms0_protocol_version}
     throttle: 5s
     id: bms0
-    # Override the label of one or more error bits (bit 0-31, JK02 only). JK
-    # reassigned some bits across firmware generations: bit 4 used to mean
-    # "Cell overvoltage" while newer firmware reports "Battery is fully charged"
-    # there. An empty label suppresses the bit entirely.
+    # Override the label of one or more error bits (bit 0-31, JK02 only).
+    # An empty label suppresses the bit entirely.
+    #
     # error_overrides:
-    #   4: Cell overvoltage
+    #   4: "Cell overvoltage"
   - ble_client_id: client1
     protocol_version: ${bms1_protocol_version}
     throttle: 5s

--- a/esp32-ble-v19-3pack-olimex-poe-example.yaml
+++ b/esp32-ble-v19-3pack-olimex-poe-example.yaml
@@ -99,6 +99,12 @@ jk_bms_ble:
     protocol_version: ${bms0_protocol_version}
     throttle: 5s
     id: bms0
+    # Override the label of one or more error bits (bit 0-31, JK02 only). JK
+    # reassigned some bits across firmware generations: bit 4 used to mean
+    # "Cell overvoltage" while newer firmware reports "Battery is fully charged"
+    # there. An empty label suppresses the bit entirely.
+    # error_overrides:
+    #   4: Cell overvoltage
   - ble_client_id: client1
     protocol_version: ${bms1_protocol_version}
     throttle: 5s

--- a/esp32-ble-v19-example.yaml
+++ b/esp32-ble-v19-example.yaml
@@ -64,6 +64,12 @@ jk_bms_ble:
     protocol_version: ${protocol_version}
     throttle: 5s
     id: bms0
+    # Override the label of one or more error bits (bit 0-31, JK02 only). JK
+    # reassigned some bits across firmware generations: bit 4 used to mean
+    # "Cell overvoltage" while newer firmware reports "Battery is fully charged"
+    # there. An empty label suppresses the bit entirely.
+    # error_overrides:
+    #   4: Cell overvoltage
 
 binary_sensor:
   - platform: jk_bms_ble

--- a/esp32-ble-v19-example.yaml
+++ b/esp32-ble-v19-example.yaml
@@ -64,12 +64,11 @@ jk_bms_ble:
     protocol_version: ${protocol_version}
     throttle: 5s
     id: bms0
-    # Override the label of one or more error bits (bit 0-31, JK02 only). JK
-    # reassigned some bits across firmware generations: bit 4 used to mean
-    # "Cell overvoltage" while newer firmware reports "Battery is fully charged"
-    # there. An empty label suppresses the bit entirely.
+    # Override the label of one or more error bits (bit 0-31, JK02 only).
+    # An empty label suppresses the bit entirely.
+    #
     # error_overrides:
-    #   4: Cell overvoltage
+    #   4: "Cell overvoltage"
 
 binary_sensor:
   - platform: jk_bms_ble

--- a/tests/components/jk_bms_ble/jk_bms_ble_errors_test.cpp
+++ b/tests/components/jk_bms_ble/jk_bms_ble_errors_test.cpp
@@ -1,4 +1,7 @@
 #include <gtest/gtest.h>
+#include <iterator>
+#include <string>
+#include <utility>
 #include "common.h"
 #include "frames_jk02_32s_v11.h"
 
@@ -7,7 +10,9 @@ namespace esphome::jk_bms_ble::testing {
 // A lookup table mirroring what the Python codegen in jk_bms_ble/__init__.py
 // (DEFAULT_ERRORS_JK02, optionally patched by `error_overrides`) emits as a
 // static constexpr array and hands to the hub via set_errors_jk02_table().
-static constexpr const char *const kTestErrorsJk02[] = {
+// Only the first few bits are covered here - the table is deliberately shorter
+// than the 32 bits the decoder scans so the bounds check is exercised too.
+static constexpr const char *const DEFAULT_ERRORS[] = {
     "Wire resistance",                      // bit 0
     "MOSFET overtemperature",               // bit 1
     "Cell count is not equal to settings",  // bit 2
@@ -15,11 +20,10 @@ static constexpr const char *const kTestErrorsJk02[] = {
     "Battery is fully charged",             // bit 4
     "Battery pack overvoltage",             // bit 5
 };
-static constexpr size_t kTestErrorsJk02Count = 6;
 
 // Same table, but with bit 4 overridden - as if the user had configured
 // `error_overrides: {4: "Cell overvoltage"}` for older firmware.
-static constexpr const char *const kOverriddenErrorsJk02[] = {
+static constexpr const char *const OVERRIDDEN_ERRORS[] = {
     "Wire resistance",                      // bit 0
     "MOSFET overtemperature",               // bit 1
     "Cell count is not equal to settings",  // bit 2
@@ -44,95 +48,89 @@ static void set_jk02_24s_error_mask(std::vector<uint8_t> &frame, uint16_t mask) 
   frame[137] = uint8_t(mask >> 8);
 }
 
-TEST(JkBmsBleErrorsTest, NoTableConfiguredMaskZeroIsSafe) {
+// Feeds a JK02_32S cell info frame carrying `mask` into the decoder and returns the
+// published (errors bitmask hex, errors) pair. Passing a nullptr table leaves
+// errors_jk02_table_ at its default, i.e. a hub whose set_errors_jk02_table() call
+// the codegen never emitted.
+static std::pair<std::string, std::string> decode_32s_errors(uint32_t mask, const char *const *table, size_t count) {
   TestableJkBmsBle bms;
   bms.set_protocol_version(PROTOCOL_VERSION_JK02_32S);
+  if (table != nullptr)
+    bms.set_errors_jk02_table(table, count);
+
   text_sensor::TextSensor hex, text;
   bms.set_errors_bitmask_hex_text_sensor(&hex);
   bms.set_errors_text_sensor(&text);
 
-  // errors_jk02_table_ is left at its default (entries=nullptr, count=0), just
-  // like a freshly constructed hub before to_code() runs the generated
-  // set_errors_jk02_table() call. A zero mask must never dereference the table.
   auto frame = CELL_INFO_JK02_32S_V11;
-  set_jk02_32s_error_mask(frame, 0x00000000);
-
+  set_jk02_32s_error_mask(frame, mask);
   bms.decode_jk02_cell_info_(frame);
 
-  EXPECT_EQ(hex.state, "0x00000000");
-  EXPECT_EQ(text.state, "");
+  return {hex.state, text.state};
+}
+
+static std::pair<std::string, std::string> decode_32s_errors(uint32_t mask) {
+  return decode_32s_errors(mask, DEFAULT_ERRORS, std::size(DEFAULT_ERRORS));
 }
 
 TEST(JkBmsBleErrorsTest, SingleKnownBit) {
-  TestableJkBmsBle bms;
-  bms.set_protocol_version(PROTOCOL_VERSION_JK02_32S);
-  bms.set_errors_jk02_table(kTestErrorsJk02, kTestErrorsJk02Count);
-  text_sensor::TextSensor hex, text;
-  bms.set_errors_bitmask_hex_text_sensor(&hex);
-  bms.set_errors_text_sensor(&text);
+  auto [hex, text] = decode_32s_errors(0x00000001);  // bit 0
 
-  auto frame = CELL_INFO_JK02_32S_V11;
-  set_jk02_32s_error_mask(frame, 0x00000001);  // bit 0
+  EXPECT_EQ(hex, "0x00000001");
+  EXPECT_EQ(text, "Wire resistance");
+}
 
-  bms.decode_jk02_cell_info_(frame);
+TEST(JkBmsBleErrorsTest, MaskZeroPublishesEmptyString) {
+  auto [hex, text] = decode_32s_errors(0x00000000);
 
-  EXPECT_EQ(hex.state, "0x00000001");
-  EXPECT_EQ(text.state, "Wire resistance");
+  EXPECT_EQ(hex, "0x00000000");
+  EXPECT_EQ(text, "");
 }
 
 TEST(JkBmsBleErrorsTest, MultipleBitsJoinedInAscendingOrder) {
-  TestableJkBmsBle bms;
-  bms.set_protocol_version(PROTOCOL_VERSION_JK02_32S);
-  bms.set_errors_jk02_table(kTestErrorsJk02, kTestErrorsJk02Count);
-  text_sensor::TextSensor text;
-  bms.set_errors_text_sensor(&text);
+  auto [hex, text] = decode_32s_errors(0x00000011);  // bit 0 + bit 4
 
-  auto frame = CELL_INFO_JK02_32S_V11;
-  set_jk02_32s_error_mask(frame, 0x00000011);  // bit 0 + bit 4
-
-  bms.decode_jk02_cell_info_(frame);
-
-  EXPECT_EQ(text.state, "Wire resistance;Battery is fully charged");
+  EXPECT_EQ(hex, "0x00000011");
+  EXPECT_EQ(text, "Wire resistance;Battery is fully charged");
 }
 
 TEST(JkBmsBleErrorsTest, EmptyPlaceholderBitIsSkippedButStillInHex) {
-  TestableJkBmsBle bms;
-  bms.set_protocol_version(PROTOCOL_VERSION_JK02_32S);
-  bms.set_errors_jk02_table(kTestErrorsJk02, kTestErrorsJk02Count);
-  text_sensor::TextSensor hex, text;
-  bms.set_errors_bitmask_hex_text_sensor(&hex);
-  bms.set_errors_text_sensor(&text);
+  auto [hex, text] = decode_32s_errors(0x00000009);  // bit 0 + bit 3 (placeholder, "")
 
-  auto frame = CELL_INFO_JK02_32S_V11;
-  set_jk02_32s_error_mask(frame, 0x00000009);  // bit 0 + bit 3 (placeholder, "")
-
-  bms.decode_jk02_cell_info_(frame);
-
-  EXPECT_EQ(hex.state, "0x00000009");
-  EXPECT_EQ(text.state, "Wire resistance");
+  EXPECT_EQ(hex, "0x00000009");
+  EXPECT_EQ(text, "Wire resistance");
 }
 
-// Validates the generic table-override mechanism that error_overrides relies
-// on: swapping in a different table changes the decoded label for a bit
-// without any change to jk_bms_ble.cpp.
+// The decoder scans 32 bits regardless of how many entries the configured table
+// holds. Bits past the end must be dropped instead of read out of bounds.
+TEST(JkBmsBleErrorsTest, BitBeyondTableEndIsIgnored) {
+  auto [hex, text] = decode_32s_errors(0x80000041);  // bit 0 + bit 6 + bit 31, table holds 6 entries
+
+  EXPECT_EQ(hex, "0x80000041");
+  EXPECT_EQ(text, "Wire resistance");
+}
+
+// A hub without a table (entries == nullptr, count == 0) must not dereference it,
+// no matter which bits are set - the raw bitmask is still published.
+TEST(JkBmsBleErrorsTest, NoTableConfiguredPublishesBitmaskOnly) {
+  auto [hex, text] = decode_32s_errors(0xFFFFFFFF, nullptr, 0);
+
+  EXPECT_EQ(hex, "0xFFFFFFFF");
+  EXPECT_EQ(text, "");
+}
+
+// Validates the mechanism error_overrides relies on: swapping in a different table
+// changes the decoded label for a bit without any change to jk_bms_ble.cpp.
 TEST(JkBmsBleErrorsTest, OverriddenLabelIsUsedInsteadOfDefault) {
-  TestableJkBmsBle bms;
-  bms.set_protocol_version(PROTOCOL_VERSION_JK02_32S);
-  bms.set_errors_jk02_table(kOverriddenErrorsJk02, kTestErrorsJk02Count);
-  text_sensor::TextSensor text;
-  bms.set_errors_text_sensor(&text);
+  auto [hex, text] = decode_32s_errors(0x00000010, OVERRIDDEN_ERRORS, std::size(OVERRIDDEN_ERRORS));  // bit 4
 
-  auto frame = CELL_INFO_JK02_32S_V11;
-  set_jk02_32s_error_mask(frame, 0x00000010);  // bit 4
-
-  bms.decode_jk02_cell_info_(frame);
-
-  EXPECT_EQ(text.state, "Cell overvoltage");
+  EXPECT_EQ(hex, "0x00000010");
+  EXPECT_EQ(text, "Cell overvoltage");
 }
 
 TEST(JkBmsBleErrorsTest, Jk02_24SUsesSameTableWith16BitMask) {
   TestableJkBmsBle bms;  // default protocol version is JK02_24S
-  bms.set_errors_jk02_table(kTestErrorsJk02, kTestErrorsJk02Count);
+  bms.set_errors_jk02_table(DEFAULT_ERRORS, std::size(DEFAULT_ERRORS));
   text_sensor::TextSensor hex, text;
   bms.set_errors_bitmask_hex_text_sensor(&hex);
   bms.set_errors_text_sensor(&text);

--- a/tests/components/jk_bms_ble/jk_bms_ble_errors_test.cpp
+++ b/tests/components/jk_bms_ble/jk_bms_ble_errors_test.cpp
@@ -1,0 +1,149 @@
+#include <gtest/gtest.h>
+#include "common.h"
+#include "frames_jk02_32s_v11.h"
+
+namespace esphome::jk_bms_ble::testing {
+
+// A lookup table mirroring what the Python codegen in jk_bms_ble/__init__.py
+// (DEFAULT_ERRORS_JK02, optionally patched by `error_overrides`) emits as a
+// static constexpr array and hands to the hub via set_errors_jk02_table().
+static constexpr const char *const kTestErrorsJk02[] = {
+    "Wire resistance",                      // bit 0
+    "MOSFET overtemperature",               // bit 1
+    "Cell count is not equal to settings",  // bit 2
+    "",                                     // bit 3
+    "Battery is fully charged",             // bit 4
+    "Battery pack overvoltage",             // bit 5
+};
+static constexpr size_t kTestErrorsJk02Count = 6;
+
+// Same table, but with bit 4 overridden - as if the user had configured
+// `error_overrides: {4: "Cell overvoltage"}` for older firmware.
+static constexpr const char *const kOverriddenErrorsJk02[] = {
+    "Wire resistance",                      // bit 0
+    "MOSFET overtemperature",               // bit 1
+    "Cell count is not equal to settings",  // bit 2
+    "",                                     // bit 3
+    "Cell overvoltage",                     // bit 4 (overridden)
+    "Battery pack overvoltage",             // bit 5
+};
+
+static void set_jk02_32s_error_mask(std::vector<uint8_t> &frame, uint32_t mask) {
+  // Errors bitmask lives at byte offset 166-169 (little-endian) for JK02_32S frames:
+  // decode_jk02_cell_info_ doubles its 16-byte JK02_32S offset (134 + 16*2 = 166)
+  // once it reaches the extra cells/temperature fields past the shared 24S layout.
+  frame[166] = uint8_t(mask >> 0);
+  frame[167] = uint8_t(mask >> 8);
+  frame[168] = uint8_t(mask >> 16);
+  frame[169] = uint8_t(mask >> 24);
+}
+
+static void set_jk02_24s_error_mask(std::vector<uint8_t> &frame, uint16_t mask) {
+  // Errors bitmask lives at byte offset 136-137 (little-endian) for JK02_24S frames.
+  frame[136] = uint8_t(mask >> 0);
+  frame[137] = uint8_t(mask >> 8);
+}
+
+TEST(JkBmsBleErrorsTest, NoTableConfiguredMaskZeroIsSafe) {
+  TestableJkBmsBle bms;
+  bms.set_protocol_version(PROTOCOL_VERSION_JK02_32S);
+  text_sensor::TextSensor hex, text;
+  bms.set_errors_bitmask_hex_text_sensor(&hex);
+  bms.set_errors_text_sensor(&text);
+
+  // errors_jk02_table_ is left at its default (entries=nullptr, count=0), just
+  // like a freshly constructed hub before to_code() runs the generated
+  // set_errors_jk02_table() call. A zero mask must never dereference the table.
+  auto frame = CELL_INFO_JK02_32S_V11;
+  set_jk02_32s_error_mask(frame, 0x00000000);
+
+  bms.decode_jk02_cell_info_(frame);
+
+  EXPECT_EQ(hex.state, "0x00000000");
+  EXPECT_EQ(text.state, "");
+}
+
+TEST(JkBmsBleErrorsTest, SingleKnownBit) {
+  TestableJkBmsBle bms;
+  bms.set_protocol_version(PROTOCOL_VERSION_JK02_32S);
+  bms.set_errors_jk02_table(kTestErrorsJk02, kTestErrorsJk02Count);
+  text_sensor::TextSensor hex, text;
+  bms.set_errors_bitmask_hex_text_sensor(&hex);
+  bms.set_errors_text_sensor(&text);
+
+  auto frame = CELL_INFO_JK02_32S_V11;
+  set_jk02_32s_error_mask(frame, 0x00000001);  // bit 0
+
+  bms.decode_jk02_cell_info_(frame);
+
+  EXPECT_EQ(hex.state, "0x00000001");
+  EXPECT_EQ(text.state, "Wire resistance");
+}
+
+TEST(JkBmsBleErrorsTest, MultipleBitsJoinedInAscendingOrder) {
+  TestableJkBmsBle bms;
+  bms.set_protocol_version(PROTOCOL_VERSION_JK02_32S);
+  bms.set_errors_jk02_table(kTestErrorsJk02, kTestErrorsJk02Count);
+  text_sensor::TextSensor text;
+  bms.set_errors_text_sensor(&text);
+
+  auto frame = CELL_INFO_JK02_32S_V11;
+  set_jk02_32s_error_mask(frame, 0x00000011);  // bit 0 + bit 4
+
+  bms.decode_jk02_cell_info_(frame);
+
+  EXPECT_EQ(text.state, "Wire resistance;Battery is fully charged");
+}
+
+TEST(JkBmsBleErrorsTest, EmptyPlaceholderBitIsSkippedButStillInHex) {
+  TestableJkBmsBle bms;
+  bms.set_protocol_version(PROTOCOL_VERSION_JK02_32S);
+  bms.set_errors_jk02_table(kTestErrorsJk02, kTestErrorsJk02Count);
+  text_sensor::TextSensor hex, text;
+  bms.set_errors_bitmask_hex_text_sensor(&hex);
+  bms.set_errors_text_sensor(&text);
+
+  auto frame = CELL_INFO_JK02_32S_V11;
+  set_jk02_32s_error_mask(frame, 0x00000009);  // bit 0 + bit 3 (placeholder, "")
+
+  bms.decode_jk02_cell_info_(frame);
+
+  EXPECT_EQ(hex.state, "0x00000009");
+  EXPECT_EQ(text.state, "Wire resistance");
+}
+
+// Validates the generic table-override mechanism that error_overrides relies
+// on: swapping in a different table changes the decoded label for a bit
+// without any change to jk_bms_ble.cpp.
+TEST(JkBmsBleErrorsTest, OverriddenLabelIsUsedInsteadOfDefault) {
+  TestableJkBmsBle bms;
+  bms.set_protocol_version(PROTOCOL_VERSION_JK02_32S);
+  bms.set_errors_jk02_table(kOverriddenErrorsJk02, kTestErrorsJk02Count);
+  text_sensor::TextSensor text;
+  bms.set_errors_text_sensor(&text);
+
+  auto frame = CELL_INFO_JK02_32S_V11;
+  set_jk02_32s_error_mask(frame, 0x00000010);  // bit 4
+
+  bms.decode_jk02_cell_info_(frame);
+
+  EXPECT_EQ(text.state, "Cell overvoltage");
+}
+
+TEST(JkBmsBleErrorsTest, Jk02_24SUsesSameTableWith16BitMask) {
+  TestableJkBmsBle bms;  // default protocol version is JK02_24S
+  bms.set_errors_jk02_table(kTestErrorsJk02, kTestErrorsJk02Count);
+  text_sensor::TextSensor hex, text;
+  bms.set_errors_bitmask_hex_text_sensor(&hex);
+  bms.set_errors_text_sensor(&text);
+
+  auto frame = CELL_INFO_JK02_24S_V10;
+  set_jk02_24s_error_mask(frame, 0x0021);  // bit 0 + bit 5
+
+  bms.decode_jk02_cell_info_(frame);
+
+  EXPECT_EQ(hex.state, "0x00000021");
+  EXPECT_EQ(text.state, "Wire resistance;Battery pack overvoltage");
+}
+
+}  // namespace esphome::jk_bms_ble::testing

--- a/tests/components/jk_bms_ble/jk_bms_ble_errors_test.cpp
+++ b/tests/components/jk_bms_ble/jk_bms_ble_errors_test.cpp
@@ -128,7 +128,7 @@ TEST(JkBmsBleErrorsTest, OverriddenLabelIsUsedInsteadOfDefault) {
   EXPECT_EQ(text, "Cell overvoltage");
 }
 
-TEST(JkBmsBleErrorsTest, Jk02_24SUsesSameTableWith16BitMask) {
+TEST(JkBmsBleErrorsTest, Protocol24SUsesSameTableWith16BitMask) {
   TestableJkBmsBle bms;  // default protocol version is JK02_24S
   bms.set_errors_jk02_table(DEFAULT_ERRORS, std::size(DEFAULT_ERRORS));
   text_sensor::TextSensor hex, text;

--- a/tests/components/jk_bms_ble/test.host.yaml
+++ b/tests/components/jk_bms_ble/test.host.yaml
@@ -1,3 +1,9 @@
 jk_bms_ble:
   id: test_bms
   update_interval: 20s
+  # Override the label of one or more error bits (bit 0-31, JK02 only). JK
+  # reassigned some bits across firmware generations: bit 4 used to mean
+  # "Cell overvoltage" while newer firmware reports "Battery is fully charged"
+  # there. An empty label suppresses the bit entirely.
+  # error_overrides:
+  #   4: Cell overvoltage

--- a/tests/components/jk_bms_ble/test.host.yaml
+++ b/tests/components/jk_bms_ble/test.host.yaml
@@ -1,9 +1,8 @@
 jk_bms_ble:
   id: test_bms
   update_interval: 20s
-  # Override the label of one or more error bits (bit 0-31, JK02 only). JK
-  # reassigned some bits across firmware generations: bit 4 used to mean
-  # "Cell overvoltage" while newer firmware reports "Battery is fully charged"
-  # there. An empty label suppresses the bit entirely.
+  # Override the label of one or more error bits (bit 0-31, JK02 only).
+  # An empty label suppresses the bit entirely.
+  #
   # error_overrides:
-  #   4: Cell overvoltage
+  #   4: "Cell overvoltage"

--- a/tests/esp32-ble-b2a25s-example.yaml
+++ b/tests/esp32-ble-b2a25s-example.yaml
@@ -64,6 +64,12 @@ jk_bms_ble:
     protocol_version: ${protocol_version}
     throttle: 5s
     id: bms0
+    # Override the label of one or more error bits (bit 0-31, JK02 only). JK
+    # reassigned some bits across firmware generations: bit 4 used to mean
+    # "Cell overvoltage" while newer firmware reports "Battery is fully charged"
+    # there. An empty label suppresses the bit entirely.
+    # error_overrides:
+    #   4: Cell overvoltage
 
 binary_sensor:
   - platform: jk_bms_ble

--- a/tests/esp32-ble-b2a25s-example.yaml
+++ b/tests/esp32-ble-b2a25s-example.yaml
@@ -64,12 +64,11 @@ jk_bms_ble:
     protocol_version: ${protocol_version}
     throttle: 5s
     id: bms0
-    # Override the label of one or more error bits (bit 0-31, JK02 only). JK
-    # reassigned some bits across firmware generations: bit 4 used to mean
-    # "Cell overvoltage" while newer firmware reports "Battery is fully charged"
-    # there. An empty label suppresses the bit entirely.
+    # Override the label of one or more error bits (bit 0-31, JK02 only).
+    # An empty label suppresses the bit entirely.
+    #
     # error_overrides:
-    #   4: Cell overvoltage
+    #   4: "Cell overvoltage"
 
 binary_sensor:
   - platform: jk_bms_ble

--- a/tests/esp32c6-compatibility-test.yaml
+++ b/tests/esp32c6-compatibility-test.yaml
@@ -69,6 +69,12 @@ jk_bms_ble:
     protocol_version: JK02_32S
     throttle: 5s
     id: bms1
+    # Override the label of one or more error bits (bit 0-31, JK02 only). JK
+    # reassigned some bits across firmware generations: bit 4 used to mean
+    # "Cell overvoltage" while newer firmware reports "Battery is fully charged"
+    # there. An empty label suppresses the bit entirely.
+    # error_overrides:
+    #   4: Cell overvoltage
 
 # jk_bms_display
 jk_bms_display:

--- a/tests/esp32c6-compatibility-test.yaml
+++ b/tests/esp32c6-compatibility-test.yaml
@@ -69,12 +69,11 @@ jk_bms_ble:
     protocol_version: JK02_32S
     throttle: 5s
     id: bms1
-    # Override the label of one or more error bits (bit 0-31, JK02 only). JK
-    # reassigned some bits across firmware generations: bit 4 used to mean
-    # "Cell overvoltage" while newer firmware reports "Battery is fully charged"
-    # there. An empty label suppresses the bit entirely.
+    # Override the label of one or more error bits (bit 0-31, JK02 only).
+    # An empty label suppresses the bit entirely.
+    #
     # error_overrides:
-    #   4: Cell overvoltage
+    #   4: "Cell overvoltage"
 
 # jk_bms_display
 jk_bms_display:

--- a/tests/esp32c6-compatibility-test.yaml
+++ b/tests/esp32c6-compatibility-test.yaml
@@ -72,8 +72,8 @@ jk_bms_ble:
     # Override the label of one or more error bits (bit 0-31, JK02 only).
     # An empty label suppresses the bit entirely.
     #
-    # error_overrides:
-    #   4: "Cell overvoltage"
+    error_overrides:
+      4: "Cell overvoltage"
 
 # jk_bms_display
 jk_bms_display:

--- a/tests/test_component_schemas.py
+++ b/tests/test_component_schemas.py
@@ -5,6 +5,9 @@ import sys
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
+import pytest  # noqa: E402
+import voluptuous as vol  # noqa: E402
+
 import components.heltec_balancer_ble as hub_heltec  # noqa: E402
 from components.heltec_balancer_ble import (  # noqa: E402
     binary_sensor as heltec_binary_sensor,
@@ -121,6 +124,62 @@ class TestJkBmsBleSensorLists:
         assert "battery_type_id" in ble_sensor.SENSOR_DEFS
         assert ble_sensor.CONF_POWER_ON_COUNT in ble_sensor.SENSOR_DEFS
         assert len(ble_sensor.SENSOR_DEFS) == 33
+
+
+class TestJkBmsBleErrorOverrides:
+    def test_default_errors_cover_all_32_bits(self):
+        assert len(hub_ble.DEFAULT_ERRORS_JK02) == 32
+
+    def test_default_errors_labels(self):
+        assert hub_ble.DEFAULT_ERRORS_JK02[0] == "Wire resistance"
+        assert hub_ble.DEFAULT_ERRORS_JK02[4] == "Battery is fully charged"
+        assert hub_ble.DEFAULT_ERRORS_JK02[28] == "GPS remote lock"
+
+    def test_unused_bits_are_empty(self):
+        for bit in (3, 29, 30, 31):
+            assert hub_ble.DEFAULT_ERRORS_JK02[bit] == ""
+
+    def test_schema_accepts_bit_index_as_string(self):
+        # ESPHome's YAML loader turns every mapping key into a string.
+        assert hub_ble.ERROR_OVERRIDES_SCHEMA({"4": "Cell overvoltage"}) == {
+            4: "Cell overvoltage"
+        }
+
+    def test_schema_accepts_boundary_bits(self):
+        assert hub_ble.ERROR_OVERRIDES_SCHEMA({"0": "a", "31": "b"}) == {
+            0: "a",
+            31: "b",
+        }
+
+    def test_schema_accepts_empty_label(self):
+        assert hub_ble.ERROR_OVERRIDES_SCHEMA({"4": ""}) == {4: ""}
+
+    def test_schema_rejects_out_of_range_bit(self):
+        with pytest.raises(vol.Invalid):
+            hub_ble.ERROR_OVERRIDES_SCHEMA({"32": "Nope"})
+        with pytest.raises(vol.Invalid):
+            hub_ble.ERROR_OVERRIDES_SCHEMA({"-1": "Nope"})
+
+    def test_schema_rejects_non_string_label(self):
+        with pytest.raises(vol.Invalid):
+            hub_ble.ERROR_OVERRIDES_SCHEMA({"4": 42})
+
+    def test_apply_overrides_replaces_only_the_given_bits(self):
+        errors = hub_ble.apply_error_overrides({4: "Cell overvoltage", 29: "Reserved"})
+
+        assert errors[4] == "Cell overvoltage"
+        assert errors[29] == "Reserved"
+        assert errors[0] == hub_ble.DEFAULT_ERRORS_JK02[0]
+        assert errors[5] == hub_ble.DEFAULT_ERRORS_JK02[5]
+        assert len(errors) == 32
+
+    def test_apply_overrides_without_overrides_returns_defaults(self):
+        assert hub_ble.apply_error_overrides({}) == hub_ble.DEFAULT_ERRORS_JK02
+
+    def test_apply_overrides_does_not_mutate_defaults(self):
+        hub_ble.apply_error_overrides({0: "Patched"})
+
+        assert hub_ble.DEFAULT_ERRORS_JK02[0] == "Wire resistance"
 
 
 class TestJkBmsBleBinarySensorConstants:

--- a/tests/test_component_schemas.py
+++ b/tests/test_component_schemas.py
@@ -165,14 +165,21 @@ class TestJkBmsBleErrorOverrides:
     def test_schema_accepts_empty_label(self):
         assert self._validate({"4": ""}) == {4: ""}
 
+    def test_schema_accepts_hex_bit_index(self):
+        assert self._validate({"0x1F": "Reserved"}) == {31: "Reserved"}
+
     def test_schema_rejects_out_of_range_bit(self):
-        with pytest.raises(vol.Invalid):
+        with pytest.raises(vol.Invalid, match="Error bit 32 is out of range"):
             self._validate({"32": "Nope"})
-        with pytest.raises(vol.Invalid):
+        with pytest.raises(vol.Invalid, match="Error bit -1 is out of range"):
             self._validate({"-1": "Nope"})
 
+    def test_schema_rejects_non_numeric_bit(self):
+        with pytest.raises(vol.Invalid, match="'abc' is not a valid error bit"):
+            self._validate({"abc": "Nope"})
+
     def test_schema_rejects_non_string_label(self):
-        with pytest.raises(vol.Invalid):
+        with pytest.raises(vol.Invalid, match="Must be string"):
             self._validate({"4": 42})
 
     def test_error_overrides_is_optional(self):

--- a/tests/test_component_schemas.py
+++ b/tests/test_component_schemas.py
@@ -130,6 +130,11 @@ class TestJkBmsBleErrorOverrides:
     def test_default_errors_cover_all_32_bits(self):
         assert len(hub_ble.DEFAULT_ERRORS_JK02) == 32
 
+    def test_default_errors_are_immutable(self):
+        # to_code() patches a copy per hub; a mutable default would let one hub's
+        # error_overrides leak into the next one.
+        assert isinstance(hub_ble.DEFAULT_ERRORS_JK02, tuple)
+
     def test_default_errors_labels(self):
         assert hub_ble.DEFAULT_ERRORS_JK02[0] == "Wire resistance"
         assert hub_ble.DEFAULT_ERRORS_JK02[4] == "Battery is fully charged"
@@ -139,47 +144,43 @@ class TestJkBmsBleErrorOverrides:
         for bit in (3, 29, 30, 31):
             assert hub_ble.DEFAULT_ERRORS_JK02[bit] == ""
 
+    @staticmethod
+    def _validate(overrides):
+        config = hub_ble.CONFIG_SCHEMA(
+            {
+                "protocol_version": "JK02_32S",
+                "ble_client_id": "client0",
+                "error_overrides": overrides,
+            }
+        )
+        return config["error_overrides"]
+
     def test_schema_accepts_bit_index_as_string(self):
         # ESPHome's YAML loader turns every mapping key into a string.
-        assert hub_ble.ERROR_OVERRIDES_SCHEMA({"4": "Cell overvoltage"}) == {
-            4: "Cell overvoltage"
-        }
+        assert self._validate({"4": "Cell overvoltage"}) == {4: "Cell overvoltage"}
 
     def test_schema_accepts_boundary_bits(self):
-        assert hub_ble.ERROR_OVERRIDES_SCHEMA({"0": "a", "31": "b"}) == {
-            0: "a",
-            31: "b",
-        }
+        assert self._validate({"0": "a", "31": "b"}) == {0: "a", 31: "b"}
 
     def test_schema_accepts_empty_label(self):
-        assert hub_ble.ERROR_OVERRIDES_SCHEMA({"4": ""}) == {4: ""}
+        assert self._validate({"4": ""}) == {4: ""}
 
     def test_schema_rejects_out_of_range_bit(self):
         with pytest.raises(vol.Invalid):
-            hub_ble.ERROR_OVERRIDES_SCHEMA({"32": "Nope"})
+            self._validate({"32": "Nope"})
         with pytest.raises(vol.Invalid):
-            hub_ble.ERROR_OVERRIDES_SCHEMA({"-1": "Nope"})
+            self._validate({"-1": "Nope"})
 
     def test_schema_rejects_non_string_label(self):
         with pytest.raises(vol.Invalid):
-            hub_ble.ERROR_OVERRIDES_SCHEMA({"4": 42})
+            self._validate({"4": 42})
 
-    def test_apply_overrides_replaces_only_the_given_bits(self):
-        errors = hub_ble.apply_error_overrides({4: "Cell overvoltage", 29: "Reserved"})
+    def test_error_overrides_is_optional(self):
+        config = hub_ble.CONFIG_SCHEMA(
+            {"protocol_version": "JK02_32S", "ble_client_id": "client0"}
+        )
 
-        assert errors[4] == "Cell overvoltage"
-        assert errors[29] == "Reserved"
-        assert errors[0] == hub_ble.DEFAULT_ERRORS_JK02[0]
-        assert errors[5] == hub_ble.DEFAULT_ERRORS_JK02[5]
-        assert len(errors) == 32
-
-    def test_apply_overrides_without_overrides_returns_defaults(self):
-        assert hub_ble.apply_error_overrides({}) == hub_ble.DEFAULT_ERRORS_JK02
-
-    def test_apply_overrides_does_not_mutate_defaults(self):
-        hub_ble.apply_error_overrides({0: "Patched"})
-
-        assert hub_ble.DEFAULT_ERRORS_JK02[0] == "Wire resistance"
+        assert hub_ble.CONF_ERROR_OVERRIDES not in config
 
 
 class TestJkBmsBleBinarySensorConstants:

--- a/yaml-snippets/esp32-ble-energy-dashboard.yaml
+++ b/yaml-snippets/esp32-ble-energy-dashboard.yaml
@@ -62,6 +62,12 @@ jk_bms_ble:
     protocol_version: ${protocol_version}
     throttle: 5s
     id: bms0
+    # Override the label of one or more error bits (bit 0-31, JK02 only). JK
+    # reassigned some bits across firmware generations: bit 4 used to mean
+    # "Cell overvoltage" while newer firmware reports "Battery is fully charged"
+    # there. An empty label suppresses the bit entirely.
+    # error_overrides:
+    #   4: Cell overvoltage
 
 sensor:
   - platform: jk_bms_ble

--- a/yaml-snippets/esp32-ble-energy-dashboard.yaml
+++ b/yaml-snippets/esp32-ble-energy-dashboard.yaml
@@ -62,12 +62,11 @@ jk_bms_ble:
     protocol_version: ${protocol_version}
     throttle: 5s
     id: bms0
-    # Override the label of one or more error bits (bit 0-31, JK02 only). JK
-    # reassigned some bits across firmware generations: bit 4 used to mean
-    # "Cell overvoltage" while newer firmware reports "Battery is fully charged"
-    # there. An empty label suppresses the bit entirely.
+    # Override the label of one or more error bits (bit 0-31, JK02 only).
+    # An empty label suppresses the bit entirely.
+    #
     # error_overrides:
-    #   4: Cell overvoltage
+    #   4: "Cell overvoltage"
 
 sensor:
   - platform: jk_bms_ble


### PR DESCRIPTION
## Summary
- The JK BMS manufacturer has changed the meaning of some JK02 error bitmask bits across firmware generations (e.g. bit 4 used to report "Cell Overvoltage" on older firmware, but "Battery is fully charged" on newer firmware). This was previously hardcoded as a single `static constexpr` array in `jk_bms_ble.cpp` with no way to select the older meaning.
- Move the 32-entry default error label list to `components/jk_bms_ble/__init__.py` as the single source of truth, and add an optional `error_overrides` config map (bit index → custom label).
- `to_code()` always generates a per-instance `static constexpr const char *const` lookup array (merging any `error_overrides` into the defaults) and hands a pointer/count to the hub via a new `set_errors_jk02_table()` setter — `jk_bms_ble.cpp` no longer holds any error-label data of its own.

Example:
```yaml
jk_bms_ble:
  - ble_client_id: client0
    protocol_version: JK02_32S
    error_overrides:
      4: "Cell overvoltage"
```

## Test plan
- [x] `run-cpp-tests.sh jk_bms_ble` — 222/222 tests pass, including 6 new tests in `jk_bms_ble_errors_test.cpp` covering: no table configured + zero mask, a single known bit, multiple bits joined in ascending order, an empty placeholder bit being skipped from the text but still reflected in the hex mask, an overridden label being used instead of the default, and the JK02_24S 16-bit path using the same table.
- [x] `pytest tests/test_component_schemas.py` — 43/43 pass.
- [x] `esphome compile --only-generate` against a local test config with two `jk_bms_ble` instances (one with `error_overrides` including a value containing a `"`, one without) — verified the generated `main.cpp` contains a correctly per-instance-named array, the override applied at the right index, the default preserved for the unconfigured instance, and the quote safely escaped (no code-generation injection).