### PR TITLE
Make jk_bms error labels configurable via error_overrides

### DIFF
--- a/components/jk_bms/__init__.py
+++ b/components/jk_bms/__init__.py
@@ -29,6 +29,54 @@ def deprecated_renames(renames: dict[str, str]):
 
 
 CONF_JK_BMS_ID = "jk_bms_id"
+CONF_ERROR_OVERRIDES = "error_overrides"
+
+# fmt: off
+DEFAULT_ERRORS = (
+    "Low capacity",                 # bit 0, warning
+    "MOSFET overtemperature",       # bit 1, alarm
+    "Charge overvoltage",           # bit 2, alarm
+    "Discharge undervoltage",       # bit 3, alarm
+    "Battery overtemperature",      # bit 4, alarm
+    "Charge overcurrent",           # bit 5, alarm
+    "Discharge overcurrent",        # bit 6, alarm
+    "Cell pressure difference",     # bit 7, alarm
+    "Battery box overtemperature",  # bit 8, alarm
+    "Battery undertemperature",     # bit 9, alarm
+    "Cell overvoltage",             # bit 10, alarm
+    "Cell undervoltage",            # bit 11, alarm
+    "309_A protection",             # bit 12, alarm
+    "309_A protection",             # bit 13, alarm
+    "",                             # bit 14 (reserved)
+    "",                             # bit 15 (reserved)
+)
+# fmt: on
+MAX_ERROR_BIT = len(DEFAULT_ERRORS) - 1
+
+
+def error_overrides(value):
+    # A plain {cv.int_range(...): cv.string_strict} schema rejects an out of range
+    # bit with voluptuous' "extra keys not allowed", which tells the user nothing.
+    value = cv.Schema({cv.string: cv.string_strict})(value)
+
+    overrides = {}
+    for key, label in value.items():
+        try:
+            bit = cv.int_(key)
+        except cv.Invalid:
+            raise cv.Invalid(
+                f"'{key}' is not a valid error bit, expected a number between 0 and {MAX_ERROR_BIT}",
+                path=[key],
+            ) from None
+        if not 0 <= bit <= MAX_ERROR_BIT:
+            raise cv.Invalid(
+                f"Error bit {bit} is out of range, must be between 0 and {MAX_ERROR_BIT}",
+                path=[key],
+            )
+        overrides[bit] = label
+
+    return overrides
+
 
 jk_bms_ns = cg.esphome_ns.namespace("jk_bms")
 JkBms = jk_bms_ns.class_("JkBms", cg.PollingComponent, jk_modbus.JkModbusDevice)
@@ -44,6 +92,7 @@ CONFIG_SCHEMA = cv.All(
     cv.Schema(
         {
             cv.GenerateID(): cv.declare_id(JkBms),
+            cv.Optional(CONF_ERROR_OVERRIDES): error_overrides,
         }
     )
     .extend(cv.polling_component_schema("5s"))
@@ -55,3 +104,16 @@ async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
     await jk_modbus.register_jk_modbus_device(var, config)
+
+    errors = list(DEFAULT_ERRORS)
+    for bit, label in config.get(CONF_ERROR_OVERRIDES, {}).items():
+        errors[bit] = label
+
+    arr_name = f"{config[CONF_ID]}_ERRORS"
+    entries = ", ".join(str(cg.safe_exp(label)) for label in errors)
+    cg.add_global(
+        cg.RawStatement(
+            f"static constexpr const char *const {arr_name}[] = {{{entries}}};"
+        )
+    )
+    cg.add(var.set_errors_table(cg.RawExpression(arr_name), len(errors)))

--- a/components/jk_bms/jk_bms.cpp
+++ b/components/jk_bms/jk_bms.cpp
@@ -11,24 +11,6 @@ static const uint8_t MAX_NO_RESPONSE_COUNT = 5;
 static const uint8_t FUNCTION_READ_ALL = 0x06;
 static const uint8_t FUNCTION_WRITE_REGISTER = 0x02;
 
-static const uint8_t ERRORS_SIZE = 14;
-static constexpr const char *const ERRORS[ERRORS_SIZE] = {
-    "Low capacity",                 // Byte 0.0, warning
-    "MOSFET overtemperature",       // Byte 0.1, alarm
-    "Charge overvoltage",           // Byte 0.2, alarm
-    "Discharge undervoltage",       // Byte 0.3, alarm
-    "Battery overtemperature",      // Byte 0.4, alarm
-    "Charge overcurrent",           // Byte 0.5, alarm
-    "Discharge overcurrent",        // Byte 0.6, alarm
-    "Cell pressure difference",     // Byte 0.7, alarm
-    "Battery box overtemperature",  // Byte 1.0, alarm
-    "Battery undertemperature",     // Byte 1.1, alarm
-    "Cell overvoltage",             // Byte 1.2, alarm
-    "Cell undervoltage",            // Byte 1.3, alarm
-    "309_A protection",             // Byte 1.4, alarm
-    "309_A protection",             // Byte 1.5, alarm
-};
-
 static const uint8_t OPERATION_MODES_SIZE = 4;
 static constexpr const char *const OPERATION_MODES[OPERATION_MODES_SIZE] = {
     "Charging enabled",     // 0x00
@@ -205,7 +187,8 @@ void JkBms::on_status_data_(const std::vector<uint8_t> &data) {
   // 0x0003 = 00000000 00000011: Low capacity alarm AND MOSFET overtemperature alarm
   uint16_t raw_errors_bitmask = jk_get_16bit(offset + 6 + 3 * 8);
   this->publish_state_(this->errors_bitmask_sensor_, (float) raw_errors_bitmask);
-  this->publish_state_(this->errors_text_sensor_, this->error_bits_to_string_(raw_errors_bitmask));
+  this->publish_state_(this->errors_text_sensor_,
+                       this->error_bits_to_string_(raw_errors_bitmask, this->errors_table_, 16));
 
   // 0x8C 0x00 0x07: Battery status information                  0000 0000 0000 0111
   // Bit 0: Charging enabled        1 (on), 0 (off)
@@ -511,21 +494,22 @@ void JkBms::publish_state_(text_sensor::TextSensor *text_sensor, const std::stri
   text_sensor->publish_state(state);
 }
 
-std::string JkBms::error_bits_to_string_(const uint16_t mask) {
-  bool first = true;
+std::string JkBms::error_bits_to_string_(const uint16_t mask, const LookupTable &errors, const uint8_t bits) {
   std::string errors_list;
 
-  if (mask) {
-    for (int i = 0; i < ERRORS_SIZE; i++) {
-      if (mask & (1 << i)) {
-        if (first) {
-          first = false;
-        } else {
-          errors_list.append(";");
-        }
-        errors_list.append(ERRORS[i]);
-      }
-    }
+  for (uint8_t i = 0; i < bits; i++) {
+    if ((mask & (1UL << i)) == 0)
+      continue;
+
+    // Bits without a label (reserved or suppressed via `error_overrides`) and bits beyond
+    // the configured table are reported by the raw bitmask sensor only.
+    const char *label = errors.get(i);
+    if (label == nullptr || label[0] == '\0')
+      continue;
+
+    if (!errors_list.empty())
+      errors_list.append(";");
+    errors_list.append(label);
   }
 
   return errors_list;

--- a/components/jk_bms/jk_bms.h
+++ b/components/jk_bms/jk_bms.h
@@ -9,8 +9,16 @@
 
 namespace esphome::jk_bms {
 
+struct LookupTable {
+  const char *const *entries{nullptr};
+  size_t count{0};
+  const char *get(uint8_t index) const { return (entries != nullptr && index < count) ? entries[index] : nullptr; }
+};
+
 class JkBms : public PollingComponent, public jk_modbus::JkModbusDevice {
  public:
+  void set_errors_table(const char *const *entries, size_t count) { errors_table_ = {entries, count}; }
+
   void set_balancing_binary_sensor(binary_sensor::BinarySensor *balancing_binary_sensor) {
     balancing_binary_sensor_ = balancing_binary_sensor;
   }
@@ -319,6 +327,8 @@ class JkBms : public PollingComponent, public jk_modbus::JkModbusDevice {
     sensor::Sensor *cell_voltage_sensor_{nullptr};
   } cells_[24];
 
+  LookupTable errors_table_;
+
   uint8_t no_response_count_{0};
 
   void on_status_data_(const std::vector<uint8_t> &data);
@@ -330,7 +340,7 @@ class JkBms : public PollingComponent, public jk_modbus::JkModbusDevice {
   void reset_online_status_tracker_();
   void track_online_status_();
 
-  std::string error_bits_to_string_(uint16_t bitmask);
+  std::string error_bits_to_string_(uint16_t bitmask, const LookupTable &errors, uint8_t bits);
   std::string mode_bits_to_string_(uint16_t bitmask);
 
   float get_temperature_(const uint16_t value) {

--- a/esp32-ble-uart-hybrid-example.yaml
+++ b/esp32-ble-uart-hybrid-example.yaml
@@ -93,6 +93,11 @@ jk_bms:
   - id: bms0
     jk_modbus_id: modbus0
     update_interval: 5s
+    # Override the label of one or more error bits (bit 0-15).
+    # An empty label suppresses the bit entirely.
+    #
+    # error_overrides:
+    #   0: "Low SoC"
 
 binary_sensor:
   - platform: jk_bms

--- a/esp32-example-multiple-devices.yaml
+++ b/esp32-example-multiple-devices.yaml
@@ -74,6 +74,11 @@ jk_bms:
   - id: bms0
     jk_modbus_id: modbus0
     update_interval: 5s
+    # Override the label of one or more error bits (bit 0-15).
+    # An empty label suppresses the bit entirely.
+    #
+    # error_overrides:
+    #   0: "Low SoC"
   - id: bms1
     jk_modbus_id: modbus1
     update_interval: 5s

--- a/esp32-example.yaml
+++ b/esp32-example.yaml
@@ -59,6 +59,11 @@ jk_bms:
   - id: bms0
     jk_modbus_id: modbus0
     update_interval: 5s
+    # Override the label of one or more error bits (bit 0-15).
+    # An empty label suppresses the bit entirely.
+    #
+    # error_overrides:
+    #   0: "Low SoC"
 
 binary_sensor:
   - platform: jk_bms

--- a/esp8266-example.yaml
+++ b/esp8266-example.yaml
@@ -58,6 +58,11 @@ jk_bms:
   - id: bms0
     jk_modbus_id: modbus0
     update_interval: 5s
+    # Override the label of one or more error bits (bit 0-15).
+    # An empty label suppresses the bit entirely.
+    #
+    # error_overrides:
+    #   0: "Low SoC"
 
 binary_sensor:
   - platform: jk_bms

--- a/tests/components/jk_bms/jk_bms_errors_test.cpp
+++ b/tests/components/jk_bms/jk_bms_errors_test.cpp
@@ -1,0 +1,123 @@
+#include <gtest/gtest.h>
+#include <iterator>
+#include <string>
+#include <utility>
+#include "common.h"
+
+namespace esphome::jk_bms::testing {
+
+static constexpr uint8_t FUNCTION_READ_ALL = 0x06;
+
+// A lookup table mirroring what the Python codegen in jk_bms/__init__.py
+// (DEFAULT_ERRORS, optionally patched by `error_overrides`) emits as a static
+// constexpr array and hands to the hub via set_errors_table(). Only the first
+// few bits are covered here - the table is deliberately shorter than the 16 bits
+// the decoder scans so the bounds check is exercised too.
+static constexpr const char *const DEFAULT_ERRORS[] = {
+    "Low capacity",             // bit 0
+    "MOSFET overtemperature",   // bit 1
+    "Charge overvoltage",       // bit 2
+    "Discharge undervoltage",   // bit 3
+    "Battery overtemperature",  // bit 4
+    "",                         // bit 5 (reserved placeholder for this fixture)
+};
+
+// Same table, but with bit 0 overridden - as if the user had configured
+// `error_overrides: {0: "Low SoC"}`.
+static constexpr const char *const OVERRIDDEN_ERRORS[] = {
+    "Low SoC",                  // bit 0 (overridden)
+    "MOSFET overtemperature",   // bit 1
+    "Charge overvoltage",       // bit 2
+    "Discharge undervoltage",   // bit 3
+    "Battery overtemperature",  // bit 4
+    "",                         // bit 5
+};
+
+static void set_error_mask(std::vector<uint8_t> &frame, uint16_t mask) {
+  // on_status_data_ reads the errors bitmask via jk_get_16bit(offset + 6 + 3 * 8)
+  // with offset = frame[1] + 3 = 0x2A + 3 = 45, so index 75. jk_get_16bit is
+  // big-endian: high byte first.
+  frame[75] = uint8_t(mask >> 8);
+  frame[76] = uint8_t(mask >> 0);
+}
+
+// Feeds a status frame carrying `mask` into the decoder and returns the published
+// (errors bitmask, errors) pair. Passing a nullptr table leaves errors_table_ at
+// its default, i.e. a hub whose set_errors_table() call the codegen never emitted.
+static std::pair<float, std::string> decode_errors(uint16_t mask, const char *const *table, size_t count) {
+  TestableJkBms bms;
+  if (table != nullptr)
+    bms.set_errors_table(table, count);
+
+  sensor::Sensor bitmask;
+  text_sensor::TextSensor text;
+  bms.set_errors_bitmask_sensor(&bitmask);
+  bms.set_errors_text_sensor(&text);
+
+  auto frame = STATUS_FRAME_14S;
+  set_error_mask(frame, mask);
+  bms.on_jk_modbus_data(FUNCTION_READ_ALL, frame);
+
+  return {bitmask.state, text.state};
+}
+
+static std::pair<float, std::string> decode_errors(uint16_t mask) {
+  return decode_errors(mask, DEFAULT_ERRORS, std::size(DEFAULT_ERRORS));
+}
+
+TEST(JkBmsErrorsTest, SingleKnownBit) {
+  auto [bitmask, text] = decode_errors(0x0001);  // bit 0
+
+  EXPECT_FLOAT_EQ(bitmask, 1.0f);
+  EXPECT_EQ(text, "Low capacity");
+}
+
+TEST(JkBmsErrorsTest, MaskZeroPublishesEmptyString) {
+  auto [bitmask, text] = decode_errors(0x0000);
+
+  EXPECT_FLOAT_EQ(bitmask, 0.0f);
+  EXPECT_EQ(text, "");
+}
+
+TEST(JkBmsErrorsTest, MultipleBitsJoinedInAscendingOrder) {
+  auto [bitmask, text] = decode_errors(0x0003);  // bit 0 + bit 1
+
+  EXPECT_FLOAT_EQ(bitmask, 3.0f);
+  EXPECT_EQ(text, "Low capacity;MOSFET overtemperature");
+}
+
+TEST(JkBmsErrorsTest, EmptyPlaceholderBitIsSkippedButStillInBitmask) {
+  auto [bitmask, text] = decode_errors(0x0021);  // bit 0 + bit 5 (placeholder, "")
+
+  EXPECT_FLOAT_EQ(bitmask, 33.0f);
+  EXPECT_EQ(text, "Low capacity");
+}
+
+// The decoder scans 16 bits regardless of how many entries the configured table
+// holds. Bits past the end must be dropped instead of read out of bounds.
+TEST(JkBmsErrorsTest, BitBeyondTableEndIsIgnored) {
+  auto [bitmask, text] = decode_errors(0x8041);  // bit 0 + bit 6 + bit 15, table holds 6 entries
+
+  EXPECT_FLOAT_EQ(bitmask, 32833.0f);
+  EXPECT_EQ(text, "Low capacity");
+}
+
+// A hub without a table (entries == nullptr, count == 0) must not dereference it,
+// no matter which bits are set - the raw bitmask is still published.
+TEST(JkBmsErrorsTest, NoTableConfiguredPublishesBitmaskOnly) {
+  auto [bitmask, text] = decode_errors(0xFFFF, nullptr, 0);
+
+  EXPECT_FLOAT_EQ(bitmask, 65535.0f);
+  EXPECT_EQ(text, "");
+}
+
+// Validates the mechanism error_overrides relies on: swapping in a different table
+// changes the decoded label for a bit without any change to jk_bms.cpp.
+TEST(JkBmsErrorsTest, OverriddenLabelIsUsedInsteadOfDefault) {
+  auto [bitmask, text] = decode_errors(0x0001, OVERRIDDEN_ERRORS, std::size(OVERRIDDEN_ERRORS));  // bit 0
+
+  EXPECT_FLOAT_EQ(bitmask, 1.0f);
+  EXPECT_EQ(text, "Low SoC");
+}
+
+}  // namespace esphome::jk_bms::testing

--- a/tests/components/jk_bms/test.host.yaml
+++ b/tests/components/jk_bms/test.host.yaml
@@ -10,3 +10,8 @@ jk_bms:
   id: test_bms
   jk_modbus_id: modbus_bus
   update_interval: 5s
+  # Override the label of one or more error bits (bit 0-15).
+  # An empty label suppresses the bit entirely.
+  #
+  # error_overrides:
+  #   0: "Low SoC"

--- a/tests/esp32c6-compatibility-test.yaml
+++ b/tests/esp32c6-compatibility-test.yaml
@@ -62,6 +62,11 @@ jk_bms:
   - id: bms0
     jk_modbus_id: modbus0
     update_interval: 5s
+    # Override the label of one or more error bits (bit 0-15).
+    # An empty label suppresses the bit entirely.
+    #
+    error_overrides:
+      0: "Low SoC"
 
 # jk_bms_ble
 jk_bms_ble:

--- a/tests/test_component_schemas.py
+++ b/tests/test_component_schemas.py
@@ -102,6 +102,57 @@ class TestJkBmsSwitchConstants:
         assert len(switch.SWITCHES) == 3
 
 
+class TestJkBmsErrorOverrides:
+    def test_default_errors_cover_all_16_bits(self):
+        assert len(hub.DEFAULT_ERRORS) == 16
+
+    def test_default_errors_are_immutable(self):
+        # to_code() patches a copy per hub; a mutable default would let one hub's
+        # error_overrides leak into the next one.
+        assert isinstance(hub.DEFAULT_ERRORS, tuple)
+
+    def test_default_errors_labels(self):
+        assert hub.DEFAULT_ERRORS[0] == "Low capacity"
+        assert hub.DEFAULT_ERRORS[10] == "Cell overvoltage"
+        assert hub.DEFAULT_ERRORS[13] == "309_A protection"
+
+    def test_reserved_bits_are_empty(self):
+        for bit in (14, 15):
+            assert hub.DEFAULT_ERRORS[bit] == ""
+
+    @staticmethod
+    def _validate(overrides):
+        config = hub.CONFIG_SCHEMA({"error_overrides": overrides})
+        return config["error_overrides"]
+
+    def test_schema_accepts_bit_index_as_string(self):
+        # ESPHome's YAML loader turns every mapping key into a string.
+        assert self._validate({"0": "Low SoC"}) == {0: "Low SoC"}
+
+    def test_schema_accepts_boundary_bits(self):
+        assert self._validate({"0": "a", "15": "b"}) == {0: "a", 15: "b"}
+
+    def test_schema_accepts_empty_label(self):
+        assert self._validate({"0": ""}) == {0: ""}
+
+    def test_schema_rejects_out_of_range_bit(self):
+        with pytest.raises(vol.Invalid, match="Error bit 16 is out of range"):
+            self._validate({"16": "Nope"})
+        with pytest.raises(vol.Invalid, match="Error bit -1 is out of range"):
+            self._validate({"-1": "Nope"})
+
+    def test_schema_rejects_non_numeric_bit(self):
+        with pytest.raises(vol.Invalid, match="'abc' is not a valid error bit"):
+            self._validate({"abc": "Nope"})
+
+    def test_schema_rejects_non_string_label(self):
+        with pytest.raises(vol.Invalid, match="Must be string"):
+            self._validate({"0": 42})
+
+    def test_error_overrides_is_optional(self):
+        assert hub.CONF_ERROR_OVERRIDES not in hub.CONFIG_SCHEMA({})
+
+
 class TestJkBmsBleSensorLists:
     def test_cells_count(self):
         assert len(ble_sensor.CELL_VOLTAGES) == 32


### PR DESCRIPTION
Ports the `error_overrides` option from `jk_bms_ble` to the UART component, so the JK error labels can be relabelled from YAML without patching the component.

```yaml
jk_bms:
  - id: bms0
    jk_modbus_id: modbus0
    error_overrides:
      0: "Low SoC"
```

### What changed

The labels move out of the static `ERRORS` array in `jk_bms.cpp` into `DEFAULT_ERRORS` in Python. `to_code()` copies that tuple, applies the overrides and emits a `static constexpr` array per hub, which is handed to the component via `set_errors_table()`. The labels stay in flash (`.rodata`), same as before.

`error_bits_to_string_()` now looks labels up through `LookupTable::get()`, which bounds checks the index and tolerates an unset table, and scans the full 16 bits of the mask instead of the 14 the old array happened to hold.

Bits 14 and 15 are documented as reserved in `docs/protocol-design-uart-ttl-gps-port.md` and were never evaluated before. They are now empty placeholders, so a firmware that does use them can be labelled. An empty label keeps a bit out of the errors text sensor; it is still reported by the raw bitmask sensor.

An out of range bit is rejected with a message that names the bit and the accepted range, instead of voluptuous' `extra keys not allowed`.

### Compatibility

No behaviour change for existing configurations: the defaults are the previous labels, and bits 14/15 were not decoded before either.

### Tests

* 7 new C++ tests in `tests/components/jk_bms/jk_bms_errors_test.cpp`, covering a single bit, joined bits, empty labels, a bit past the end of the table, an unconfigured table and a label override.
* 11 new pytest cases covering the bit range, the label validation, the empty label suppression and the immutability of the defaults.
* `error_overrides` is enabled in `tests/esp32c6-compatibility-test.yaml` so CI actually compiles the generated table.

`BitBeyondTableEndIsIgnored` was verified against a build with the bounds check removed, where it fails with an ASAN `global-buffer-overflow`.
