### PR TITLE
Make jk_balancer error labels configurable via error_overrides

### DIFF
--- a/components/jk_balancer/__init__.py
+++ b/components/jk_balancer/__init__.py
@@ -15,6 +15,46 @@ CODEOWNERS = ["@syssi"]
 MULTI_CONF = True
 
 CONF_JK_BALANCER_ID = "jk_balancer_id"
+CONF_ERROR_OVERRIDES = "error_overrides"
+
+# fmt: off
+DEFAULT_ERRORS = (
+    "Wrong cell count",     # bit 0
+    "Resistance too high",  # bit 1
+    "Overvoltage",          # bit 2
+    "",                     # bit 3 (reserved)
+    "",                     # bit 4 (reserved)
+    "",                     # bit 5 (reserved)
+    "",                     # bit 6 (reserved)
+    "",                     # bit 7 (reserved)
+)
+# fmt: on
+MAX_ERROR_BIT = len(DEFAULT_ERRORS) - 1
+
+
+def error_overrides(value):
+    # A plain {cv.int_range(...): cv.string_strict} schema rejects an out of range
+    # bit with voluptuous' "extra keys not allowed", which tells the user nothing.
+    value = cv.Schema({cv.string: cv.string_strict})(value)
+
+    overrides = {}
+    for key, label in value.items():
+        try:
+            bit = cv.int_(key)
+        except cv.Invalid:
+            raise cv.Invalid(
+                f"'{key}' is not a valid error bit, expected a number between 0 and {MAX_ERROR_BIT}",
+                path=[key],
+            ) from None
+        if not 0 <= bit <= MAX_ERROR_BIT:
+            raise cv.Invalid(
+                f"Error bit {bit} is out of range, must be between 0 and {MAX_ERROR_BIT}",
+                path=[key],
+            )
+        overrides[bit] = label
+
+    return overrides
+
 
 jk_balancer_ns = cg.esphome_ns.namespace("jk_balancer")
 JkBalancer = jk_balancer_ns.class_(
@@ -32,6 +72,7 @@ CONFIG_SCHEMA = cv.All(
     cv.Schema(
         {
             cv.GenerateID(): cv.declare_id(JkBalancer),
+            cv.Optional(CONF_ERROR_OVERRIDES): error_overrides,
         }
     )
     .extend(cv.polling_component_schema("5s"))
@@ -43,3 +84,16 @@ async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
     await jk_balancer_modbus.register_jk_balancer_modbus_device(var, config)
+
+    errors = list(DEFAULT_ERRORS)
+    for bit, label in config.get(CONF_ERROR_OVERRIDES, {}).items():
+        errors[bit] = label
+
+    arr_name = f"{config[CONF_ID]}_ERRORS"
+    entries = ", ".join(str(cg.safe_exp(label)) for label in errors)
+    cg.add_global(
+        cg.RawStatement(
+            f"static constexpr const char *const {arr_name}[] = {{{entries}}};"
+        )
+    )
+    cg.add(var.set_errors_table(cg.RawExpression(arr_name), len(errors)))

--- a/components/jk_balancer/jk_balancer.cpp
+++ b/components/jk_balancer/jk_balancer.cpp
@@ -13,13 +13,6 @@ static const uint8_t FUNCTION_SET_CELL_COUNT = 0xF0;
 static const uint8_t FUNCTION_SET_TRIGGER_VOLTAGE = 0xF2;
 static const uint8_t FUNCTION_SET_MAX_BALANCE_CURRENT = 0xF4;
 
-static const uint8_t ERRORS_SIZE = 3;
-static constexpr const char *const ERRORS[ERRORS_SIZE] = {
-    "Wrong cell count",
-    "Resistance too high",
-    "Overvoltage",
-};
-
 void JkBalancer::on_jk_balancer_modbus_data(const uint8_t &function, const std::vector<uint8_t> &data) {
   this->reset_online_status_tracker_();
 
@@ -84,7 +77,8 @@ void JkBalancer::on_status_data_(const std::vector<uint8_t> &data) {
   // 12    1   0x01                   Alarm Status
   uint8_t raw_errors_bitmask = data[12];
   this->publish_state_(this->errors_bitmask_sensor_, (float) raw_errors_bitmask);
-  this->publish_state_(this->errors_text_sensor_, this->error_bits_to_string_(raw_errors_bitmask));
+  this->publish_state_(this->errors_text_sensor_,
+                       this->error_bits_to_string_(raw_errors_bitmask, this->errors_table_, 8));
 
   // 13    2   0x00 0x03              Maximum Voltage Difference      0.001f        V         3 * 0.001 = 0.003V
   // this->publish_state_(this->delta_cell_voltage_sensor_, jk_get_16bit(13) * 0.001f);
@@ -235,21 +229,22 @@ void JkBalancer::publish_state_(text_sensor::TextSensor *text_sensor, const std:
   text_sensor->publish_state(state);
 }
 
-std::string JkBalancer::error_bits_to_string_(const uint8_t mask) {
-  bool first = true;
+std::string JkBalancer::error_bits_to_string_(const uint8_t mask, const LookupTable &errors, const uint8_t bits) {
   std::string errors_list;
 
-  if (mask) {
-    for (int i = 0; i < ERRORS_SIZE; i++) {
-      if (mask & (1 << i)) {
-        if (first) {
-          first = false;
-        } else {
-          errors_list.append(";");
-        }
-        errors_list.append(ERRORS[i]);
-      }
-    }
+  for (uint8_t i = 0; i < bits; i++) {
+    if ((mask & (1UL << i)) == 0)
+      continue;
+
+    // Bits without a label (reserved or suppressed via `error_overrides`) and bits beyond
+    // the configured table are reported by the raw bitmask sensor only.
+    const char *label = errors.get(i);
+    if (label == nullptr || label[0] == '\0')
+      continue;
+
+    if (!errors_list.empty())
+      errors_list.append(";");
+    errors_list.append(label);
   }
 
   return errors_list;

--- a/components/jk_balancer/jk_balancer.h
+++ b/components/jk_balancer/jk_balancer.h
@@ -10,8 +10,16 @@
 
 namespace esphome::jk_balancer {
 
+struct LookupTable {
+  const char *const *entries{nullptr};
+  size_t count{0};
+  const char *get(uint8_t index) const { return (entries != nullptr && index < count) ? entries[index] : nullptr; }
+};
+
 class JkBalancer : public PollingComponent, public jk_balancer_modbus::JkBalancerModbusDevice {
  public:
+  void set_errors_table(const char *const *entries, size_t count) { errors_table_ = {entries, count}; }
+
   void set_balancing_binary_sensor(binary_sensor::BinarySensor *balancing_binary_sensor) {
     balancing_binary_sensor_ = balancing_binary_sensor;
   }
@@ -104,6 +112,8 @@ class JkBalancer : public PollingComponent, public jk_balancer_modbus::JkBalance
     sensor::Sensor *cell_voltage_sensor_{nullptr};
   } cells_[24];
 
+  LookupTable errors_table_;
+
   uint8_t no_response_count_{0};
 
   void on_status_data_(const std::vector<uint8_t> &data);
@@ -116,7 +126,7 @@ class JkBalancer : public PollingComponent, public jk_balancer_modbus::JkBalance
   void reset_online_status_tracker_();
   void track_online_status_();
 
-  std::string error_bits_to_string_(uint8_t bitmask);
+  std::string error_bits_to_string_(uint8_t bitmask, const LookupTable &errors, uint8_t bits);
 
   bool check_bit_(uint16_t mask, uint16_t flag) { return (mask & flag) == flag; }
 };

--- a/esp32-active-balancer-example.yaml
+++ b/esp32-active-balancer-example.yaml
@@ -60,6 +60,11 @@ jk_balancer:
     jk_balancer_modbus_id: modbus0
     address: 0x01
     update_interval: 5s
+    # Override the label of one or more error bits (bit 0-7).
+    # An empty label suppresses the bit entirely.
+    #
+    # error_overrides:
+    #   0: "Cell count mismatch"
 
 binary_sensor:
   - platform: jk_balancer

--- a/esp8266-active-balancer-example.yaml
+++ b/esp8266-active-balancer-example.yaml
@@ -59,6 +59,11 @@ jk_balancer:
     jk_balancer_modbus_id: modbus0
     address: 0x01
     update_interval: 5s
+    # Override the label of one or more error bits (bit 0-7).
+    # An empty label suppresses the bit entirely.
+    #
+    # error_overrides:
+    #   0: "Cell count mismatch"
 
 binary_sensor:
   - platform: jk_balancer

--- a/tests/components/jk_balancer/common.h
+++ b/tests/components/jk_balancer/common.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <cstdint>
+#include <iterator>
 #include <vector>
 #include "esphome/components/jk_balancer/jk_balancer.h"
 
@@ -8,6 +9,19 @@ namespace esphome::jk_balancer::testing {
 class TestableJkBalancer : public JkBalancer {
  public:
   void update() override {}  // avoids calling send() with null parent_
+};
+
+// Mirrors DEFAULT_ERRORS in jk_balancer/__init__.py, which to_code() emits as a
+// static constexpr array and hands to the hub via set_errors_table().
+static constexpr const char *const DEFAULT_ERRORS[] = {
+    "Wrong cell count",     // bit 0
+    "Resistance too high",  // bit 1
+    "Overvoltage",          // bit 2
+    "",                     // bit 3 (reserved)
+    "",                     // bit 4 (reserved)
+    "",                     // bit 5 (reserved)
+    "",                     // bit 6 (reserved)
+    "",                     // bit 7 (reserved)
 };
 
 // Traffic from tests/esp8266-fake-active-balancer.yaml

--- a/tests/components/jk_balancer/jk_balancer_errors_test.cpp
+++ b/tests/components/jk_balancer/jk_balancer_errors_test.cpp
@@ -1,0 +1,111 @@
+#include <gtest/gtest.h>
+#include <iterator>
+#include <string>
+#include <utility>
+#include "common.h"
+
+namespace esphome::jk_balancer::testing {
+
+static constexpr uint8_t FUNCTION_READ_ALL = 0xFF;
+
+// Deliberately shorter than the 8 bits the decoder scans, so the bounds check
+// of LookupTable::get() is exercised.
+static constexpr const char *const SHORT_ERRORS[] = {
+    "Wrong cell count",     // bit 0
+    "Resistance too high",  // bit 1
+    "Overvoltage",          // bit 2
+};
+
+// The default table with bit 0 overridden - as if the user had configured
+// `error_overrides: {0: "Cell count mismatch"}`.
+static constexpr const char *const OVERRIDDEN_ERRORS[] = {
+    "Cell count mismatch",  // bit 0 (overridden)
+    "Resistance too high",  // bit 1
+    "Overvoltage",          // bit 2
+    "",                     // bit 3
+    "",                     // bit 4
+    "",                     // bit 5
+    "",                     // bit 6
+    "",                     // bit 7
+};
+
+// Feeds a status frame carrying `mask` into the decoder and returns the published
+// (errors bitmask, errors) pair. Passing a nullptr table leaves errors_table_ at
+// its default, i.e. a hub whose set_errors_table() call the codegen never emitted.
+static std::pair<float, std::string> decode_errors(uint8_t mask, const char *const *table, size_t count) {
+  TestableJkBalancer bms;
+  if (table != nullptr)
+    bms.set_errors_table(table, count);
+
+  sensor::Sensor bitmask;
+  text_sensor::TextSensor text;
+  bms.set_errors_bitmask_sensor(&bitmask);
+  bms.set_errors_text_sensor(&text);
+
+  auto frame = STATUS_FRAME_17S;
+  frame[12] = mask;  // byte 12 holds the alarm status bitmask
+  bms.on_jk_balancer_modbus_data(FUNCTION_READ_ALL, frame);
+
+  return {bitmask.state, text.state};
+}
+
+static std::pair<float, std::string> decode_errors(uint8_t mask) {
+  return decode_errors(mask, DEFAULT_ERRORS, std::size(DEFAULT_ERRORS));
+}
+
+TEST(JkBalancerErrorsTest, SingleKnownBit) {
+  auto [bitmask, text] = decode_errors(0x01);  // bit 0
+
+  EXPECT_FLOAT_EQ(bitmask, 1.0f);
+  EXPECT_EQ(text, "Wrong cell count");
+}
+
+TEST(JkBalancerErrorsTest, MaskZeroPublishesEmptyString) {
+  auto [bitmask, text] = decode_errors(0x00);
+
+  EXPECT_FLOAT_EQ(bitmask, 0.0f);
+  EXPECT_EQ(text, "");
+}
+
+TEST(JkBalancerErrorsTest, MultipleBitsJoinedInAscendingOrder) {
+  auto [bitmask, text] = decode_errors(0x05);  // bit 0 + bit 2
+
+  EXPECT_FLOAT_EQ(bitmask, 5.0f);
+  EXPECT_EQ(text, "Wrong cell count;Overvoltage");
+}
+
+TEST(JkBalancerErrorsTest, ReservedBitIsSkippedButStillInBitmask) {
+  auto [bitmask, text] = decode_errors(0x09);  // bit 0 + bit 3 (reserved, "")
+
+  EXPECT_FLOAT_EQ(bitmask, 9.0f);
+  EXPECT_EQ(text, "Wrong cell count");
+}
+
+// The decoder scans 8 bits regardless of how many entries the configured table
+// holds. Bits past the end must be dropped instead of read out of bounds.
+TEST(JkBalancerErrorsTest, BitBeyondTableEndIsIgnored) {
+  auto [bitmask, text] = decode_errors(0x89, SHORT_ERRORS, std::size(SHORT_ERRORS));  // bit 0 + 3 + 7
+
+  EXPECT_FLOAT_EQ(bitmask, 137.0f);
+  EXPECT_EQ(text, "Wrong cell count");
+}
+
+// A hub without a table (entries == nullptr, count == 0) must not dereference it,
+// no matter which bits are set - the raw bitmask is still published.
+TEST(JkBalancerErrorsTest, NoTableConfiguredPublishesBitmaskOnly) {
+  auto [bitmask, text] = decode_errors(0xFF, nullptr, 0);
+
+  EXPECT_FLOAT_EQ(bitmask, 255.0f);
+  EXPECT_EQ(text, "");
+}
+
+// Validates the mechanism error_overrides relies on: swapping in a different table
+// changes the decoded label for a bit without any change to jk_balancer.cpp.
+TEST(JkBalancerErrorsTest, OverriddenLabelIsUsedInsteadOfDefault) {
+  auto [bitmask, text] = decode_errors(0x01, OVERRIDDEN_ERRORS, std::size(OVERRIDDEN_ERRORS));  // bit 0
+
+  EXPECT_FLOAT_EQ(bitmask, 1.0f);
+  EXPECT_EQ(text, "Cell count mismatch");
+}
+
+}  // namespace esphome::jk_balancer::testing

--- a/tests/components/jk_balancer/jk_balancer_test.cpp
+++ b/tests/components/jk_balancer/jk_balancer_test.cpp
@@ -55,6 +55,7 @@ TEST(JkBalancerStatusTest, Errors) {
   TestableJkBalancer bms;
   sensor::Sensor bitmask;
   text_sensor::TextSensor errors_text;
+  bms.set_errors_table(DEFAULT_ERRORS, std::size(DEFAULT_ERRORS));
   bms.set_errors_bitmask_sensor(&bitmask);
   bms.set_errors_text_sensor(&errors_text);
 

--- a/tests/components/jk_balancer/test.host.yaml
+++ b/tests/components/jk_balancer/test.host.yaml
@@ -10,3 +10,8 @@ jk_balancer:
   id: test_bms
   jk_balancer_modbus_id: modbus_bus
   update_interval: 5s
+  # Override the label of one or more error bits (bit 0-7).
+  # An empty label suppresses the bit entirely.
+  #
+  # error_overrides:
+  #   0: "Cell count mismatch"

--- a/tests/test_component_schemas.py
+++ b/tests/test_component_schemas.py
@@ -381,6 +381,62 @@ class TestJkBalancerSensorLists:
         assert len(jk_balancer_switch.SWITCHES) == 1
 
 
+class TestJkBalancerErrorOverrides:
+    def test_default_errors_cover_all_8_bits(self):
+        assert len(hub_jk_balancer.DEFAULT_ERRORS) == 8
+
+    def test_default_errors_are_immutable(self):
+        # to_code() patches a copy per hub; a mutable default would let one hub's
+        # error_overrides leak into the next one.
+        assert isinstance(hub_jk_balancer.DEFAULT_ERRORS, tuple)
+
+    def test_default_errors_labels(self):
+        assert hub_jk_balancer.DEFAULT_ERRORS[0] == "Wrong cell count"
+        assert hub_jk_balancer.DEFAULT_ERRORS[1] == "Resistance too high"
+        assert hub_jk_balancer.DEFAULT_ERRORS[2] == "Overvoltage"
+
+    def test_reserved_bits_are_empty(self):
+        for bit in range(3, 8):
+            assert hub_jk_balancer.DEFAULT_ERRORS[bit] == ""
+
+    @staticmethod
+    def _validate(overrides):
+        config = hub_jk_balancer.CONFIG_SCHEMA({"error_overrides": overrides})
+        return config["error_overrides"]
+
+    def test_schema_accepts_bit_index_as_string(self):
+        # ESPHome's YAML loader turns every mapping key into a string.
+        assert self._validate({"0": "Cell count mismatch"}) == {
+            0: "Cell count mismatch"
+        }
+
+    def test_schema_accepts_boundary_bits(self):
+        assert self._validate({"0": "a", "7": "b"}) == {0: "a", 7: "b"}
+
+    def test_schema_accepts_empty_label(self):
+        assert self._validate({"0": ""}) == {0: ""}
+
+    def test_schema_rejects_out_of_range_bit(self):
+        with pytest.raises(vol.Invalid, match="Error bit 8 is out of range"):
+            self._validate({"8": "Nope"})
+        with pytest.raises(vol.Invalid, match="Error bit -1 is out of range"):
+            self._validate({"-1": "Nope"})
+
+    def test_schema_rejects_non_numeric_bit(self):
+        with pytest.raises(vol.Invalid, match="'abc' is not a valid error bit"):
+            self._validate({"abc": "Nope"})
+
+    def test_schema_rejects_non_string_label(self):
+        with pytest.raises(vol.Invalid, match="Must be string"):
+            self._validate({"0": 42})
+
+    def test_error_overrides_is_optional(self):
+        assert (
+            hub_jk_balancer.CONF_ERROR_OVERRIDES
+            not in hub_jk_balancer.CONFIG_SCHEMA({})
+        )
+
+
 class TestHeltecBalancerBleSensorLists:
     def test_sensor_defs_completeness(self):
         assert heltec_sensor.CONF_TOTAL_RUNTIME in heltec_sensor.SENSOR_DEFS


### PR DESCRIPTION
Ports the `error_overrides` option from `jk_bms_ble` and `jk_bms` to the active balancer, so the alarm labels can be relabelled from YAML without patching the component.

```yaml
jk_balancer:
  - id: balancer0
    jk_balancer_modbus_id: modbus0
    error_overrides:
      0: "Cell count mismatch"
```

### What changed

The labels move out of the static `ERRORS` array in `jk_balancer.cpp` into `DEFAULT_ERRORS` in Python. `to_code()` copies that tuple, applies the overrides and emits a `static constexpr` array per hub, which is handed to the component via `set_errors_table()`. The labels stay in flash (`.rodata`), same as before.

`error_bits_to_string_()` now looks labels up through `LookupTable::get()`, which bounds checks the index and tolerates an unset table.

The alarm status byte at offset 12 is 8 bits wide, while the old array held 3 entries, so bits 3 to 7 were never evaluated. They are now empty placeholders and the decoder scans all 8 bits, which means a balancer that does set one of them can have it labelled. An empty label keeps a bit out of the errors text sensor; it is still reported by the raw bitmask sensor.

An out of range bit is rejected with a message that names the bit and the accepted range, instead of voluptuous' `extra keys not allowed`.

### Compatibility

No behaviour change for existing configurations: the defaults are the previous labels, and bits 3 to 7 were not decoded before either.

### Tests

* 7 new C++ tests in `tests/components/jk_balancer/jk_balancer_errors_test.cpp`, covering a single bit, joined bits, reserved bits, a bit past the end of the table, an unconfigured table and a label override.
* 12 new pytest cases covering the bit range, the label validation, the empty label suppression and the immutability of the defaults.
* `JkBalancerStatusTest.Errors` decodes a frame with bit 0 set, so it needs the table the codegen would otherwise provide. It now sets it explicitly from a shared `DEFAULT_ERRORS` fixture in `common.h` and asserts the same result as before.

`BitBeyondTableEndIsIgnored` was verified against a build with the bounds check removed, where it fails with an ASAN `global-buffer-overflow`.
