### PR TITLE
Wire up the heltec_balancer_ble errors sensors and make the labels configurable

### DIFF
--- a/components/heltec_balancer_ble/__init__.py
+++ b/components/heltec_balancer_ble/__init__.py
@@ -17,6 +17,48 @@ AUTO_LOAD = [
 MULTI_CONF = True
 
 CONF_HELTEC_BALANCER_BLE_ID = "heltec_balancer_ble_id"
+CONF_ERROR_OVERRIDES = "error_overrides"
+
+# Aggregated error conditions, one bit each. The order must match collect_error_bits()
+# in heltec_balancer_ble.cpp.
+# fmt: off
+DEFAULT_ERRORS = (
+    "Battery detection failed",   # bit 0
+    "Overvoltage",                # bit 1
+    "Undervoltage",               # bit 2
+    "Polarity error",             # bit 3
+    "Excessive line resistance",  # bit 4
+    "System overheating",         # bit 5
+    "Charging fault",             # bit 6
+    "Discharge fault",            # bit 7
+)
+# fmt: on
+MAX_ERROR_BIT = len(DEFAULT_ERRORS) - 1
+
+
+def error_overrides(value):
+    # A plain {cv.int_range(...): cv.string_strict} schema rejects an out of range
+    # bit with voluptuous' "extra keys not allowed", which tells the user nothing.
+    value = cv.Schema({cv.string: cv.string_strict})(value)
+
+    overrides = {}
+    for key, label in value.items():
+        try:
+            bit = cv.int_(key)
+        except cv.Invalid:
+            raise cv.Invalid(
+                f"'{key}' is not a valid error bit, expected a number between 0 and {MAX_ERROR_BIT}",
+                path=[key],
+            ) from None
+        if not 0 <= bit <= MAX_ERROR_BIT:
+            raise cv.Invalid(
+                f"Error bit {bit} is out of range, must be between 0 and {MAX_ERROR_BIT}",
+                path=[key],
+            )
+        overrides[bit] = label
+
+    return overrides
+
 
 heltec_balancer_ble_ns = cg.esphome_ns.namespace("heltec_balancer_ble")
 HeltecBalancerBle = heltec_balancer_ble_ns.class_(
@@ -37,6 +79,7 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(
                 CONF_THROTTLE, default="2s"
             ): cv.positive_time_period_milliseconds,
+            cv.Optional(CONF_ERROR_OVERRIDES): error_overrides,
         }
     )
     .extend(ble_client.BLE_CLIENT_SCHEMA)
@@ -50,3 +93,16 @@ async def to_code(config):
     await ble_client.register_ble_node(var, config)
 
     cg.add(var.set_throttle(config[CONF_THROTTLE]))
+
+    errors = list(DEFAULT_ERRORS)
+    for bit, label in config.get(CONF_ERROR_OVERRIDES, {}).items():
+        errors[bit] = label
+
+    arr_name = f"{config[CONF_ID]}_ERRORS"
+    entries = ", ".join(str(cg.safe_exp(label)) for label in errors)
+    cg.add_global(
+        cg.RawStatement(
+            f"static constexpr const char *const {arr_name}[] = {{{entries}}};"
+        )
+    )
+    cg.add(var.set_errors_table(cg.RawExpression(arr_name), len(errors)))

--- a/components/heltec_balancer_ble/heltec_balancer_ble.cpp
+++ b/components/heltec_balancer_ble/heltec_balancer_ble.cpp
@@ -1215,6 +1215,7 @@ void HeltecBalancerBle::reset_online_status_tracker_() {
 void HeltecBalancerBle::publish_device_unavailable_() {
   this->publish_state_(this->online_status_binary_sensor_, false);
   this->publish_state_(this->operation_status_text_sensor_, "Offline");
+  this->publish_state_(this->errors_text_sensor_, "Offline");
 
   this->publish_state_(min_cell_voltage_sensor_, NAN);
   this->publish_state_(max_cell_voltage_sensor_, NAN);

--- a/components/heltec_balancer_ble/heltec_balancer_ble.cpp
+++ b/components/heltec_balancer_ble/heltec_balancer_ble.cpp
@@ -76,11 +76,20 @@ static constexpr const char *const BATTERY_TYPES[BATTERY_TYPES_SIZE] = {
     "PbAc",     // 0x04
 };
 
-static const uint8_t CELL_ERRORS_SIZE = 8;
-static constexpr const char *const CELL_ERRORS[CELL_ERRORS_SIZE] = {
-    "Battery detection failed",  "Overvoltage",        "Undervoltage",   "Polarity error",
-    "Excessive line resistance", "System overheating", "Charging fault", "Discharge fault",
-};
+// Aggregates the five per-cell error bitmasks and the three fault bytes into one bit per
+// error condition. The bit order matches DEFAULT_ERRORS in heltec_balancer_ble/__init__.py.
+static uint8_t collect_error_bits(uint32_t detection_failed, uint32_t overvoltage, uint32_t undervoltage,
+                                  uint32_t polarity_error, uint32_t excessive_line_resistance,
+                                  uint8_t system_overheating, uint8_t charging_fault, uint8_t discharge_fault) {
+  return uint8_t((detection_failed != 0) << 0) |           //
+         uint8_t((overvoltage != 0) << 1) |                //
+         uint8_t((undervoltage != 0) << 2) |               //
+         uint8_t((polarity_error != 0) << 3) |             //
+         uint8_t((excessive_line_resistance != 0) << 4) |  //
+         uint8_t((system_overheating != 0) << 5) |         //
+         uint8_t((charging_fault != 0) << 6) |             //
+         uint8_t((discharge_fault != 0) << 7);
+}
 
 uint8_t crc(const uint8_t data[], const uint16_t len) {
   uint8_t crc = 0;
@@ -679,6 +688,11 @@ void HeltecBalancerBle::decode_cell_info_(const std::vector<uint8_t> &data) {
   //                                              0x00: Off
   //                                              0x01: On
   this->publish_state_(this->error_discharging_binary_sensor_, (bool) data[246]);
+
+  this->publish_errors_(collect_error_bits(heltec_get_24bit(229), heltec_get_24bit(232), heltec_get_24bit(235),
+                                           heltec_get_24bit(238), heltec_get_24bit(241), data[244], data[245],
+                                           data[246]));
+
   // 247   1   0x00                             Unknown
   //                                              Bit0: Read failed
   //                                              Bit1: Write failed
@@ -780,6 +794,11 @@ void HeltecBalancerBle::decode_cell_info_v2_(const std::vector<uint8_t> &data) {
   this->publish_state_(this->error_charging_binary_sensor_, (bool) data[282]);
   // 283   1   Discharge fault (+37 from v1 offset 246)
   this->publish_state_(this->error_discharging_binary_sensor_, (bool) data[283]);
+
+  this->publish_errors_(collect_error_bits(heltec_get_24bit(266), heltec_get_24bit(269), heltec_get_24bit(272),
+                                           heltec_get_24bit(275), heltec_get_24bit(278), data[281], data[282],
+                                           data[283]));
+
   // 284   1   Unknown
   // 285   6   Reserved
   // 291   4   Uptime (+37 from v1 offset 254)
@@ -1159,6 +1178,33 @@ void HeltecBalancerBle::track_online_status_() {
     this->publish_device_unavailable_();
     this->no_response_count_++;
   }
+}
+
+std::string HeltecBalancerBle::error_bits_to_string_(const uint8_t mask, const LookupTable &errors,
+                                                     const uint8_t bits) {
+  std::string errors_list;
+
+  for (uint8_t i = 0; i < bits; i++) {
+    if ((mask & (1UL << i)) == 0)
+      continue;
+
+    // Bits without a label (suppressed via `error_overrides`) and bits beyond the
+    // configured table are reported by the raw bitmask sensor only.
+    const char *label = errors.get(i);
+    if (label == nullptr || label[0] == '\0')
+      continue;
+
+    if (!errors_list.empty())
+      errors_list.append(";");
+    errors_list.append(label);
+  }
+
+  return errors_list;
+}
+
+void HeltecBalancerBle::publish_errors_(const uint8_t bitmask) {
+  this->publish_state_(this->errors_bitmask_sensor_, (float) bitmask);
+  this->publish_state_(this->errors_text_sensor_, this->error_bits_to_string_(bitmask, this->errors_table_, 8));
 }
 
 void HeltecBalancerBle::reset_online_status_tracker_() {

--- a/components/heltec_balancer_ble/heltec_balancer_ble.h
+++ b/components/heltec_balancer_ble/heltec_balancer_ble.h
@@ -22,6 +22,12 @@ namespace esphome::heltec_balancer_ble {
 namespace espbt = esphome::esp32_ble_tracker;
 #endif
 
+struct LookupTable {
+  const char *const *entries{nullptr};
+  size_t count{0};
+  const char *get(uint8_t index) const { return (entries != nullptr && index < count) ? entries[index] : nullptr; }
+};
+
 enum ProtocolVersion {
   PROTOCOL_VERSION_V1,
   PROTOCOL_VERSION_V2,
@@ -163,6 +169,7 @@ class HeltecBalancerBle :
   }
 
   void set_protocol_version(ProtocolVersion protocol_version) { protocol_version_ = protocol_version; }
+  void set_errors_table(const char *const *entries, size_t count) { errors_table_ = {entries, count}; }
   ProtocolVersion get_protocol_version() { return protocol_version_; }
   void set_throttle(uint32_t throttle) { this->throttle_ = throttle; }
   void set_min_cell_voltage_sensor(sensor::Sensor *min_cell_voltage_sensor) {
@@ -364,6 +371,8 @@ class HeltecBalancerBle :
   std::vector<uint8_t> frame_buffer_;
   InitState init_state_{InitState::NEED_DEVICE_INFO};
   ProtocolVersion protocol_version_{PROTOCOL_VERSION_V1};
+  LookupTable errors_table_;
+
   uint8_t no_response_count_{0};
   uint16_t char_handle_{0};
   uint32_t connection_time_{0};
@@ -389,7 +398,8 @@ class HeltecBalancerBle :
   void publish_device_unavailable_();
   void reset_online_status_tracker_();
   void track_online_status_();
-  std::string error_bits_to_string_(uint16_t bitmask);
+  std::string error_bits_to_string_(uint8_t bitmask, const LookupTable &errors, uint8_t bits);
+  void publish_errors_(uint8_t bitmask);
 
   std::string format_total_runtime_(const uint32_t value) {
     int seconds = (int) value;

--- a/esp32-heltec-balancer-ble-ek-b24s8e200a-example.yaml
+++ b/esp32-heltec-balancer-ble-ek-b24s8e200a-example.yaml
@@ -58,6 +58,11 @@ heltec_balancer_ble:
   - ble_client_id: client0
     throttle: 5s
     id: balancer0
+    # Override the label of one or more error bits (bit 0-7).
+    # An empty label suppresses the bit entirely.
+    #
+    # error_overrides:
+    #   1: "Cell overvoltage"
 
 binary_sensor:
   - platform: heltec_balancer_ble

--- a/esp32-heltec-balancer-ble-example-multiple-devices.yaml
+++ b/esp32-heltec-balancer-ble-example-multiple-devices.yaml
@@ -68,6 +68,11 @@ heltec_balancer_ble:
   - ble_client_id: client0
     throttle: 5s
     id: balancer0
+    # Override the label of one or more error bits (bit 0-7).
+    # An empty label suppresses the bit entirely.
+    #
+    # error_overrides:
+    #   1: "Cell overvoltage"
   - ble_client_id: client1
     throttle: 5s
     id: balancer1

--- a/esp32-heltec-balancer-ble-example.yaml
+++ b/esp32-heltec-balancer-ble-example.yaml
@@ -58,6 +58,11 @@ heltec_balancer_ble:
   - ble_client_id: client0
     throttle: 5s
     id: balancer0
+    # Override the label of one or more error bits (bit 0-7).
+    # An empty label suppresses the bit entirely.
+    #
+    # error_overrides:
+    #   1: "Cell overvoltage"
 
 binary_sensor:
   - platform: heltec_balancer_ble

--- a/tests/components/heltec_balancer_ble/common.h
+++ b/tests/components/heltec_balancer_ble/common.h
@@ -24,6 +24,7 @@ class TestableHeltecBalancerBle : public HeltecBalancerBle {
   using HeltecBalancerBle::decode_device_info_;
   using HeltecBalancerBle::decode_settings_;
   using HeltecBalancerBle::decode_settings_v2_;
+  using HeltecBalancerBle::publish_device_unavailable_;
 };
 
 }  // namespace esphome::heltec_balancer_ble::testing

--- a/tests/components/heltec_balancer_ble/errors_test.cpp
+++ b/tests/components/heltec_balancer_ble/errors_test.cpp
@@ -1,4 +1,5 @@
 #include <gtest/gtest.h>
+#include <cmath>
 #include <iterator>
 #include <string>
 #include <utility>
@@ -176,6 +177,23 @@ TEST(HeltecBalancerErrorsTest, ProtocolV2UsesSameTable) {
 
   EXPECT_FLOAT_EQ(bitmask.state, 36.0f);  // bit 2 + bit 5
   EXPECT_EQ(text.state, "Undervoltage;System overheating");
+}
+
+// Going offline clears the bitmask and marks the text sensor, like the other
+// components do in their device unavailable path.
+TEST(HeltecBalancerErrorsTest, DeviceUnavailablePublishesOffline) {
+  TestableHeltecBalancerBle bms;
+  bms.set_errors_table(DEFAULT_ERRORS, std::size(DEFAULT_ERRORS));
+
+  sensor::Sensor bitmask;
+  text_sensor::TextSensor text;
+  bms.set_errors_bitmask_sensor(&bitmask);
+  bms.set_errors_text_sensor(&text);
+
+  bms.publish_device_unavailable_();
+
+  EXPECT_TRUE(std::isnan(bitmask.state));
+  EXPECT_EQ(text.state, "Offline");
 }
 
 }  // namespace esphome::heltec_balancer_ble::testing

--- a/tests/components/heltec_balancer_ble/errors_test.cpp
+++ b/tests/components/heltec_balancer_ble/errors_test.cpp
@@ -1,0 +1,181 @@
+#include <gtest/gtest.h>
+#include <iterator>
+#include <string>
+#include <utility>
+#include "common.h"
+#include "frames_ek-b24s8e200a.h"
+#include "frames_gw-24s4eb.h"
+
+namespace esphome::heltec_balancer_ble::testing {
+
+// Mirrors DEFAULT_ERRORS in heltec_balancer_ble/__init__.py, which to_code() emits
+// as a static constexpr array and hands to the hub via set_errors_table().
+static constexpr const char *const DEFAULT_ERRORS[] = {
+    "Battery detection failed",   // bit 0
+    "Overvoltage",                // bit 1
+    "Undervoltage",               // bit 2
+    "Polarity error",             // bit 3
+    "Excessive line resistance",  // bit 4
+    "System overheating",         // bit 5
+    "Charging fault",             // bit 6
+    "Discharge fault",            // bit 7
+};
+
+// Deliberately shorter than the 8 bits the decoder scans, so the bounds check of
+// LookupTable::get() is exercised.
+static constexpr const char *const SHORT_ERRORS[] = {
+    "Battery detection failed",  // bit 0
+    "Overvoltage",               // bit 1
+    "Undervoltage",              // bit 2
+};
+
+// The default table with bit 1 overridden - as if the user had configured
+// `error_overrides: {1: "Cell overvoltage"}`.
+static constexpr const char *const OVERRIDDEN_ERRORS[] = {
+    "Battery detection failed",   // bit 0
+    "Cell overvoltage",           // bit 1 (overridden)
+    "Undervoltage",               // bit 2
+    "Polarity error",             // bit 3
+    "Excessive line resistance",  // bit 4
+    "System overheating",         // bit 5
+    "Charging fault",             // bit 6
+    "Discharge fault",            // bit 7
+};
+
+struct ErrorInputs {
+  bool detection_failed{false};
+  bool overvoltage{false};
+  bool undervoltage{false};
+  bool polarity_error{false};
+  bool excessive_line_resistance{false};
+  bool system_overheating{false};
+  bool charging_fault{false};
+  bool discharge_fault{false};
+};
+
+// The error block is five 24-bit per-cell bitmasks followed by three fault bytes.
+// It starts at offset 229 in a V1 cell info frame and at 266 in a V2 one.
+static void set_error_fields(std::vector<uint8_t> &frame, size_t base, const ErrorInputs &in) {
+  auto set_cell_mask = [&](size_t offset, bool value) {
+    frame[offset + 0] = value ? 0x01 : 0x00;  // one affected cell is enough
+    frame[offset + 1] = 0x00;
+    frame[offset + 2] = 0x00;
+  };
+
+  set_cell_mask(base + 0, in.detection_failed);
+  set_cell_mask(base + 3, in.overvoltage);
+  set_cell_mask(base + 6, in.undervoltage);
+  set_cell_mask(base + 9, in.polarity_error);
+  set_cell_mask(base + 12, in.excessive_line_resistance);
+  frame[base + 15] = in.system_overheating ? 0x01 : 0x00;
+  frame[base + 16] = in.charging_fault ? 0x01 : 0x00;
+  frame[base + 17] = in.discharge_fault ? 0x01 : 0x00;
+}
+
+// Feeds a V1 cell info frame carrying `in` into the decoder and returns the published
+// (errors bitmask, errors) pair. Passing a nullptr table leaves errors_table_ at its
+// default, i.e. a hub whose set_errors_table() call the codegen never emitted.
+static std::pair<float, std::string> decode_errors(const ErrorInputs &in, const char *const *table, size_t count) {
+  TestableHeltecBalancerBle bms;
+  if (table != nullptr)
+    bms.set_errors_table(table, count);
+
+  sensor::Sensor bitmask;
+  text_sensor::TextSensor text;
+  bms.set_errors_bitmask_sensor(&bitmask);
+  bms.set_errors_text_sensor(&text);
+
+  auto frame = gw::CELL_INFO_FRAME;
+  set_error_fields(frame, 229, in);
+  bms.decode_cell_info_(frame);
+
+  return {bitmask.state, text.state};
+}
+
+static std::pair<float, std::string> decode_errors(const ErrorInputs &in) {
+  return decode_errors(in, DEFAULT_ERRORS, std::size(DEFAULT_ERRORS));
+}
+
+TEST(HeltecBalancerErrorsTest, NoErrorsPublishesZeroAndEmptyString) {
+  auto [bitmask, text] = decode_errors({});
+
+  EXPECT_FLOAT_EQ(bitmask, 0.0f);
+  EXPECT_EQ(text, "");
+}
+
+TEST(HeltecBalancerErrorsTest, SingleCellConditionSetsItsBit) {
+  auto [bitmask, text] = decode_errors({.overvoltage = true});
+
+  EXPECT_FLOAT_EQ(bitmask, 2.0f);  // bit 1
+  EXPECT_EQ(text, "Overvoltage");
+}
+
+TEST(HeltecBalancerErrorsTest, SingleFaultByteSetsItsBit) {
+  auto [bitmask, text] = decode_errors({.discharge_fault = true});
+
+  EXPECT_FLOAT_EQ(bitmask, 128.0f);  // bit 7
+  EXPECT_EQ(text, "Discharge fault");
+}
+
+TEST(HeltecBalancerErrorsTest, MultipleConditionsJoinedInAscendingOrder) {
+  auto [bitmask, text] = decode_errors({.overvoltage = true, .charging_fault = true});
+
+  EXPECT_FLOAT_EQ(bitmask, 66.0f);  // bit 1 + bit 6
+  EXPECT_EQ(text, "Overvoltage;Charging fault");
+}
+
+TEST(HeltecBalancerErrorsTest, AllConditionsProduceFullMask) {
+  auto [bitmask, text] = decode_errors({true, true, true, true, true, true, true, true});
+
+  EXPECT_FLOAT_EQ(bitmask, 255.0f);
+  EXPECT_EQ(text, "Battery detection failed;Overvoltage;Undervoltage;Polarity error;"
+                  "Excessive line resistance;System overheating;Charging fault;Discharge fault");
+}
+
+// The decoder scans 8 bits regardless of how many entries the configured table holds.
+// Bits past the end must be dropped instead of read out of bounds.
+TEST(HeltecBalancerErrorsTest, BitBeyondTableEndIsIgnored) {
+  auto [bitmask, text] =
+      decode_errors({.detection_failed = true, .discharge_fault = true}, SHORT_ERRORS, std::size(SHORT_ERRORS));
+
+  EXPECT_FLOAT_EQ(bitmask, 129.0f);  // bit 0 + bit 7, table holds 3 entries
+  EXPECT_EQ(text, "Battery detection failed");
+}
+
+// A hub without a table (entries == nullptr, count == 0) must not dereference it,
+// no matter which bits are set - the raw bitmask is still published.
+TEST(HeltecBalancerErrorsTest, NoTableConfiguredPublishesBitmaskOnly) {
+  auto [bitmask, text] = decode_errors({true, true, true, true, true, true, true, true}, nullptr, 0);
+
+  EXPECT_FLOAT_EQ(bitmask, 255.0f);
+  EXPECT_EQ(text, "");
+}
+
+// Validates the mechanism error_overrides relies on: swapping in a different table
+// changes the decoded label for a bit without any change to heltec_balancer_ble.cpp.
+TEST(HeltecBalancerErrorsTest, OverriddenLabelIsUsedInsteadOfDefault) {
+  auto [bitmask, text] = decode_errors({.overvoltage = true}, OVERRIDDEN_ERRORS, std::size(OVERRIDDEN_ERRORS));
+
+  EXPECT_FLOAT_EQ(bitmask, 2.0f);
+  EXPECT_EQ(text, "Cell overvoltage");
+}
+
+// The V2 frame carries the same error block 37 bytes further in.
+TEST(HeltecBalancerErrorsTest, ProtocolV2UsesSameTable) {
+  TestableHeltecBalancerBle bms;
+  bms.set_errors_table(DEFAULT_ERRORS, std::size(DEFAULT_ERRORS));
+
+  sensor::Sensor bitmask;
+  text_sensor::TextSensor text;
+  bms.set_errors_bitmask_sensor(&bitmask);
+  bms.set_errors_text_sensor(&text);
+
+  auto frame = ek200a::CELL_INFO_FRAME;
+  set_error_fields(frame, 266, {.undervoltage = true, .system_overheating = true});
+  bms.decode_cell_info_v2_(frame);
+
+  EXPECT_FLOAT_EQ(bitmask.state, 36.0f);  // bit 2 + bit 5
+  EXPECT_EQ(text.state, "Undervoltage;System overheating");
+}
+
+}  // namespace esphome::heltec_balancer_ble::testing

--- a/tests/components/heltec_balancer_ble/test.host.yaml
+++ b/tests/components/heltec_balancer_ble/test.host.yaml
@@ -1,3 +1,8 @@
 heltec_balancer_ble:
   id: test_balancer
   update_interval: 20s
+  # Override the label of one or more error bits (bit 0-7).
+  # An empty label suppresses the bit entirely.
+  #
+  # error_overrides:
+  #   1: "Cell overvoltage"

--- a/tests/esp32c6-compatibility-test.yaml
+++ b/tests/esp32c6-compatibility-test.yaml
@@ -90,6 +90,11 @@ heltec_balancer_ble:
   - ble_client_id: client0
     throttle: 5s
     id: balancer0
+    # Override the label of one or more error bits (bit 0-7).
+    # An empty label suppresses the bit entirely.
+    #
+    error_overrides:
+      1: "Cell overvoltage"
 
 sensor:
   - platform: jk_bms

--- a/tests/test_component_schemas.py
+++ b/tests/test_component_schemas.py
@@ -437,6 +437,61 @@ class TestJkBalancerErrorOverrides:
         )
 
 
+class TestHeltecBalancerBleErrorOverrides:
+    def test_default_errors_cover_all_8_bits(self):
+        assert len(hub_heltec.DEFAULT_ERRORS) == 8
+
+    def test_default_errors_are_immutable(self):
+        # to_code() patches a copy per hub; a mutable default would let one hub's
+        # error_overrides leak into the next one.
+        assert isinstance(hub_heltec.DEFAULT_ERRORS, tuple)
+
+    def test_default_errors_labels(self):
+        assert hub_heltec.DEFAULT_ERRORS[0] == "Battery detection failed"
+        assert hub_heltec.DEFAULT_ERRORS[4] == "Excessive line resistance"
+        assert hub_heltec.DEFAULT_ERRORS[7] == "Discharge fault"
+
+    def test_no_default_label_is_empty(self):
+        # Unlike the other components every bit maps to a decoded condition.
+        assert all(hub_heltec.DEFAULT_ERRORS)
+
+    @staticmethod
+    def _validate(overrides):
+        config = hub_heltec.CONFIG_SCHEMA(
+            {"ble_client_id": "client0", "error_overrides": overrides}
+        )
+        return config["error_overrides"]
+
+    def test_schema_accepts_bit_index_as_string(self):
+        # ESPHome's YAML loader turns every mapping key into a string.
+        assert self._validate({"1": "Cell overvoltage"}) == {1: "Cell overvoltage"}
+
+    def test_schema_accepts_boundary_bits(self):
+        assert self._validate({"0": "a", "7": "b"}) == {0: "a", 7: "b"}
+
+    def test_schema_accepts_empty_label(self):
+        assert self._validate({"1": ""}) == {1: ""}
+
+    def test_schema_rejects_out_of_range_bit(self):
+        with pytest.raises(vol.Invalid, match="Error bit 8 is out of range"):
+            self._validate({"8": "Nope"})
+        with pytest.raises(vol.Invalid, match="Error bit -1 is out of range"):
+            self._validate({"-1": "Nope"})
+
+    def test_schema_rejects_non_numeric_bit(self):
+        with pytest.raises(vol.Invalid, match="'abc' is not a valid error bit"):
+            self._validate({"abc": "Nope"})
+
+    def test_schema_rejects_non_string_label(self):
+        with pytest.raises(vol.Invalid, match="Must be string"):
+            self._validate({"1": 42})
+
+    def test_error_overrides_is_optional(self):
+        config = hub_heltec.CONFIG_SCHEMA({"ble_client_id": "client0"})
+
+        assert hub_heltec.CONF_ERROR_OVERRIDES not in config
+
+
 class TestHeltecBalancerBleSensorLists:
     def test_sensor_defs_completeness(self):
         assert heltec_sensor.CONF_TOTAL_RUNTIME in heltec_sensor.SENSOR_DEFS


### PR DESCRIPTION
Brings `error_overrides` to `heltec_balancer_ble`, completing the set after `jk_bms_ble` (#1039), `jk_bms` (#1040) and `jk_balancer` (#1041). Unlike those three this component had no working error reporting to make configurable, so the first commit wires it up.

```yaml
heltec_balancer_ble:
  - ble_client_id: client0
    error_overrides:
      1: "Cell overvoltage"
```

### The errors sensors never worked

The `errors` text sensor has always been configurable, but nothing ever published to it:

* `CELL_ERRORS` was defined in `heltec_balancer_ble.cpp` and never referenced.
* `error_bits_to_string_()` was declared in the header with no definition anywhere.
* `errors_bitmask_sensor_` only ever received `NAN`, from the device unavailable path.

Both cell info decoders already read the five per-cell error bitmasks and the three fault bytes, and the eight labels in the unused `CELL_ERRORS` array map exactly onto those eight conditions. `collect_error_bits()` now aggregates them into one bit each, which feeds `errors_bitmask_sensor_` and, resolved through the label table, `errors_text_sensor_`.

| Bit | Condition | Source (V1 / V2 offset) |
| --- | --- | --- |
| 0 | Battery detection failed | cell detection failed bitmask, 229 / 266 |
| 1 | Overvoltage | cell overvoltage bitmask, 232 / 269 |
| 2 | Undervoltage | cell undervoltage bitmask, 235 / 272 |
| 3 | Polarity error | cell polarity error bitmask, 238 / 275 |
| 4 | Excessive line resistance | excessive line resistance bitmask, 241 / 278 |
| 5 | System overheating | fault byte, 244 / 281 |
| 6 | Charging fault | fault byte, 245 / 282 |
| 7 | Discharge fault | fault byte, 246 / 283 |

The aggregation lives in one function that both decoders call, so the bit order is defined in a single place.

### Configurable labels

`DEFAULT_ERRORS` lives in Python. `to_code()` copies that tuple, applies the overrides and emits a `static constexpr` array per hub, which is handed to the component via `set_errors_table()`. `error_bits_to_string_()` resolves labels through `LookupTable::get()`, so an out of range bit or an unset table cannot dereference anything. An empty label keeps a bit out of the text sensor; it is still reported by the raw bitmask sensor. An out of range bit in the configuration is rejected with a message naming the bit and the accepted range.

### Behaviour change

This one is not a pure refactor. Anyone who already configured `errors` or `errors_bitmask` saw nothing before and will start seeing values. The second commit also makes the errors text sensor report `"Offline"` when the device stops responding, matching the other three components, so a stale error string does not linger after the balancer disappears.

### Tests

* 10 new C++ tests in `tests/components/heltec_balancer_ble/errors_test.cpp`, covering an idle frame, a per-cell condition, a fault byte, joined conditions, the full mask, a bit past the end of the table, an unconfigured table, a label override, the V2 decoder and the offline path.
* 11 new pytest cases covering the bit range, the label validation, the empty label suppression and the immutability of the defaults.
* `error_overrides` is enabled in `tests/esp32c6-compatibility-test.yaml` so CI compiles the generated table with a real override.
* `publish_device_unavailable_()` is exposed to the test harness; that path had no coverage in any component before.

`BitBeyondTableEndIsIgnored` and `NoTableConfiguredPublishesBitmaskOnly` were verified against a build with the `LookupTable::get()` lookup replaced by a raw index, where they fail under ASAN.
